### PR TITLE
Documentation update

### DIFF
--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -90,11 +90,11 @@ Calling any API endpoint without a resource ID or name will return a paginated l
 
 #### APIResourceList
 
-| Name     | Description | Data Type |
-| -------- | ----------- | --------- |
-| count    | The total number of resources available from this API | integer |
-| next     | The URL for the next page in the list               | string  |
-| previous | The URL for the previous page in the list             | boolean |
+| Name     | Description                                           | Data Type                        |
+|:---------|:------------------------------------------------------|:---------------------------------|
+| count    | The total number of resources available from this API | integer                          |
+| next     | The URL for the next page in the list                 | string                           |
+| previous | The URL for the previous page in the list             | boolean                          |
 | results  | A list of unnamed API resources                       | list [APIResource](#apiresource) |
 
 ###### Example response for named resources
@@ -113,12 +113,12 @@ Calling any API endpoint without a resource ID or name will return a paginated l
 
 #### NamedAPIResourceList
 
-| Name     | Description | Data Type |
-| -------- | ----------- | --------- |
-| count    | The total number of resources available from this API | integer |
-| next     | The URL for the next page in the list               | string  |
-| previous | The URL for the previous page in the list             | boolean |
-| results  | A list of named API resources                    	   | list [NamedAPIResource](#namedapiresource) |
+| Name     | Description                                           | Data Type                                  |
+|:---------|:------------------------------------------------------|:-------------------------------------------|
+| count    | The total number of resources available from this API | integer                                    |
+| next     | The URL for the next page in the list                 | string                                     |
+| previous | The URL for the previous page in the list             | boolean                                    |
+| results  | A list of named API resources                         | list [NamedAPIResource](#namedapiresource) |
 
 <h1 id="berries-section">Berries</h1>
 
@@ -166,26 +166,26 @@ Berries are small fruits that can provide HP and status condition restoration, s
 
 #### Berry
 
-| Name               | Description | Data Type |
-| ------------------ | ----------- | --------- |
-| id                 | The identifier for this berry resource                                                                                             | integer |
-| name               | The name for this berry resource                                                                                                   | string  |
-| growth_time        | Time it takes the tree to grow one stage, in hours. Berry trees go through four of these growth stages before they can be picked.  | integer |
-| max_harvest        | The maximum number of these berries that can grow on one tree in Generation IV                                                     | integer |
-| natural_gift_power | The power of the move "Natural Gift" when used with this Berry                                                                     | integer |
-| size               | The size of this Berry, in millimeters                                                                                             | integer |
-| smoothness         | The smoothness of this Berry, used in making Pokéblocks or Poffins                                                                 | integer |
-| soil_dryness       | The speed at which this Berry dries out the soil as it grows.  A higher rate means the soil dries more quickly.                    | integer |
-| firmness           | The firmness of this berry, used in making Pokéblocks or Poffins                                                                   | [NamedAPIResource](#namedapiresource) ([BerryFirmness](#berry-firmnesses)) |
-| flavors            | A list of references to each flavor a berry can have and the potency of each of those flavors in regard to this berry              | list [BerryFlavorMap](#berryflavormap) |
-| item               | Berries are actually items. This is a reference to the item specific data for this berry.                                          | [NamedAPIResource](#namedapiresource) ([Item](#items)) |
-| natural_gift_type  | The Type the move "Natural Gift" has when used with this Berry                                                                     | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
+| Name               | Description                                                                                                                       | Data Type                                                                  |
+|:-------------------|:----------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------|
+| id                 | The identifier for this berry resource                                                                                            | integer                                                                    |
+| name               | The name for this berry resource                                                                                                  | string                                                                     |
+| growth_time        | Time it takes the tree to grow one stage, in hours. Berry trees go through four of these growth stages before they can be picked. | integer                                                                    |
+| max_harvest        | The maximum number of these berries that can grow on one tree in Generation IV                                                    | integer                                                                    |
+| natural_gift_power | The power of the move "Natural Gift" when used with this Berry                                                                    | integer                                                                    |
+| size               | The size of this Berry, in millimeters                                                                                            | integer                                                                    |
+| smoothness         | The smoothness of this Berry, used in making Pokéblocks or Poffins                                                                | integer                                                                    |
+| soil_dryness       | The speed at which this Berry dries out the soil as it grows.  A higher rate means the soil dries more quickly.                   | integer                                                                    |
+| firmness           | The firmness of this berry, used in making Pokéblocks or Poffins                                                                  | [NamedAPIResource](#namedapiresource) ([BerryFirmness](#berry-firmnesses)) |
+| flavors            | A list of references to each flavor a berry can have and the potency of each of those flavors in regard to this berry             | list [BerryFlavorMap](#berryflavormap)                                     |
+| item               | Berries are actually items. This is a reference to the item specific data for this berry.                                         | [NamedAPIResource](#namedapiresource) ([Item](#items))                     |
+| natural_gift_type  | The Type the move "Natural Gift" has when used with this Berry                                                                    | [NamedAPIResource](#namedapiresource) ([Type](#types))                     |
 
 #### BerryFlavorMap
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| potency | How powerful the referenced flavor is for this berry | integer |
+| Name    | Description                                          | Data Type                                                             |
+|:--------|:-----------------------------------------------------|:----------------------------------------------------------------------|
+| potency | How powerful the referenced flavor is for this berry | integer                                                               |
 | flavor  | The referenced berry flavor                          | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
 
 ## Berry Firmnesses
@@ -217,12 +217,12 @@ Berries are small fruits that can provide HP and status condition restoration, s
 
 #### BerryFirmness
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| id      | The identifier for this berry firmness resource               | integer |
-| name    | The name for this berry firmness resource                     | string  |
+| Name    | Description                                                   | Data Type                                                      |
+|:--------|:--------------------------------------------------------------|:---------------------------------------------------------------|
+| id      | The identifier for this berry firmness resource               | integer                                                        |
+| name    | The name for this berry firmness resource                     | string                                                         |
 | berries | A list of the berries with this firmness                      | list [NamedAPIResource](#namedapiresource) ([Berry](#berries)) |
-| names   | The name of this berry firmness listed in different languages | list [Name](#resourcename) |
+| names   | The name of this berry firmness listed in different languages | list [Name](#resourcename)                                     |
 
 ## Berry Flavors
 Flavors determine whether a Pokémon will benefit or suffer from eating a berry based on their [nature](#natures). Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Flavor) for greater detail.
@@ -261,19 +261,19 @@ Flavors determine whether a Pokémon will benefit or suffer from eating a berry 
 
 #### BerryFlavor
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this berry flavor resource               | integer |
-| name         | The name for this berry flavor resource                     | string  |
-| berries      | A list of the berries with this flavor                      | list [FlavorBerryMap](#flavorberrymap) |
+| Name         | Description                                                 | Data Type                                                             |
+|:-------------|:------------------------------------------------------------|:----------------------------------------------------------------------|
+| id           | The identifier for this berry flavor resource               | integer                                                               |
+| name         | The name for this berry flavor resource                     | string                                                                |
+| berries      | A list of the berries with this flavor                      | list [FlavorBerryMap](#flavorberrymap)                                |
 | contest_type | The contest type that correlates with this berry flavor     | [NamedAPIResource](#namedapiresource) ([ContestType](#contest-types)) |
-| names        | The name of this berry flavor listed in different languages | list [Name](#resourcename) |
+| names        | The name of this berry flavor listed in different languages | list [Name](#resourcename)                                            |
 
 #### FlavorBerryMap
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| potency | How powerful the referenced flavor is for this berry | integer |
+| Name    | Description                                          | Data Type                                               |
+|:--------|:-----------------------------------------------------|:--------------------------------------------------------|
+| potency | How powerful the referenced flavor is for this berry | integer                                                 |
 | berry   | The berry with the referenced flavor                 | [NamedAPIResource](#namedapiresource) ([Berry](#berry)) |
 
 <h1 id="contests-section">Contests</h1>
@@ -309,20 +309,20 @@ Contest types are categories judges used to weigh a Pokémon's condition in Pok�
 
 #### ContestType
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this contest type resource               | integer |
-| name         | The name for this contest type resource                     | string  |
+| Name         | Description                                                 | Data Type                                                             |
+|:-------------|:------------------------------------------------------------|:----------------------------------------------------------------------|
+| id           | The identifier for this contest type resource               | integer                                                               |
+| name         | The name for this contest type resource                     | string                                                                |
 | berry_flavor | The berry flavor that correlates with this contest type     | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
-| names        | The name of this contest type listed in different languages | list [ContestName](#contestname) |
+| names        | The name of this contest type listed in different languages | list [ContestName](#contestname)                                      |
 
 #### ContestName
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| name         | The name for this contest                                   | string  |
-| color        | The color associated with this contest's name               | string  |
-| language     | The language that this name is in                           | [NamedAPIResource](#namedapiresource) ([Language](#language)) |
+| Name     | Description                                   | Data Type                                                     |
+|:---------|:----------------------------------------------|:--------------------------------------------------------------|
+| name     | The name for this contest                     | string                                                        |
+| color    | The color associated with this contest's name | string                                                        |
+| language | The language that this name is in             | [NamedAPIResource](#namedapiresource) ([Language](#language)) |
 
 ## Contest Effects
 Contest effects refer to the effects of moves when used in contests.
@@ -358,12 +358,12 @@ Contest effects refer to the effects of moves when used in contests.
 
 #### ContestEffect
 
-| Name                | Description | Data Type |
-| ------------------- | ----------- | --------- |
-| id                  | The identifier for this contest type resource                        | integer |
-| appeal              | The base number of hearts the user of this move gets                 | integer |
-| jam                 | The base number of hearts the user's opponent loses                  | integer |
-| effect_entries      | The result of this contest effect listed in different languages      | list [Effect](#effect) |
+| Name                | Description                                                          | Data Type                      |
+|:--------------------|:---------------------------------------------------------------------|:-------------------------------|
+| id                  | The identifier for this contest type resource                        | integer                        |
+| appeal              | The base number of hearts the user of this move gets                 | integer                        |
+| jam                 | The base number of hearts the user's opponent loses                  | integer                        |
+| effect_entries      | The result of this contest effect listed in different languages      | list [Effect](#effect)         |
 | flavor_text_entries | The flavor text of this contest effect listed in different languages | list [FlavorText](#flavortext) |
 
 ## Super Contest Effects
@@ -395,11 +395,11 @@ Super contest effects refer to the effects of moves when used in super contests.
 
 #### SuperContestEffect
 
-| Name                | Description | Data Type |
-| ------------------- | ----------- | --------- |
-| id                  | The identifier for this super contest effect resource                      | integer |
-| appeal              | The level of appeal this super contest effect has                          | integer |
-| flavor_text_entries | The flavor text of this super contest effect listed in different languages | list [FlavorText](#flavortext) |
+| Name                | Description                                                                | Data Type                                                   |
+|:--------------------|:---------------------------------------------------------------------------|:------------------------------------------------------------|
+| id                  | The identifier for this super contest effect resource                      | integer                                                     |
+| appeal              | The level of appeal this super contest effect has                          | integer                                                     |
+| flavor_text_entries | The flavor text of this super contest effect listed in different languages | list [FlavorText](#flavortext)                              |
 | moves               | A list of moves that have the effect when used in super contests           | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 
 <h1 id="encounters-section">Encounters</h1>
@@ -431,11 +431,11 @@ Methods by which the player might can encounter Pokémon in the wild, e.g., walk
 
 #### EncounterMethod
 
-| Name  | Description | Data Type |
-| ----- | ----------- | --------- |
-| id    | The identifier for this encounter method resource               | integer |
-| name  | The name for this encounter method resource                     | string  |
-| order | A good value for sorting                                        | integer |
+| Name  | Description                                                     | Data Type                  |
+|:------|:----------------------------------------------------------------|:---------------------------|
+| id    | The identifier for this encounter method resource               | integer                    |
+| name  | The name for this encounter method resource                     | string                     |
+| order | A good value for sorting                                        | integer                    |
 | names | The name of this encounter method listed in different languages | list [Name](#resourcename) |
 
 ## Encounter Conditions
@@ -471,11 +471,11 @@ Conditions which affect what pokemon might appear in the wild, e.g., day or nigh
 
 #### EncounterCondition
 
-| Name  | Description | Data Type |
-| ------ | ----------- | --------- |
-| id     | The identifier for this encounter condition resource            | integer |
-| name   | The name for this encounter condition resource                  | string  |
-| names  | The name of this encounter method listed in different languages | list [Name](#resourcename) |
+| Name   | Description                                                     | Data Type                                                                                           |
+|:-------|:----------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| id     | The identifier for this encounter condition resource            | integer                                                                                             |
+| name   | The name for this encounter condition resource                  | string                                                                                              |
+| names  | The name of this encounter method listed in different languages | list [Name](#resourcename)                                                                          |
 | values | A list of possible values for this encounter condition          | list [NamedAPIResource](#namedapiresource) ([EncounterConditionValue](#encounter-condition-values)) |
 
 ## Encounter Condition Values
@@ -508,12 +508,12 @@ Encounter condition values are the various states that an encounter condition ca
 
 #### EncounterConditionValue
 
-| Name      | Description | Data Type |
-| --------- | ----------- | --------- |
-| id        | The identifier for this encounter condition value resource               | integer |
-| name      | The name for this encounter condition value resource                     | string  |
+| Name      | Description                                                              | Data Type                                                                                |
+|:----------|:-------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------|
+| id        | The identifier for this encounter condition value resource               | integer                                                                                  |
+| name      | The name for this encounter condition value resource                     | string                                                                                   |
 | condition | The condition this encounter condition value pertains to                 | list [NamedAPIResource](#namedapiresource) ([EncounterCondition](#encounter-conditions)) |
-| names     | The name of this encounter condition value listed in different languages | list [Name](#resourcename) |
+| names     | The name of this encounter condition value listed in different languages | list [Name](#resourcename)                                                               |
 
 <h1 id="evolution-section">Evolution</h1>
 
@@ -574,43 +574,43 @@ Evolution chains are essentially family trees. They start with the lowest stage 
 
 #### EvolutionChain
 
-| Name              | Description | Data Type |
-| ----------------- | ----------- | --------- |
-| id                | The identifier for this evolution chain resource                                                                                                                   | integer |
+| Name              | Description                                                                                                                                                        | Data Type                                              |
+|:------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------|
+| id                | The identifier for this evolution chain resource                                                                                                                   | integer                                                |
 | baby_trigger_item | The item that a Pokémon would be holding when mating that would trigger the egg hatching a baby Pokémon rather than a basic Pokémon                                | [NamedAPIResource](#namedapiresource) ([Item](#items)) |
-| chain             | The base chain link object. Each link contains evolution details for a Pokémon in the chain. Each link references the next Pokémon in the natural evolution order. | [ChainLink](#chainlink) |
+| chain             | The base chain link object. Each link contains evolution details for a Pokémon in the chain. Each link references the next Pokémon in the natural evolution order. | [ChainLink](#chainlink)                                |
 
 #### ChainLink
 
-| Name              | Description | Data Type |
-| ----------------- | ----------- | --------- |
-| is_baby           | Whether or not this link is for a baby Pokémon. This would only ever be true on the base link. | boolean |
+| Name              | Description                                                                                    | Data Type                                                                  |
+|:------------------|:-----------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------|
+| is_baby           | Whether or not this link is for a baby Pokémon. This would only ever be true on the base link. | boolean                                                                    |
 | species           | The Pokémon species at this point in the evolution chain                                       | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| evolution_details | All details regarding the specific details of the referenced Pokémon species evolution         | list [EvolutionDetail](#evolutiondetail) |
-| evolves_to        | A List of chain objects.                                                                       | list [ChainLink](#chainlink) |
+| evolution_details | All details regarding the specific details of the referenced Pokémon species evolution         | list [EvolutionDetail](#evolutiondetail)                                   |
+| evolves_to        | A List of chain objects.                                                                       | list [ChainLink](#chainlink)                                               |
 
 #### EvolutionDetail
 
-| Name                    | Description | Data Type |
-| ----------------------- | ----------- | --------- |
-| item                    | The item required to cause evolution this into Pokémon species                                                                                                              | [NamedAPIResource](#namedapiresource) ([Item](#items)) |
+| Name                    | Description                                                                                                                                                                 | Data Type                                                                       |
+|:------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| item                    | The item required to cause evolution this into Pokémon species                                                                                                              | [NamedAPIResource](#namedapiresource) ([Item](#items))                          |
 | trigger                 | The type of event that triggers evolution into this Pokémon species                                                                                                         | [NamedAPIResource](#namedapiresource) ([EvolutionTrigger](#evolution-triggers)) |
-| gender                  | The id of the gender of the evolving Pokémon species must be in order to evolve into this Pokémon species                                                                   | integer |
-| held_item               | The item the evolving Pokémon species must be holding during the evolution trigger event to evolve into this Pokémon species                                                | [NamedAPIResource](#namedapiresource) ([Item](#items)) |
-| known_move              | The move that must be known by the evolving Pokémon species during the evolution trigger event in order to evolve into this Pokémon species                                 | [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
-| known_move_type         | The evolving Pokémon species must know a move with this type during the evolution trigger event in order to evolve into this Pokémon species                                | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
-| location                | The location the evolution must be triggered at.                                                                                                                            | [NamedAPIResource](#namedapiresource) ([Location](#locations)) |
-| min_level               | The minimum required level of the evolving Pokémon species to evolve into this Pokémon species                                                                              | integer |
-| min_happiness           | The minimum required level of happiness the evolving Pokémon species to evolve into this Pokémon species                                                                    | integer |
-| min_beauty              | The minimum required level of beauty the evolving Pokémon species to evolve into this Pokémon species                                                                       | integer |
-| min_affection           | The minimum required level of affection the evolving Pokémon species to evolve into this Pokémon species                                                                    | integer |
-| needs_overworld_rain    | Whether or not it must be raining in the overworld to cause evolution this Pokémon species                                                                                  | boolean |
-| party_species           | The Pokémon species that must be in the players party in order for the evolving Pokémon species to evolve into this Pokémon species                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| party_type              | The player must have a Pokémon of this type in their party during the evolution trigger event in order for the evolving Pokémon species to evolve into this Pokémon species | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
-| relative_physical_stats | The required relation between the Pokémon's Attack and Defense stats. 1 means Attack > Defense. 0 means Attack = Defense. -1 means Attack < Defense.                        | integer |
-| time_of_day             | The required time of day. Day or night.                                                                                                                                     | string  |
-| trade_species           | Pokémon species for which this one must be traded.                                                                                                                          | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| turn_upside_down        | Whether or not the 3DS needs to be turned upside-down as this Pokémon levels up.                                                                                            | boolean |
+| gender                  | The id of the gender of the evolving Pokémon species must be in order to evolve into this Pokémon species                                                                   | integer                                                                         |
+| held_item               | The item the evolving Pokémon species must be holding during the evolution trigger event to evolve into this Pokémon species                                                | [NamedAPIResource](#namedapiresource) ([Item](#items))                          |
+| known_move              | The move that must be known by the evolving Pokémon species during the evolution trigger event in order to evolve into this Pokémon species                                 | [NamedAPIResource](#namedapiresource) ([Move](#moves))                          |
+| known_move_type         | The evolving Pokémon species must know a move with this type during the evolution trigger event in order to evolve into this Pokémon species                                | [NamedAPIResource](#namedapiresource) ([Type](#types))                          |
+| location                | The location the evolution must be triggered at.                                                                                                                            | [NamedAPIResource](#namedapiresource) ([Location](#locations))                  |
+| min_level               | The minimum required level of the evolving Pokémon species to evolve into this Pokémon species                                                                              | integer                                                                         |
+| min_happiness           | The minimum required level of happiness the evolving Pokémon species to evolve into this Pokémon species                                                                    | integer                                                                         |
+| min_beauty              | The minimum required level of beauty the evolving Pokémon species to evolve into this Pokémon species                                                                       | integer                                                                         |
+| min_affection           | The minimum required level of affection the evolving Pokémon species to evolve into this Pokémon species                                                                    | integer                                                                         |
+| needs_overworld_rain    | Whether or not it must be raining in the overworld to cause evolution this Pokémon species                                                                                  | boolean                                                                         |
+| party_species           | The Pokémon species that must be in the players party in order for the evolving Pokémon species to evolve into this Pokémon species                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species))      |
+| party_type              | The player must have a Pokémon of this type in their party during the evolution trigger event in order for the evolving Pokémon species to evolve into this Pokémon species | [NamedAPIResource](#namedapiresource) ([Type](#types))                          |
+| relative_physical_stats | The required relation between the Pokémon's Attack and Defense stats. 1 means Attack > Defense. 0 means Attack = Defense. -1 means Attack < Defense.                        | integer                                                                         |
+| time_of_day             | The required time of day. Day or night.                                                                                                                                     | string                                                                          |
+| trade_species           | Pokémon species for which this one must be traded.                                                                                                                          | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species))      |
+| turn_upside_down        | Whether or not the 3DS needs to be turned upside-down as this Pokémon levels up.                                                                                            | boolean                                                                         |
 
 ## Evolution Triggers
 Evolution triggers are the events and conditions that cause a Pokémon to evolve. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Methods_of_evolution) for greater detail.
@@ -642,11 +642,11 @@ Evolution triggers are the events and conditions that cause a Pokémon to evolve
 
 #### EvolutionTrigger
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| id              | The identifier for this evolution trigger resource                | integer |
-| name            | The name for this evolution trigger resource                      | string  |
-| names           | The name of this evolution trigger listed in different languages  | list [Name](#resourcename) |
+| Name            | Description                                                       | Data Type                                                                       |
+|:----------------|:------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this evolution trigger resource                | integer                                                                         |
+| name            | The name for this evolution trigger resource                      | string                                                                          |
+| names           | The name of this evolution trigger listed in different languages  | list [Name](#resourcename)                                                      |
 | pokemon_species | A list of pokemon species that result from this evolution trigger | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 <h1 id="games-section">Games</h1>
@@ -698,17 +698,17 @@ A generation is a grouping of the Pokémon games that separates them based on th
 
 #### Generation
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| id              | The identifier for this generation resource                       | integer |
-| name            | The name for this generation resource                             | string  |
-| abilities       | A list of abilities that were introduced in this generation       | list [NamedAPIResource](#namedapiresource) ([Ability](#abilities)) |
-| names           | The name of this generation listed in different languages         | list [Name](#resourcename) |
-| main_region     | The main region travelled in this generation                      | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
-| moves           | A list of moves that were introduced in this generation           | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
+| Name            | Description                                                       | Data Type                                                                       |
+|:----------------|:------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this generation resource                       | integer                                                                         |
+| name            | The name for this generation resource                             | string                                                                          |
+| abilities       | A list of abilities that were introduced in this generation       | list [NamedAPIResource](#namedapiresource) ([Ability](#abilities))              |
+| names           | The name of this generation listed in different languages         | list [Name](#resourcename)                                                      |
+| main_region     | The main region travelled in this generation                      | [NamedAPIResource](#namedapiresource) ([Region](#regions))                      |
+| moves           | A list of moves that were introduced in this generation           | list [NamedAPIResource](#namedapiresource) ([Move](#moves))                     |
 | pokemon_species | A list of Pokémon species that were introduced in this generation | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| types           | A list of types that were introduced in this generation           | list [NamedAPIResource](#namedapiresource) ([Type](#types)) |
-| version_groups  | A list of version groups that were introduced in this generation  | list [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
+| types           | A list of types that were introduced in this generation           | list [NamedAPIResource](#namedapiresource) ([Type](#types))                     |
+| version_groups  | A list of version groups that were introduced in this generation  | list [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups))    |
 
 ## Pokedexes
 A Pokédex is a handheld electronic encyclopedia device; one which is capable of recording and retaining information of the various Pokémon in a given region with the exception of the national dex and some smaller dexes related to portions of a region. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Pokedex) for greater detail.
@@ -758,22 +758,22 @@ A Pokédex is a handheld electronic encyclopedia device; one which is capable of
 
 #### Pokedex
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| id              | The identifier for this Pokédex resource                                     | integer |
-| name            | The name for this Pokédex resource                                           | string  |
-| is_main_series  | Whether or not this Pokédex originated in the main series of the video games | boolean |
-| descriptions    | The description of this Pokédex listed in different languages                | list [Description](#description) |
-| names           | The name of this Pokédex listed in different languages                       | list [Name](#resourcename) |
-| pokemon_entries | A list of Pokémon catalogued in this Pokédex and their indexes               | list [PokemonEntry](#pokemonentry) |
-| region          | The region this Pokédex catalogues Pokémon for                               | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
+| Name            | Description                                                                  | Data Type                                                                    |
+|:----------------|:-----------------------------------------------------------------------------|:-----------------------------------------------------------------------------|
+| id              | The identifier for this Pokédex resource                                     | integer                                                                      |
+| name            | The name for this Pokédex resource                                           | string                                                                       |
+| is_main_series  | Whether or not this Pokédex originated in the main series of the video games | boolean                                                                      |
+| descriptions    | The description of this Pokédex listed in different languages                | list [Description](#description)                                             |
+| names           | The name of this Pokédex listed in different languages                       | list [Name](#resourcename)                                                   |
+| pokemon_entries | A list of Pokémon catalogued in this Pokédex and their indexes               | list [PokemonEntry](#pokemonentry)                                           |
+| region          | The region this Pokédex catalogues Pokémon for                               | [NamedAPIResource](#namedapiresource) ([Region](#regions))                   |
 | version_groups  | A list of version groups this Pokédex is relevant to                         | list [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 #### PokemonEntry
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| entry_number    | The index of this Pokémon species entry within the Pokédex | integer |
+| Name            | Description                                                | Data Type                                                                  |
+|:----------------|:-----------------------------------------------------------|:---------------------------------------------------------------------------|
+| entry_number    | The index of this Pokémon species entry within the Pokédex | integer                                                                    |
 | pokemon_species | The Pokémon species being encountered                      | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Versions
@@ -806,11 +806,11 @@ Versions of the games, e.g., Red, Blue or Yellow.
 
 #### Version
 
-| Name          | Description | Data Type |
-| ------------- | ----------- | --------- |
-| id            | The identifier for this version resource               | integer |
-| name          | The name for this version resource                     | string  |
-| names         | The name of this version listed in different languages | list [Name](#resourcename) |
+| Name          | Description                                            | Data Type                                                               |
+|:--------------|:-------------------------------------------------------|:------------------------------------------------------------------------|
+| id            | The identifier for this version resource               | integer                                                                 |
+| name          | The name for this version resource                     | string                                                                  |
+| names         | The name of this version listed in different languages | list [Name](#resourcename)                                              |
 | version_group | The version group this version belongs to              | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 ## Version Groups
@@ -852,16 +852,16 @@ Version groups categorize highly similar versions of the games.
 
 #### VersionGroup
 
-| Name               | Description | Data Type |
-| ------------------ | ----------- | --------- |
-| id                 | The identifier for this version group resource                                              | integer |
-| name               | The name for this version group resource                                                    | string  |
-| order              | Order for sorting. Almost by date of release, except similar versions are grouped together. | integer |
-| generation         | The generation this version was introduced in                                               | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
+| Name               | Description                                                                                 | Data Type                                                                           |
+|:-------------------|:--------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| id                 | The identifier for this version group resource                                              | integer                                                                             |
+| name               | The name for this version group resource                                                    | string                                                                              |
+| order              | Order for sorting. Almost by date of release, except similar versions are grouped together. | integer                                                                             |
+| generation         | The generation this version was introduced in                                               | [NamedAPIResource](#namedapiresource) ([Generation](#generations))                  |
 | move_learn_methods | A list of methods in which Pokémon can learn moves in this version group                    | list [NamedAPIResource](#namedapiresource) ([MoveLearnMethod](#move-learn-methods)) |
-| pokedexes          | A list of Pokédexes introduces in this version group                                        | list [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
-| regions            | A list of regions that can be visited in this version group                                 | list [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
-| versions           | The versions this version group owns                                                        | list [NamedAPIResource](#namedapiresource) ([Version](#versions)) |
+| pokedexes          | A list of Pokédexes introduces in this version group                                        | list [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes))                  |
+| regions            | A list of regions that can be visited in this version group                                 | list [NamedAPIResource](#namedapiresource) ([Region](#regions))                     |
+| versions           | The versions this version group owns                                                        | list [NamedAPIResource](#namedapiresource) ([Version](#versions))                   |
 
 <h1 id="items-section">Items</h1>
 
@@ -949,41 +949,41 @@ An item is an object in the games which the player can pick up, keep in their ba
 
 #### Item
 
-| Name                | Description | Data Type |
-| ------------------- | ----------- | --------- |
-| id                  | The identifier for this item resource                                | integer |
-| name                | The name for this item resource                                      | string  |
-| cost                | The price of this item in stores                                     | integer |
-| fling_power         | The power of the move Fling when used with this item.                | integer |
+| Name                | Description                                                          | Data Type                                                                      |
+|:--------------------|:---------------------------------------------------------------------|:-------------------------------------------------------------------------------|
+| id                  | The identifier for this item resource                                | integer                                                                        |
+| name                | The name for this item resource                                      | string                                                                         |
+| cost                | The price of this item in stores                                     | integer                                                                        |
+| fling_power         | The power of the move Fling when used with this item.                | integer                                                                        |
 | fling_effect        | The effect of the move Fling when used with this item                | [NamedAPIResource](#namedapiresource) ([ItemFlingEffect](#item-fling-effects)) |
 | attributes          | A list of attributes this item has                                   | list [NamedAPIResource](#namedapiresource) ([ItemAttribute](#item-attributes)) |
-| category            | The category of items this item falls into                           | [ItemCategory](#item-categories) |
-| effect_entries      | The effect of this ability listed in different languages             | list [VerboseEffect](#verboseeffect) |
-| flavor_text_entries | The flavor text of this ability listed in different languages        | list [VersionGroupFlavorText](#versiongroupflavortext) |
-| game_indices        | A list of game indices relevent to this item by generation           | list [GenerationGameIndex](#generationgameindex) |
-| names               | The name of this item listed in different languages                  | list [Name](#resourcename) |
-| sprites        	    | A set of sprites used to depict this item in the game                | [ItemSprites](#item-sprites) |
-| held_by_pokemon     | A list of Pokémon that might be found in the wild holding this item  | list [ItemHolderPokemon](#itemholderpokemon) |
-| baby_trigger_for    | An evolution chain this item requires to produce a bay during mating | [APIResource](#apiresource) ([EvolutionChain](#evolution-chains)) |
+| category            | The category of items this item falls into                           | [ItemCategory](#item-categories)                                               |
+| effect_entries      | The effect of this ability listed in different languages             | list [VerboseEffect](#verboseeffect)                                           |
+| flavor_text_entries | The flavor text of this ability listed in different languages        | list [VersionGroupFlavorText](#versiongroupflavortext)                         |
+| game_indices        | A list of game indices relevent to this item by generation           | list [GenerationGameIndex](#generationgameindex)                               |
+| names               | The name of this item listed in different languages                  | list [Name](#resourcename)                                                     |
+| sprites             | A set of sprites used to depict this item in the game                | [ItemSprites](#item-sprites)                                                   |
+| held_by_pokemon     | A list of Pokémon that might be found in the wild holding this item  | list [ItemHolderPokemon](#itemholderpokemon)                                   |
+| baby_trigger_for    | An evolution chain this item requires to produce a bay during mating | [APIResource](#apiresource) ([EvolutionChain](#evolution-chains))              |
 
 #### ItemSprites
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| default | The default depiction of this item | string |
+| Name    | Description                        | Data Type |
+|:--------|:-----------------------------------|:----------|
+| default | The default depiction of this item | string    |
 
 #### ItemHolderPokemon
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| pokemon | The Pokémon that holds this item | string |
+| Name            | Description                                                          | Data Type                                                              |
+|:----------------|:---------------------------------------------------------------------|:-----------------------------------------------------------------------|
+| pokemon         | The Pokémon that holds this item                                     | string                                                                 |
 | version_details | The details for the version that this item is held in by the Pokémon | list [ItemHolderPokemonVersionDetail](#ItemHolderPokemonVersionDetail) |
 
 #### ItemHolderPokemonVersionDetail
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| rarity  | How often this Pokémon holds this item in this version | string |
+| Name    | Description                                            | Data Type                                                   |
+|:--------|:-------------------------------------------------------|:------------------------------------------------------------|
+| rarity  | How often this Pokémon holds this item in this version | string                                                      |
 | version | The version that this item is held in by the Pokémon   | [NamedAPIResource](#namedapiresource) ([Version](#version)) |
 
 ## Item Attributes
@@ -1022,13 +1022,13 @@ Item attributes define particular aspects of items, e.g. "usable in battle" or "
 
 #### ItemAttribute
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this item attribute resource                      | integer |
-| name         | The name for this item attribute resource                            | string  |
+| Name         | Description                                                          | Data Type                                                   |
+|:-------------|:---------------------------------------------------------------------|:------------------------------------------------------------|
+| id           | The identifier for this item attribute resource                      | integer                                                     |
+| name         | The name for this item attribute resource                            | string                                                      |
 | items        | A list of items that have this attribute                             | list [NamedAPIResource](#namedapiresource) ([Item](#items)) |
-| names        | The name of this item attribute listed in different languages        | list [Name](#resourcename) |
-| descriptions | The description of this item attribute listed in different languages | list [Description](#description) |
+| names        | The name of this item attribute listed in different languages        | list [Name](#resourcename)                                  |
+| descriptions | The description of this item attribute listed in different languages | list [Description](#description)                            |
 
 ## Item Categories
 Item categories determine where items will be placed in the players bag.
@@ -1063,12 +1063,12 @@ Item categories determine where items will be placed in the players bag.
 
 #### ItemCategory
 
-| Name   | Description | Data Type |
-| ------ | ----------- | --------- |
-| id     | The identifier for this item category resource               | integer |
-| name   | The name for this item category resource                     | string  |
-| items  | A list of items that are a part of this category             | list [NamedAPIResource](#namedapiresource) ([Item](#items)) |
-| names  | The name of this item category listed in different languages | list [Name](#resourcename) |
+| Name   | Description                                                  | Data Type                                                           |
+|:-------|:-------------------------------------------------------------|:--------------------------------------------------------------------|
+| id     | The identifier for this item category resource               | integer                                                             |
+| name   | The name for this item category resource                     | string                                                              |
+| items  | A list of items that are a part of this category             | list [NamedAPIResource](#namedapiresource) ([Item](#items))         |
+| names  | The name of this item category listed in different languages | list [Name](#resourcename)                                          |
 | pocket | The pocket items in this category would be put in            | [NamedAPIResource](#namedapiresource) ([ItemPocket](#item-pockets)) |
 
 ## Item Fling Effects
@@ -1100,11 +1100,11 @@ The various effects of the move "Fling" when used with different items.
 
 #### ItemFlingEffect
 
-| Name           | Description | Data Type |
-| -------------- | ----------- | --------- |
-| id             | The identifier for this fling effect resource                 | integer |
-| name           | The name for this fling effect resource                       | string  |
-| effect_entries | The result of this fling effect listed in different languages | list [Effect](#effect) |
+| Name           | Description                                                   | Data Type                                                   |
+|:---------------|:--------------------------------------------------------------|:------------------------------------------------------------|
+| id             | The identifier for this fling effect resource                 | integer                                                     |
+| name           | The name for this fling effect resource                       | string                                                      |
+| effect_entries | The result of this fling effect listed in different languages | list [Effect](#effect)                                      |
 | items          | A list of items that have this fling effect                   | list [NamedAPIResource](#namedapiresource) ([Item](#items)) |
 
 ## Item Pockets
@@ -1136,12 +1136,12 @@ Pockets within the players bag used for storing items by category.
 
 #### ItemPocket
 
-| Name       | Description | Data Type |
-| ---------- | ----------- | --------- |
-| id         | The identifier for this item pocket resource                    | integer |
-| name       | The name for this item pocket resource                          | string  |
+| Name       | Description                                                     | Data Type                                                                     |
+|:-----------|:----------------------------------------------------------------|:------------------------------------------------------------------------------|
+| id         | The identifier for this item pocket resource                    | integer                                                                       |
+| name       | The name for this item pocket resource                          | string                                                                        |
 | categories | A list of item categories that are relevant to this item pocket | list [NamedAPIResource](#namedapiresource) ([ItemCategory](#item-categories)) |
-| names      | The name of this item pocket listed in different languages      | list [Name](#resourcename) |
+| names      | The name of this item pocket listed in different languages      | list [Name](#resourcename)                                                    |
 
 <h1 id="moves-section">Moves</h1>
 
@@ -1251,78 +1251,78 @@ Moves are the skills of Pokémon in battle. In battle, a Pokémon uses one move 
 
 #### Move
 
-| Name           | Description | Data Type |
-| -------------- | ----------- | --------- |
-| id             | The identifier for this move resource                                                                                                                                     | integer |
-| name           | The name for this move resource                                                                                                                                           | string  |
-| accuracy       | The percent value of how likely this move is to be successful                                                                                                             | integer |
-| effect_chance  | The percent value of how likely it is this moves effect will happen                                                                                                       | integer |
-| pp             | Power points. The number of times this move can be used                                                                                                                   | integer |
-| priority       | A value between -8 and 8. Sets the order in which moves are executed during battle. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Priority) for greater detail. | integer |
-| power          | The base power of this move with a value of 0 if it does not have a base power                                                                                            | integer |
-| contest_combos | A detail of normal and super contest combos that require this move                                                                                                        | [ContestComboSets](#contestcombosets) |
-| contest_type   | The type of appeal this move gives a Pokémon when used in a contest                                                                                                       | [NamedAPIResource](#namedapiresource) ([ContestType](#contest-types)) |
-| contest_effect | The effect the move has when used in a contest                                                                                                                            | [APIResource](#apiresource) ([ContestEffect](#contest-effects)) |
-| damage_class   | The type of damage the move inflicts on the target, e.g. physical                                                                                                         | [NamedAPIResource](#namedapiresource) ([MoveDamageClass](#move-damage-classes)) |
-| effect_entries | The effect of this move listed in different languages                                                                                                                     | list [VerboseEffect](#verboseeffect) |
-| effect_changes | The list of previous effects this move has had across version groups of the games                                                                                         | list [AbilityEffectChange](#abilityeffectchange) |
-| generation     | The generation in which this move was introduced                                                                                                                          | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
-| meta           | Metadata about this move                                                                                                                                                  | [MoveMetaData](#movemetadata) |
-| names          | The name of this move listed in different languages                                                                                                                       | list [Name](#resourcename) |
-| past_values    | A list of move resource value changes across version groups of the game                                                                                                    | list [PastMoveStatValues](#pastmovestatvalues) |
-| stat_changes   | A list of stats this moves effects and how much it effects them                                                                                                           | list [MoveStatChange](#movestatchange) |
-| super_contest_effect | The effect the move has when used in a super contest                                                                                                                      | [APIResource](#apiresource) ([SuperContestEffect](#super-contest-effects)) |
-| target         | The type of target that will receive the effects of the attack                                                                                                            | [NamedAPIResource](#namedapiresource) ([MoveTarget](#move-targets)) |
-| type           | The elemental type of this move                                                                                                                                           | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
+| Name                 | Description                                                                                                                                                               | Data Type                                                                       |
+|:---------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id                   | The identifier for this move resource                                                                                                                                     | integer                                                                         |
+| name                 | The name for this move resource                                                                                                                                           | string                                                                          |
+| accuracy             | The percent value of how likely this move is to be successful                                                                                                             | integer                                                                         |
+| effect_chance        | The percent value of how likely it is this moves effect will happen                                                                                                       | integer                                                                         |
+| pp                   | Power points. The number of times this move can be used                                                                                                                   | integer                                                                         |
+| priority             | A value between -8 and 8. Sets the order in which moves are executed during battle. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Priority) for greater detail. | integer                                                                         |
+| power                | The base power of this move with a value of 0 if it does not have a base power                                                                                            | integer                                                                         |
+| contest_combos       | A detail of normal and super contest combos that require this move                                                                                                        | [ContestComboSets](#contestcombosets)                                           |
+| contest_type         | The type of appeal this move gives a Pokémon when used in a contest                                                                                                       | [NamedAPIResource](#namedapiresource) ([ContestType](#contest-types))           |
+| contest_effect       | The effect the move has when used in a contest                                                                                                                            | [APIResource](#apiresource) ([ContestEffect](#contest-effects))                 |
+| damage_class         | The type of damage the move inflicts on the target, e.g. physical                                                                                                         | [NamedAPIResource](#namedapiresource) ([MoveDamageClass](#move-damage-classes)) |
+| effect_entries       | The effect of this move listed in different languages                                                                                                                     | list [VerboseEffect](#verboseeffect)                                            |
+| effect_changes       | The list of previous effects this move has had across version groups of the games                                                                                         | list [AbilityEffectChange](#abilityeffectchange)                                |
+| generation           | The generation in which this move was introduced                                                                                                                          | [NamedAPIResource](#namedapiresource) ([Generation](#generations))              |
+| meta                 | Metadata about this move                                                                                                                                                  | [MoveMetaData](#movemetadata)                                                   |
+| names                | The name of this move listed in different languages                                                                                                                       | list [Name](#resourcename)                                                      |
+| past_values          | A list of move resource value changes across version groups of the game                                                                                                   | list [PastMoveStatValues](#pastmovestatvalues)                                  |
+| stat_changes         | A list of stats this moves effects and how much it effects them                                                                                                           | list [MoveStatChange](#movestatchange)                                          |
+| super_contest_effect | The effect the move has when used in a super contest                                                                                                                      | [APIResource](#apiresource) ([SuperContestEffect](#super-contest-effects))      |
+| target               | The type of target that will receive the effects of the attack                                                                                                            | [NamedAPIResource](#namedapiresource) ([MoveTarget](#move-targets))             |
+| type                 | The elemental type of this move                                                                                                                                           | [NamedAPIResource](#namedapiresource) ([Type](#types))                          |
 
 #### ContestComboSets
 
-| Name   | Description | Data Type |
-| ------ | ----------- | --------- |
+| Name   | Description                                                                                                  | Data Type                                 |
+|:-------|:-------------------------------------------------------------------------------------------------------------|:------------------------------------------|
 | normal | A detail of moves this move can be used before or after, granting additional appeal points in contests       | [ContestComboDetail](#contestcombodetail) |
 | super  | A detail of moves this move can be used before or after, granting additional appeal points in super contests | [ContestComboDetail](#contestcombodetail) |
 
 #### ContestComboDetail
 
-| Name       | Description | Data Type |
-| ---------- | ----------- | --------- |
+| Name       | Description                             | Data Type                                                   |
+|:-----------|:----------------------------------------|:------------------------------------------------------------|
 | use_before | A list of moves to use before this move | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 | use_after  | A list of moves to use after this move  | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 
 #### MoveMetaData
 
-| Name           | Description | Data Type |
-| -------------- | ----------- | --------- |
+| Name           | Description                                                                                            | Data Type                                                             |
+|:---------------|:-------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------|
 | ailment        | The status ailment this move inflicts on its target                                                    | [NamedAPIResource](#namedapiresource) ([MoveAilment](#move-ailments)) |
-| category       | The category of move this move falls under, e.g. damage or ailment                                     | [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
-| min_hits       | The minimum number of times this move hits. Null if it always only hits once.                          | integer |
-| max_hits       | The maximum number of times this move hits. Null if it always only hits once.                          | integer |
-| min_turns      | The minimum number of turns this move continues to take effect. Null if it always only lasts one turn. | integer |
-| max_turns      | The maximum number of turns this move continues to take effect. Null if it always only lasts one turn. | integer |
-| drain          | HP drain (if positive) or Recoil damage (if negative), in percent of damage done                       | integer |
-| healing        | The amount of hp gained by the attacking Pokemon, in percent of it's maximum HP                        | integer |
-| crit_rate      | Critical hit rate bonus                                                                                | integer |
-| ailment_chance | The likelihood this attack will cause an ailment                                                       | integer |
-| flinch_chance  | The likelihood this attack will cause the target Pokémon to flinch                                     | integer |
-| stat_chance    | The likelihood this attack will cause a stat change in the target Pokémon                              | integer |
+| category       | The category of move this move falls under, e.g. damage or ailment                                     | [NamedAPIResource](#namedapiresource) ([Move](#moves))                |
+| min_hits       | The minimum number of times this move hits. Null if it always only hits once.                          | integer                                                               |
+| max_hits       | The maximum number of times this move hits. Null if it always only hits once.                          | integer                                                               |
+| min_turns      | The minimum number of turns this move continues to take effect. Null if it always only lasts one turn. | integer                                                               |
+| max_turns      | The maximum number of turns this move continues to take effect. Null if it always only lasts one turn. | integer                                                               |
+| drain          | HP drain (if positive) or Recoil damage (if negative), in percent of damage done                       | integer                                                               |
+| healing        | The amount of hp gained by the attacking Pokemon, in percent of it's maximum HP                        | integer                                                               |
+| crit_rate      | Critical hit rate bonus                                                                                | integer                                                               |
+| ailment_chance | The likelihood this attack will cause an ailment                                                       | integer                                                               |
+| flinch_chance  | The likelihood this attack will cause the target Pokémon to flinch                                     | integer                                                               |
+| stat_chance    | The likelihood this attack will cause a stat change in the target Pokémon                              | integer                                                               |
 
 #### MoveStatChange
 
-| Name   | Description | Data Type |
-| ------ | ----------- | --------- |
-| change | The amount of change    | integer |
+| Name   | Description             | Data Type                                              |
+|:-------|:------------------------|:-------------------------------------------------------|
+| change | The amount of change    | integer                                                |
 | stat   | The stat being affected | [NamedAPIResource](#namedapiresource) ([Stat](#stats)) |
 
 #### PastMoveStatValues
 
-| Name           | Description | Data Type |
-| -------------- | ----------- | --------- |
-| accuracy       | The percent value of how likely this move is to be successful                  | integer |
-| effect_chance  | The percent value of how likely it is this moves effect will take effect       | integer |
-| power          | The base power of this move with a value of 0 if it does not have a base power | integer |
-| pp             | Power points. The number of times this move can be used                        | integer |
-| effect_entries | The effect of this move listed in different languages                          | list [VerboseEffect](#verboseeffect) |
-| type           | The elemental type of this move                                                | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
+| Name           | Description                                                                    | Data Type                                                               |
+|:---------------|:-------------------------------------------------------------------------------|:------------------------------------------------------------------------|
+| accuracy       | The percent value of how likely this move is to be successful                  | integer                                                                 |
+| effect_chance  | The percent value of how likely it is this moves effect will take effect       | integer                                                                 |
+| power          | The base power of this move with a value of 0 if it does not have a base power | integer                                                                 |
+| pp             | Power points. The number of times this move can be used                        | integer                                                                 |
+| effect_entries | The effect of this move listed in different languages                          | list [VerboseEffect](#verboseeffect)                                    |
+| type           | The elemental type of this move                                                | [NamedAPIResource](#namedapiresource) ([Type](#types))                  |
 | version group  | The version group in which these move stat values were in effect               | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 ## Move Ailments
@@ -1354,12 +1354,12 @@ Move Ailments are status conditions caused by moves used during battle. See [Bul
 
 #### Move Ailment
 
-| Name  | Description | Data Type |
-| ----- | ----------- | --------- |
-| id    | The identifier for this move ailment resource               | integer |
-| name  | The name for this move ailment resource	                    | string  |
+| Name  | Description                                                 | Data Type                                                   |
+|:------|:------------------------------------------------------------|:------------------------------------------------------------|
+| id    | The identifier for this move ailment resource               | integer                                                     |
+| name  | The name for this move ailment resource                     | string                                                      |
 | moves | A list of moves that cause this ailment                     | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
-| names | The name of this move ailment listed in different languages | list [Name](#resourcename) |
+| names | The name of this move ailment listed in different languages | list [Name](#resourcename)                                  |
 
 ## Move Battle Styles
 Styles of moves when used in the Battle Palace. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Battle_Frontier_(Generation_III)) for greater detail.
@@ -1386,10 +1386,10 @@ Styles of moves when used in the Battle Palace. See [Bulbapedia](http://bulbaped
 
 #### Move Battle Style
 
-| Name  | Description | Data Type |
-| ----- | ----------- | --------- |
-| id    | The identifier for this move battle style resource               | integer |
-| name  | The name for this move battle style resource                     | string  |
+| Name  | Description                                                      | Data Type                  |
+|:------|:-----------------------------------------------------------------|:---------------------------|
+| id    | The identifier for this move battle style resource               | integer                    |
+| name  | The name for this move battle style resource                     | string                     |
 | names | The name of this move battle style listed in different languages | list [Name](#resourcename) |
 
 ## Move Categories
@@ -1421,12 +1421,12 @@ Very general categories that loosely group move effects.
 
 #### Move Category
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this move category resource                     | integer |
-| name         | The name for this move category resource	                          | string  |
+| Name         | Description                                                        | Data Type                                                   |
+|:-------------|:-------------------------------------------------------------------|:------------------------------------------------------------|
+| id           | The identifier for this move category resource                     | integer                                                     |
+| name         | The name for this move category resource                           | string                                                      |
 | moves        | A list of moves that fall into this category                       | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
-| descriptions | The description of this move ailment listed in different languages | list [Description](#description) |
+| descriptions | The description of this move ailment listed in different languages | list [Description](#description)                            |
 
 ## Move Damage Classes
 Damage classes moves can have, e.g. physical, special, or non-damaging.
@@ -1457,13 +1457,13 @@ Damage classes moves can have, e.g. physical, special, or non-damaging.
 
 #### Move Damage Class
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this move damage class resource                      | integer |
-| name         | The name for this move damage class resource	                           | string  |
-| descriptions | The description of this move damage class listed in different languages | list [Description](#description) |
+| Name         | Description                                                             | Data Type                                                   |
+|:-------------|:------------------------------------------------------------------------|:------------------------------------------------------------|
+| id           | The identifier for this move damage class resource                      | integer                                                     |
+| name         | The name for this move damage class resource                            | string                                                      |
+| descriptions | The description of this move damage class listed in different languages | list [Description](#description)                            |
 | moves        | A list of moves that fall into this damage class                        | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
-| names        | The name of this move damage class listed in different languages        | list [Name](#resourcename) |
+| names        | The name of this move damage class listed in different languages        | list [Name](#resourcename)                                  |
 
 ## Move Learn Methods
 Methods by which Pokémon can learn moves.
@@ -1501,12 +1501,12 @@ Methods by which Pokémon can learn moves.
 
 #### Move Learn Method
 
-| Name           | Description | Data Type |
-| -------------- | ----------- | --------- |
-| id             | The identifier for this move learn method resource                      | integer |
-| name           | The name for this move learn method resource                            | string  |
-| descriptions   | The description of this move learn method listed in different languages | list [Description](#description) |
-| names          | The name of this move learn method listed in different languages        | list [Name](#resourcename) |
+| Name           | Description                                                             | Data Type                                                                    |
+|:---------------|:------------------------------------------------------------------------|:-----------------------------------------------------------------------------|
+| id             | The identifier for this move learn method resource                      | integer                                                                      |
+| name           | The name for this move learn method resource                            | string                                                                       |
+| descriptions   | The description of this move learn method listed in different languages | list [Description](#description)                                             |
+| names          | The name of this move learn method listed in different languages        | list [Name](#resourcename)                                                   |
 | version_groups | A list of version groups where moves can be learned through this method | list [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 ## Move Targets
@@ -1545,13 +1545,13 @@ Targets moves can be directed at during battle. Targets can be Pokémon, environ
 
 #### Move Target
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this move target resource                      | integer |
-| name         | The name for this move target resource                            | string  |
-| descriptions | The description of this move target listed in different languages | list [Description](#description) |
+| Name         | Description                                                       | Data Type                                                   |
+|:-------------|:------------------------------------------------------------------|:------------------------------------------------------------|
+| id           | The identifier for this move target resource                      | integer                                                     |
+| name         | The name for this move target resource                            | string                                                      |
+| descriptions | The description of this move target listed in different languages | list [Description](#description)                            |
 | moves        | A list of moves that that are directed at this target             | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
-| names        | The name of this move target listed in different languages        | list [Name](#resourcename) |
+| names        | The name of this move target listed in different languages        | list [Name](#resourcename)                                  |
 
 <h1 id="locations-section">Locations</h1>
 
@@ -1595,13 +1595,13 @@ Locations that can be visited within the games. Locations make up sizable portio
 
 #### Location
 
-| Name         | Description | Data Type |
-| ------------ | ----------- | --------- |
-| id           | The identifier for this location resource                      | integer |
-| name         | The name for this location resource                            | string  |
-| region       | The region this location can be found in                       | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
-| names        | The name of this language listed in different languages        | list [Name](#resourcename) |
-| game_indices | A list of game indices relevent to this location by generation | list [GenerationGameIndex](#generationgameindex) |
+| Name         | Description                                                    | Data Type                                                                    |
+|:-------------|:---------------------------------------------------------------|:-----------------------------------------------------------------------------|
+| id           | The identifier for this location resource                      | integer                                                                      |
+| name         | The name for this location resource                            | string                                                                       |
+| region       | The region this location can be found in                       | [NamedAPIResource](#namedapiresource) ([Region](#regions))                   |
+| names        | The name of this language listed in different languages        | list [Name](#resourcename)                                                   |
+| game_indices | A list of game indices relevent to this location by generation | list [GenerationGameIndex](#generationgameindex)                             |
 | areas        | Areas that can be found within this location                   | list [NamedAPIResource](#namedapiresource) ([LocationArea](#location-areas)) |
 
 ## Location Areas
@@ -1670,36 +1670,36 @@ Location areas are sections of areas, such as floors in a building or cave. Each
 
 #### LocationArea
 
-| Name                   | Description | Data Type |
-| ---------------------- | ----------- | --------- |
-| id                     | The identifier for this location resource                                                                                                    | integer |
-| name                   | The name for this location resource                                                                                                          | string  |
-| game_index             | The internal id of an API resource within game data                                                                                          | integer |
-| encounter_method_rates | A list of methods in which Pokémon may be encountered in this area and how likely the method will occur depending on the version of the game | list [EncounterMethodRate](#encountermethodrate) |
+| Name                   | Description                                                                                                                                  | Data Type                                                  |
+|:-----------------------|:---------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|
+| id                     | The identifier for this location resource                                                                                                    | integer                                                    |
+| name                   | The name for this location resource                                                                                                          | string                                                     |
+| game_index             | The internal id of an API resource within game data                                                                                          | integer                                                    |
+| encounter_method_rates | A list of methods in which Pokémon may be encountered in this area and how likely the method will occur depending on the version of the game | list [EncounterMethodRate](#encountermethodrate)           |
 | location               | The region this location can be found in                                                                                                     | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
-| names                  | The name of this location area listed in different languages                                                                                 | list [Name](#resourcename) |
-| pokemon_encounters     | A list of Pokémon that can be encountered in this area along with version specific details about the encounter                               | list [PokemonEncounter](#pokemonencounter) |
+| names                  | The name of this location area listed in different languages                                                                                 | list [Name](#resourcename)                                 |
+| pokemon_encounters     | A list of Pokémon that can be encountered in this area along with version specific details about the encounter                               | list [PokemonEncounter](#pokemonencounter)                 |
 
 #### EncounterMethodRate
 
-| Name             | Description | Data Type |
-| ---------------- | ----------- | --------- |
+| Name             | Description                                                    | Data Type                                                                   |
+|:-----------------|:---------------------------------------------------------------|:----------------------------------------------------------------------------|
 | encounter_method | The method in which Pokémon may be encountered in an area.     | [NamedAPIResource](#namedapiresource) ([EncounterMethod](#encountermehtod)) |
-| version_details  | The chance of the encounter to occur on a version of the game. | list [EncounterVersionDetails](#encounterversiondetails) |
+| version_details  | The chance of the encounter to occur on a version of the game. | list [EncounterVersionDetails](#encounterversiondetails)                    |
 
 #### EncounterVersionDetails
 
-| Name    | Description | Data Type |
-| ------- | ----------- | --------- |
-| rate    | The chance of an encounter to occur.                                            | integer |
+| Name    | Description                                                                     | Data Type                                                   |
+|:--------|:--------------------------------------------------------------------------------|:------------------------------------------------------------|
+| rate    | The chance of an encounter to occur.                                            | integer                                                     |
 | version | The version of the game in which the encounter can occur with the given chance. | [NamedAPIResource](#namedapiresource) ([Version](#version)) |
 
 #### PokemonEncounter
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
+| Name            | Description                                                                                      | Data Type                                                   |
+|:----------------|:-------------------------------------------------------------------------------------------------|:------------------------------------------------------------|
 | pokemon         | The Pokémon being encountered                                                                    | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
-| version_details | A list of versions and encounters with Pokémon that might happen in the referenced location area | list [VersionEncounterDetail](#versionencounterdetail) |
+| version_details | A list of versions and encounters with Pokémon that might happen in the referenced location area | list [VersionEncounterDetail](#versionencounterdetail)      |
 
 ## Pal Park Areas
 Areas used for grouping Pokémon encounters in Pal Park. They're like habitats that are specific to Pal Park.
@@ -1734,19 +1734,19 @@ Areas used for grouping Pokémon encounters in Pal Park. They're like habitats t
 
 #### PalParkArea
 
-| Name               | Description | Data Type |
-| ------------------ | ----------- | --------- |
-| id                 | The identifier for this pal park area resource                        | integer |
-| name               | The name for this pal park area resource                              | string  |
-| names              | The name of this pal park area listed in different languages          | list [Name](#resourcename) |
+| Name               | Description                                                           | Data Type                                                |
+|:-------------------|:----------------------------------------------------------------------|:---------------------------------------------------------|
+| id                 | The identifier for this pal park area resource                        | integer                                                  |
+| name               | The name for this pal park area resource                              | string                                                   |
+| names              | The name of this pal park area listed in different languages          | list [Name](#resourcename)                               |
 | pokemon_encounters | A list of Pokémon encountered in thi pal park area along with details | list [PalParkEncounterSpecies](#palparkencounterspecies) |
 
 #### PalParkEncounterSpecies
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| base_score      | The base score given to the player when this Pokémon is caught during a pal park run | integer |
-| rate            | The base rate for encountering this Pokémon in this pal park area                    | integer |
+| Name            | Description                                                                          | Data Type                                                                 |
+|:----------------|:-------------------------------------------------------------------------------------|:--------------------------------------------------------------------------|
+| base_score      | The base score given to the player when this Pokémon is caught during a pal park run | integer                                                                   |
+| rate            | The base rate for encountering this Pokémon in this pal park area                    | integer                                                                   |
 | pokemon_species | The Pokémon species being encountered                                                | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemonspecies)) |
 
 ## Regions
@@ -1790,14 +1790,14 @@ A region is an organized area of the Pokémon world. Most often, the main differ
 
 #### Region
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| id              | The identifier for this region resource                   | integer |
-| name            | The name for this region resource                         | string |
-| locations       | A list of locations that can be found in this region      | list [NamedAPIResource](#namedapiresource) ([Location](#locations)) |
-| main_generation | The generation this region was introduced in              | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
-| names           | The name of this region listed in different languages     | list [Name](#resourcename) |
-| pokedexes       | A list of pokédexes that catalogue Pokémon in this region | list [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
+| Name            | Description                                               | Data Type                                                                    |
+|:----------------|:----------------------------------------------------------|:-----------------------------------------------------------------------------|
+| id              | The identifier for this region resource                   | integer                                                                      |
+| name            | The name for this region resource                         | string                                                                       |
+| locations       | A list of locations that can be found in this region      | list [NamedAPIResource](#namedapiresource) ([Location](#locations))          |
+| main_generation | The generation this region was introduced in              | [NamedAPIResource](#namedapiresource) ([Generation](#generations))           |
+| names           | The name of this region listed in different languages     | list [Name](#resourcename)                                                   |
+| pokedexes       | A list of pokédexes that catalogue Pokémon in this region | list [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes))           |
 | version_groups  | A list of version groups where this region can be visited | list [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 <h1 id="pokemon-section">Pokemon</h1>
@@ -1873,39 +1873,39 @@ Abilities provide passive effects for Pokémon in battle or in the overworld. Po
 
 #### Ability
 
-| Name                | Description | Data Type |
-| ------------------- | ----------- | --------- |
-| id                  | The identifier for this ability resource                                     | integer |
-| name                | The name for this ability resource                                           | string  |
-| is_main_series      | Whether or not this ability originated in the main series of the video games | boolean |
+| Name                | Description                                                                  | Data Type                                                          |
+|:--------------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------|
+| id                  | The identifier for this ability resource                                     | integer                                                            |
+| name                | The name for this ability resource                                           | string                                                             |
+| is_main_series      | Whether or not this ability originated in the main series of the video games | boolean                                                            |
 | generation          | The generation this ability originated in                                    | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
-| names               | The name of this ability listed in different languages                       | list [Name](#resourcename) |
-| effect_entries      | The effect of this ability listed in different languages                     | list [VerboseEffect](#verboseeffect) |
-| effect_changes      | The list of previous effects this ability has had across version groups      | list [AbilityEffectChange](#abilityeffectchange) |
-| flavor_text_entries | The flavor text of this ability listed in different languages                | list [AbilityFlavorText](#abilityflavortext) |
-| pokemon             | A list of Pokémon that could potentially have this ability                   | list [AbilityPokemon](#abilitypokemon) |
+| names               | The name of this ability listed in different languages                       | list [Name](#resourcename)                                         |
+| effect_entries      | The effect of this ability listed in different languages                     | list [VerboseEffect](#verboseeffect)                               |
+| effect_changes      | The list of previous effects this ability has had across version groups      | list [AbilityEffectChange](#abilityeffectchange)                   |
+| flavor_text_entries | The flavor text of this ability listed in different languages                | list [AbilityFlavorText](#abilityflavortext)                       |
+| pokemon             | A list of Pokémon that could potentially have this ability                   | list [AbilityPokemon](#abilitypokemon)                             |
 
 #### AbilityEffectChange
 
-| Name           | Description | Data Type |
-| -------------- | ----------- | --------- |
-| effect_entries | The previous effect of this ability listed in different languages         | list [Effect](#effect) |
+| Name           | Description                                                               | Data Type                                                              |
+|:---------------|:--------------------------------------------------------------------------|:-----------------------------------------------------------------------|
+| effect_entries | The previous effect of this ability listed in different languages         | list [Effect](#effect)                                                 |
 | version_group  | The version group in which the previous effect of this ability originated | [NamedAPIResource](#namedapiresource) ([VersionGroup](#versiongroups)) |
 
 #### AbilityFlavorText
 
-| Name          | Description | Data Type |
-| ------------- | ----------- | --------- |
-| flavor_text   | The localized name for an API resource in a specific language | string |
-| language      | The language this name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
+| Name          | Description                                                   | Data Type                                                               |
+|:--------------|:--------------------------------------------------------------|:------------------------------------------------------------------------|
+| flavor_text   | The localized name for an API resource in a specific language | string                                                                  |
+| language      | The language this name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages))          |
 | version_group | The version group that uses this flavor text                  | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 #### AbilityPokemon
 
-| Name      | Description | Data Type |
-| --------- | ----------- | --------- |
-| is_hidden | Whether or not this a hidden ability for the referenced Pokémon                                                                                          | boolean |
-| slot      | Pokémon have 3 ability 'slots' which hold references to possible abilities they could have. This is the slot of this ability for the referenced pokemon. | integer |
+| Name      | Description                                                                                                                                              | Data Type                                                   |
+|:----------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------|
+| is_hidden | Whether or not this a hidden ability for the referenced Pokémon                                                                                          | boolean                                                     |
+| slot      | Pokémon have 3 ability 'slots' which hold references to possible abilities they could have. This is the slot of this ability for the referenced pokemon. | integer                                                     |
 | pokemon   | The Pokémon this ability could belong to                                                                                                                 | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
 
 ## Characteristics
@@ -1939,11 +1939,11 @@ Characteristics indicate which stat contains a Pokémon's highest IV. A Pokémon
 
 #### Characteristic
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| id              | The identifier for this characteristic resource                                                                        | integer |
-| gene_modulo     | The remainder of the highest stat/IV divided by 5                                                                      | integer |
-| possible_values | The possible values of the highest stat that would result in a Pokémon recieving this characteristic when divided by 5 | list integer |
+| Name            | Description                                                                                                            | Data Type                          |
+|:----------------|:-----------------------------------------------------------------------------------------------------------------------|:-----------------------------------|
+| id              | The identifier for this characteristic resource                                                                        | integer                            |
+| gene_modulo     | The remainder of the highest stat/IV divided by 5                                                                      | integer                            |
+| possible_values | The possible values of the highest stat that would result in a Pokémon recieving this characteristic when divided by 5 | list integer                       |
 | descriptions    | The descriptions of this characteristic listed in different languages                                                  | list ([Description](#description)) |
 
 ## Egg Groups
@@ -1976,11 +1976,11 @@ Egg Groups are categories which determine which Pokémon are able to interbreed.
 
 #### EggGroup
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| id              | The identifier for this egg group resource                       | integer |
-| name            | The name for this egg group resource                             | string  |
-| names           | The name of this egg group listed in different languages         | list [Name](#resourcename) |
+| Name            | Description                                                      | Data Type                                                                       |
+|:----------------|:-----------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this egg group resource                       | integer                                                                         |
+| name            | The name for this egg group resource                             | string                                                                          |
+| names           | The name of this egg group listed in different languages         | list [Name](#resourcename)                                                      |
 | pokemon_species | A list of all Pokémon species that are members of this egg group | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Genders
@@ -2013,18 +2013,18 @@ Genders were introduced in Generation II for the purposes of breeding Pokémon b
 
 #### Gender
 
-| Name                    | Description | Data Type |
-| ----------------------- | ----------- | --------- |
-| id                      | The identifier for this gender resource                                                        | integer |
-| name                    | The name for this gender resource                                                              | string  |
-| pokemon_species_details | A list of Pokémon species that can be this gender and how likely it is that they will be       | list [PokemonSpeciesGender](#pokemonspeciesgender) |
+| Name                    | Description                                                                                    | Data Type                                                                       |
+|:------------------------|:-----------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id                      | The identifier for this gender resource                                                        | integer                                                                         |
+| name                    | The name for this gender resource                                                              | string                                                                          |
+| pokemon_species_details | A list of Pokémon species that can be this gender and how likely it is that they will be       | list [PokemonSpeciesGender](#pokemonspeciesgender)                              |
 | required_for_evolution  | A list of Pokémon species that required this gender in order for a Pokémon to evolve into them | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 #### PokemonSpeciesGender
 
-| Name            | Description | Data Type |
-| --------------- | ----------- | --------- |
-| rate            | The chance of this Pokémon being female, in eighths; or -1 for genderless | integer |
+| Name            | Description                                                               | Data Type                                                                  |
+|:----------------|:--------------------------------------------------------------------------|:---------------------------------------------------------------------------|
+| rate            | The chance of this Pokémon being female, in eighths; or -1 for genderless | integer                                                                    |
 | pokemon_species | A Pokémon species that can be the referenced gender                       | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Growth Rates
@@ -2061,21 +2061,21 @@ Growth rates are the speed with which Pokémon gain levels through experience. C
 
 #### Growth Rate
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id              | The identifier for this gender resource                                                       | integer |
-| name            | The name for this gender resource                                                             | string  |
-| formula         | The formula used to calculate the rate at which the Pokémon species gains level               | string  |
-| descriptions    | The descriptions of this characteristic listed in different languages                         | list [Description](#description) |
-| levels          | A list of levels and the amount of experienced needed to atain them based on this growth rate | list [GrowthRateExperienceLevel](#growthrateexperiencelevel) |
+| Name            | Description                                                                                   | Data Type                                                                       |
+|:----------------|:----------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this gender resource                                                       | integer                                                                         |
+| name            | The name for this gender resource                                                             | string                                                                          |
+| formula         | The formula used to calculate the rate at which the Pokémon species gains level               | string                                                                          |
+| descriptions    | The descriptions of this characteristic listed in different languages                         | list [Description](#description)                                                |
+| levels          | A list of levels and the amount of experienced needed to atain them based on this growth rate | list [GrowthRateExperienceLevel](#growthrateexperiencelevel)                    |
 | pokemon_species | A list of Pokémon species that gain levels at this growth rate                                | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 #### GrowthRateExperienceLevel
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| level      | The level gained                                                | integer |
-| experience | The amount of experience required to reach the referenced level | integer |
+| Name       | Description                                                     | Data Type |
+|:-----------|:----------------------------------------------------------------|:----------|
+| level      | The level gained                                                | integer   |
+| experience | The amount of experience required to reach the referenced level | integer   |
 
 ## Natures
 Natures influence how a Pokémon's stats grow. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Nature) for greater detail.
@@ -2133,31 +2133,31 @@ Natures influence how a Pokémon's stats grow. See [Bulbapedia](http://bulbapedi
 
 #### Nature
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id                            | The identifier for this nature resource                                                                               | integer |
-| name                          | The name for this nature resource                                                                                     | string  |
-| decreased_stat                | The stat decreased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats)) |
-| increased_stat                | The stat increased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats)) |
+| Name                          | Description                                                                                                           | Data Type                                                             |
+|:------------------------------|:----------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------|
+| id                            | The identifier for this nature resource                                                                               | integer                                                               |
+| name                          | The name for this nature resource                                                                                     | string                                                                |
+| decreased_stat                | The stat decreased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats))                |
+| increased_stat                | The stat increased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats))                |
 | hates_flavor                  | The flavor hated by Pokémon with this nature                                                                          | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
 | likes_flavor                  | The flavor liked by Pokémon with this nature                                                                          | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
-| pokeathlon_stat_changes       | A list of Pokéathlon stats this nature effects and how much it effects them                                           | list [NatureStatChange](#naturestatchange) |
-| move_battle_style_preferences | A list of battle styles and how likely a Pokémon with this nature is to use them in the Battle Palace or Battle Tent. | list [MoveBattleStylePreference](#movebattlestylepreference) |
-| names                         | The name of this nature listed in different languages                                                                 | list [Name](#resourcename) |
+| pokeathlon_stat_changes       | A list of Pokéathlon stats this nature effects and how much it effects them                                           | list [NatureStatChange](#naturestatchange)                            |
+| move_battle_style_preferences | A list of battle styles and how likely a Pokémon with this nature is to use them in the Battle Palace or Battle Tent. | list [MoveBattleStylePreference](#movebattlestylepreference)          |
+| names                         | The name of this nature listed in different languages                                                                 | list [Name](#resourcename)                                            |
 
 #### NatureStatChange
 
-| Name   | Description | Data Type |
-| ------ | ----------- | --------- |
-| max_change | The amount of change    | integer |
+| Name            | Description             | Data Type                                                                   |
+|:----------------|:------------------------|:----------------------------------------------------------------------------|
+| max_change      | The amount of change    | integer                                                                     |
 | pokeathlon_stat | The stat being affected | [NamedAPIResource](#namedapiresource) ([PokeathlonStat](#pokeathlon-stats)) |
 
 #### MoveBattleStylePreference
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| low_hp_preference  | Chance of using the move, in percent, if HP is under one half | integer |
-| high_hp_preference | Chance of using the move, in percent, if HP is over one half  | integer |
+| Name               | Description                                                   | Data Type                                                                      |
+|:-------------------|:--------------------------------------------------------------|:-------------------------------------------------------------------------------|
+| low_hp_preference  | Chance of using the move, in percent, if HP is under one half | integer                                                                        |
+| high_hp_preference | Chance of using the move, in percent, if HP is over one half  | integer                                                                        |
 | move_battle_style  | The move battle style                                         | [NamedAPIResource](#namedapiresource) ([MoveBattleStyle](#move-battle-styles)) |
 
 ## Pokeathlon Stats
@@ -2201,25 +2201,25 @@ Pokeathlon Stats are different attributes of a Pokémon's performance in Pokéat
 
 #### PokeathlonStat
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id                | The identifier for this Pokéathlon stat resource                    | integer |
-| name              | The name for this Pokéathlon stat resource                          | string  |
-| names             | The name of this Pokéathlon stat listed in different languages      | list [Name](#resourcename) |
+| Name              | Description                                                                    | Data Type                                                         |
+|:------------------|:-------------------------------------------------------------------------------|:------------------------------------------------------------------|
+| id                | The identifier for this Pokéathlon stat resource                               | integer                                                           |
+| name              | The name for this Pokéathlon stat resource                                     | string                                                            |
+| names             | The name of this Pokéathlon stat listed in different languages                 | list [Name](#resourcename)                                        |
 | affecting_natures | A detail of natures which affect this Pokéathlon stat positively or negatively | [NaturePokeathlonStatAffectSets](#naturepokeathlonstataffectsets) |
 
 #### NaturePokeathlonStatAffectSets
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name     | Description                                                          | Data Type                                                      |
+|:---------|:---------------------------------------------------------------------|:---------------------------------------------------------------|
 | increase | A list of natures and how they change the referenced Pokéathlon stat | list [NaturePokeathlonStatAffect](#naturepokeathlonstataffect) |
 | decrease | A list of natures and how they change the referenced Pokéathlon stat | list [NaturePokeathlonStatAffect](#naturepokeathlonstataffect) |
 
 #### NaturePokeathlonStatAffect
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| max_change | The maximum amount of change to the referenced Pokéathlon stat | integer |
+| Name       | Description                                                    | Data Type                                                  |
+|:-----------|:---------------------------------------------------------------|:-----------------------------------------------------------|
+| max_change | The maximum amount of change to the referenced Pokéathlon stat | integer                                                    |
 | nature     | The nature causing the change                                  | [NamedAPIResource](#namedapiresource) ([Nature](#natures)) |
 
 ## Pokemon
@@ -2349,97 +2349,97 @@ Pokémon are the creatures that inhabit the world of the Pokémon games. They ca
 
 #### Pokemon
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id                       | The identifier for this Pokémon resource                                                         | integer |
-| name                     | The name for this Pokémon resource                                                               | string  |
-| base_experience          | The base experience gained for defeating this Pokémon                                            | integer |
-| height                   | The height of this Pokémon                                                                       | integer |
-| is_default               | Set for exactly one Pokémon used as the default for each species                                 | boolean |
-| order                    | Order for sorting. Almost national order, except families are grouped together.                  | integer |
-| weight                   | The weight of this Pokémon                                                                       | integer |
-| abilities                | A list of abilities this Pokémon could potentially have                                          | list [PokemonAbility](#pokemonability) |
+| Name                     | Description                                                                                      | Data Type                                                                  |
+|:-------------------------|:-------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------|
+| id                       | The identifier for this Pokémon resource                                                         | integer                                                                    |
+| name                     | The name for this Pokémon resource                                                               | string                                                                     |
+| base_experience          | The base experience gained for defeating this Pokémon                                            | integer                                                                    |
+| height                   | The height of this Pokémon                                                                       | integer                                                                    |
+| is_default               | Set for exactly one Pokémon used as the default for each species                                 | boolean                                                                    |
+| order                    | Order for sorting. Almost national order, except families are grouped together.                  | integer                                                                    |
+| weight                   | The weight of this Pokémon                                                                       | integer                                                                    |
+| abilities                | A list of abilities this Pokémon could potentially have                                          | list [PokemonAbility](#pokemonability)                                     |
 | forms                    | A list of forms this Pokémon can take on                                                         | list [NamedAPIResource](#namedapiresource) ([PokemonForm](#pokemon-forms)) |
-| game_indices             | A list of game indices relevent to Pokémon item by generation                                    | list [VersionGameIndex](#versiongameindex) |
-| held_items               | A list of items this Pokémon may be holding when encountered                                     | list [PokemonHeldItem](#pokemonhelditem) |
-| location_area_encounters | A link to a list of location areas as well as encounter details pertaining to specific versions  | string (URL to list [LocationAreaEncounter](#locationareaencounter)) |
-| moves                    | A list of moves along with learn methods and level details pertaining to specific version groups | list [PokemonMove](#pokemonmove) |
-| sprites                  | A set of sprites used to depict this Pokémon in the game                                         | [PokemonSprites](#pokemonsprites) |
+| game_indices             | A list of game indices relevent to Pokémon item by generation                                    | list [VersionGameIndex](#versiongameindex)                                 |
+| held_items               | A list of items this Pokémon may be holding when encountered                                     | list [PokemonHeldItem](#pokemonhelditem)                                   |
+| location_area_encounters | A link to a list of location areas as well as encounter details pertaining to specific versions  | string (URL to list [LocationAreaEncounter](#locationareaencounter))       |
+| moves                    | A list of moves along with learn methods and level details pertaining to specific version groups | list [PokemonMove](#pokemonmove)                                           |
+| sprites                  | A set of sprites used to depict this Pokémon in the game                                         | [PokemonSprites](#pokemonsprites)                                          |
 | species                  | The species this Pokémon belongs to                                                              | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| stats                    | A list of base stat values for this Pokémon                                                      | list [PokemonStat](#pokemonstat) |
-| types                    | A list of details showing types this Pokémon has                                                 | list [PokemonType](#pokemontype) |
+| stats                    | A list of base stat values for this Pokémon                                                      | list [PokemonStat](#pokemonstat)                                           |
+| types                    | A list of details showing types this Pokémon has                                                 | list [PokemonType](#pokemontype)                                           |
 
 #### PokemonAbility
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| is_hidden | Whether or not this is a hidden ability                | boolean |
-| slot      | The slot this ability occupies in this Pokémon species | integer |
+| Name      | Description                                            | Data Type                                                     |
+|:----------|:-------------------------------------------------------|:--------------------------------------------------------------|
+| is_hidden | Whether or not this is a hidden ability                | boolean                                                       |
+| slot      | The slot this ability occupies in this Pokémon species | integer                                                       |
 | ability   | The ability the Pokémon may have                       | [NamedAPIResource](#namedapiresource) ([Ability](#abilities)) |
 
 #### PokemonType
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| slot | The order the Pokémon's types are listed in | integer |
-| type | The type the referenced Pokémon has         | string  |
+| Name | Description                                 | Data Type |
+|:-----|:--------------------------------------------|:----------|
+| slot | The order the Pokémon's types are listed in | integer   |
+| type | The type the referenced Pokémon has         | string    |
 
 #### PokemonHeldItem
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| item | The item the referenced Pokémon holds | [NamedAPIResource](#namedapiresource) ([Item](#item)) |
-| version_details | The details of the different versions in which the item is held | list [PokemonHeldItemVersion](#pokemonhelditemversion)  |
+| Name            | Description                                                     | Data Type                                              |
+|:----------------|:----------------------------------------------------------------|:-------------------------------------------------------|
+| item            | The item the referenced Pokémon holds                           | [NamedAPIResource](#namedapiresource) ([Item](#item))  |
+| version_details | The details of the different versions in which the item is held | list [PokemonHeldItemVersion](#pokemonhelditemversion) |
 
 #### PokemonHeldItemVersion
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name    | Description                           | Data Type                                                   |
+|:--------|:--------------------------------------|:------------------------------------------------------------|
 | version | The version in which the item is held | [NamedAPIResource](#namedapiresource) ([Version](#version)) |
-| rarity | How often the item is held | integer  |
+| rarity  | How often the item is held            | integer                                                     |
 
 #### PokemonMove
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| move | The move the Pokémon can learn | [NamedAPIResource](#namedapiresource) ([Move](#move)) |
-| version_group_details | The details of the version in which the Pokémon can learn the move         | list [PokemonMoveVersion](#pokemonmoveversion)  |
+| Name                  | Description                                                        | Data Type                                             |
+|:----------------------|:-------------------------------------------------------------------|:------------------------------------------------------|
+| move                  | The move the Pokémon can learn                                     | [NamedAPIResource](#namedapiresource) ([Move](#move)) |
+| version_group_details | The details of the version in which the Pokémon can learn the move | list [PokemonMoveVersion](#pokemonmoveversion)        |
 
 #### PokemonMoveVersion
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| move_learn_method | The method by which the move is learned | [NamedAPIResource](#namedapiresource) ([MoveLearnMethod](#move-learn-method)) |
-| version_group | The version group in which the move is learned        | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-group))  |
-| level_learned_at | The minimum level to learn the move       | string  |
+| Name              | Description                                    | Data Type                                                                     |
+|:------------------|:-----------------------------------------------|:------------------------------------------------------------------------------|
+| move_learn_method | The method by which the move is learned        | [NamedAPIResource](#namedapiresource) ([MoveLearnMethod](#move-learn-method)) |
+| version_group     | The version group in which the move is learned | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-group))        |
+| level_learned_at  | The minimum level to learn the move            | string                                                                        |
 
 #### PokemonStat
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| stat | The stat the Pokémon has | [NamedAPIResource](#namedapiresource) ([Stat](#stat)) |
-| effort | The effort points the Pokémon has in the stat         | integer  |
-| base_stat | The base value of the stst   | integer  |
+| Name      | Description                                   | Data Type                                             |
+|:----------|:----------------------------------------------|:------------------------------------------------------|
+| stat      | The stat the Pokémon has                      | [NamedAPIResource](#namedapiresource) ([Stat](#stat)) |
+| effort    | The effort points the Pokémon has in the stat | integer                                               |
+| base_stat | The base value of the stst                    | integer                                               |
 
 #### PokemonSprites
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| front_default      | The default depiction of this Pokémon from the front in battle      | string |
-| front_shiny        | The shiny depiction of this Pokémon from the front in battle        | string |
-| front_female       | The female depiction of this Pokémon from the front in battle       | string |
-| front_shiny_female | The shiny female depiction of this Pokémon from the front in battle | string |
-| back_default       | The default depiction of this Pokémon from the back in battle       | string |
-| back_shiny         | The shiny depiction of this Pokémon from the back in battle         | string |
-| back_female        | The female depiction of this Pokémon from the back in battle        | string |
-| back_shiny_female  | The shiny female depiction of this Pokémon from the back in battle  | string |
+| Name               | Description                                                         | Data Type |
+|:-------------------|:--------------------------------------------------------------------|:----------|
+| front_default      | The default depiction of this Pokémon from the front in battle      | string    |
+| front_shiny        | The shiny depiction of this Pokémon from the front in battle        | string    |
+| front_female       | The female depiction of this Pokémon from the front in battle       | string    |
+| front_shiny_female | The shiny female depiction of this Pokémon from the front in battle | string    |
+| back_default       | The default depiction of this Pokémon from the back in battle       | string    |
+| back_shiny         | The shiny depiction of this Pokémon from the back in battle         | string    |
+| back_female        | The female depiction of this Pokémon from the back in battle        | string    |
+| back_shiny_female  | The shiny female depiction of this Pokémon from the back in battle  | string    |
 
 #### LocationAreaEncounter
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name            | Description                                                                     | Data Type                                                          |
+|:----------------|:--------------------------------------------------------------------------------|:-------------------------------------------------------------------|
 | location_area   | The location area the referenced Pokémon can be encountered in                  | [NamedAPIResource](#apiresource) ([LocationArea](#location-areas)) |
-| version_details | A list of versions and encounters with the referenced Pokémon that might happen | list [VersionEncounterDetail](#versionencounterdetail) |
+| version_details | A list of versions and encounters with the referenced Pokémon that might happen | list [VersionEncounterDetail](#versionencounterdetail)             |
 
 ## Pokémon Colors
 Colors used for sorting Pokémon in a Pokédex. The color listed in the Pokédex is usually the color most apparent or covering each Pokémon's body. No orange category exists; Pokémon that are primarily orange are listed as red or brown.
@@ -2470,11 +2470,11 @@ Colors used for sorting Pokémon in a Pokédex. The color listed in the Pokédex
 
 #### PokemonColor
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id              | The identifier for this Pokémon color resource               | integer |
-| name            | The name for this Pokémon color resource                     | string  |
-| names           | The name of this Pokémon color listed in different languages | list [Name](#resourcename) |
+| Name            | Description                                                  | Data Type                                                                       |
+|:----------------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this Pokémon color resource               | integer                                                                         |
+| name            | The name for this Pokémon color resource                     | string                                                                          |
+| names           | The name of this Pokémon color listed in different languages | list [Name](#resourcename)                                                      |
 | pokemon_species | A list of the Pokémon species that have this color           | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Pokémon Forms
@@ -2515,28 +2515,28 @@ Some Pokémon have the ability to take on different forms. At times, these diffe
 
 #### PokemonForm
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id             | The identifier for this Pokémon form resource                                                                                                            | integer |
-| name           | The name for this Pokémon form resource                                                                                                                  | string  |
-| order          | The order in which forms should be sorted within all forms. Multiple forms may have equal order, in which case they should fall back on sorting by name. | integer |
-| form_order     | The order in which forms should be sorted within a species' forms                                                                                        | integer |
-| is_default     | True for exactly one form used as the default for each Pokémon                                                                                           | boolean |
-| is_battle_only | Whether or not this form can only happen during battle                                                                                                   | boolean |
-| is_mega        | Whether or not this form requires mega evolution                                                                                                         | boolean |
-| form_name      | The name of this form                                                                                                                                    | string  |
-| pokemon        | The Pokémon that can take on this form                                                                                                                   | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
-| sprites        | A set of sprites used to depict this Pokémon form in the game                                         													                          | [PokemonFormSprites](#pokemonformsprites) |
+| Name           | Description                                                                                                                                              | Data Type                                                               |
+|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------|
+| id             | The identifier for this Pokémon form resource                                                                                                            | integer                                                                 |
+| name           | The name for this Pokémon form resource                                                                                                                  | string                                                                  |
+| order          | The order in which forms should be sorted within all forms. Multiple forms may have equal order, in which case they should fall back on sorting by name. | integer                                                                 |
+| form_order     | The order in which forms should be sorted within a species' forms                                                                                        | integer                                                                 |
+| is_default     | True for exactly one form used as the default for each Pokémon                                                                                           | boolean                                                                 |
+| is_battle_only | Whether or not this form can only happen during battle                                                                                                   | boolean                                                                 |
+| is_mega        | Whether or not this form requires mega evolution                                                                                                         | boolean                                                                 |
+| form_name      | The name of this form                                                                                                                                    | string                                                                  |
+| pokemon        | The Pokémon that can take on this form                                                                                                                   | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon))             |
+| sprites        | A set of sprites used to depict this Pokémon form in the game                                                                                            | [PokemonFormSprites](#pokemonformsprites)                               |
 | version_group  | The version group this Pokémon form was introduced in                                                                                                    | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 #### PokemonFormSprites
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| front_default | The default depiction of this Pokémon form from the front in battle | string |
-| front_shiny   | The shiny depiction of this Pokémon form from the front in battle   | string |
-| back_default  | The default depiction of this Pokémon form from the back in battle  | string |
-| back_shiny    | The shiny depiction of this Pokémon form from the back in battle    | string |
+| Name          | Description                                                         | Data Type |
+|:--------------|:--------------------------------------------------------------------|:----------|
+| front_default | The default depiction of this Pokémon form from the front in battle | string    |
+| front_shiny   | The shiny depiction of this Pokémon form from the front in battle   | string    |
+| back_default  | The default depiction of this Pokémon form from the back in battle  | string    |
+| back_shiny    | The shiny depiction of this Pokémon form from the back in battle    | string    |
 
 ## Pokémon Habitats
 Habitats are generally different terrain Pokémon can be found in but can also be areas designated for rare or legendary Pokémon.
@@ -2571,11 +2571,11 @@ Habitats are generally different terrain Pokémon can be found in but can also b
 
 #### PokemonHabitat
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id              | The identifier for this Pokémon habitat resource                | integer |
-| name            | The name for this Pokémon habitat resource                      | string  |
-| names           | The name of this Pokémon habitat listed in different languages  | list [Name](#resourcename) |
+| Name            | Description                                                     | Data Type                                                                       |
+|:----------------|:----------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this Pokémon habitat resource                | integer                                                                         |
+| name            | The name for this Pokémon habitat resource                      | string                                                                          |
+| names           | The name of this Pokémon habitat listed in different languages  | list [Name](#resourcename)                                                      |
 | pokemon_species | A list of the Pokémon species that can be found in this habitat | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Pokémon Shapes
@@ -2620,19 +2620,19 @@ Shapes used for sorting Pokémon in a Pokédex.
 
 #### PokemonShape
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id              | The identifier for this Pokémon shape resource                            | integer |
-| name            | The name for this Pokémon shape resource                                  | string  |
-| awesome_names   | The "scientific" name of this Pokémon shape listed in different languages | list [AwesomeName](#awesomename) |
-| names           | The name of this Pokémon shape listed in different languages              | list [Name](#resourcename) |
+| Name            | Description                                                               | Data Type                                                                       |
+|:----------------|:--------------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id              | The identifier for this Pokémon shape resource                            | integer                                                                         |
+| name            | The name for this Pokémon shape resource                                  | string                                                                          |
+| awesome_names   | The "scientific" name of this Pokémon shape listed in different languages | list [AwesomeName](#awesomename)                                                |
+| names           | The name of this Pokémon shape listed in different languages              | list [Name](#resourcename)                                                      |
 | pokemon_species | A list of the Pokémon species that have this shape                        | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 #### AwesomeName
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| awesome_name | The localized "scientific" name for an API resource in a specific language | string |
+| Name         | Description                                                                | Data Type                                                      |
+|:-------------|:---------------------------------------------------------------------------|:---------------------------------------------------------------|
+| awesome_name | The localized "scientific" name for an API resource in a specific language | string                                                         |
 | language     | The language this "scientific" name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 ## Pokémon Species
@@ -2736,61 +2736,61 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 
 #### PokemonSpecies
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id                     | The identifier for this Pokémon species resource                                                                                                   | integer |
-| name                   | The name for this Pokémon species resource                                                                                                         | string  |
-| order                  | The order in which species should be sorted.  Based on National Dex order, except families are grouped together and sorted by stage.               | integer |
-| gender_rate            | The chance of this Pokémon being female, in eighths; or -1 for genderless                                                                          | integer |
-| capture_rate           | The base capture rate; up to 255. The higher the number, the easier the catch.                                                                     | integer |
-| base_happiness         | The happiness when caught by a normal Pokéball; up to 255. The higher the number, the happier the Pokémon.                                         | integer |
-| is_baby                | Whether or not this is a baby Pokémon                                                                                                              | boolean |
-| hatch_counter          | Initial hatch counter: one must walk 255 × (hatch_counter + 1) steps before this Pokémon's egg hatches, unless utilizing bonuses like Flame Body's | integer |
-| has_gender_differences | Whether or not this Pokémon can have different genders                                                                                             | boolean |
-| forms_switchable       | Whether or not this Pokémon has multiple forms and can switch between them                                                                         | boolean |
-| growth_rate            | The rate at which this Pokémon species gains levels                                                                                                | [NamedAPIResource](#namedapiresource) ([GrowthRate](#growth-rates)) |
-| pokedex_numbers        | A list of Pokedexes and the indexes reserved within them for this Pokémon species                                                                  | list [PokemonSpeciesDexEntry](#pokemonspeciesdexentry) |
-| egg_groups             | A list of egg groups this Pokémon species is a member of                                                                                           | list [NamedAPIResource](#namedapiresource) ([EggGroup](#egg-groups)) |
-| color                  | The color of this Pokémon for gimmicky Pokédex search                                                                                              | [NamedAPIResource](#namedapiresource) ([PokemonColor](#pokemon-colors)) |
-| shape                  | The shape of this Pokémon for gimmicky Pokédex search                                                                                              | [NamedAPIResource](#namedapiresource) ([PokemonShape](#pokemon-shapes)) |
-| evolves_from_species   | The Pokémon species that evolves into this Pokemon_species                                                                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| evolution_chain        | The evolution chain this Pokémon species is a member of                                                                                            | [APIResource](#apiresource) ([EvolutionChain](#evolution-chains)) |
+| Name                   | Description                                                                                                                                        | Data Type                                                                   |
+|:-----------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|
+| id                     | The identifier for this Pokémon species resource                                                                                                   | integer                                                                     |
+| name                   | The name for this Pokémon species resource                                                                                                         | string                                                                      |
+| order                  | The order in which species should be sorted.  Based on National Dex order, except families are grouped together and sorted by stage.               | integer                                                                     |
+| gender_rate            | The chance of this Pokémon being female, in eighths; or -1 for genderless                                                                          | integer                                                                     |
+| capture_rate           | The base capture rate; up to 255. The higher the number, the easier the catch.                                                                     | integer                                                                     |
+| base_happiness         | The happiness when caught by a normal Pokéball; up to 255. The higher the number, the happier the Pokémon.                                         | integer                                                                     |
+| is_baby                | Whether or not this is a baby Pokémon                                                                                                              | boolean                                                                     |
+| hatch_counter          | Initial hatch counter: one must walk 255 × (hatch_counter + 1) steps before this Pokémon's egg hatches, unless utilizing bonuses like Flame Body's | integer                                                                     |
+| has_gender_differences | Whether or not this Pokémon can have different genders                                                                                             | boolean                                                                     |
+| forms_switchable       | Whether or not this Pokémon has multiple forms and can switch between them                                                                         | boolean                                                                     |
+| growth_rate            | The rate at which this Pokémon species gains levels                                                                                                | [NamedAPIResource](#namedapiresource) ([GrowthRate](#growth-rates))         |
+| pokedex_numbers        | A list of Pokedexes and the indexes reserved within them for this Pokémon species                                                                  | list [PokemonSpeciesDexEntry](#pokemonspeciesdexentry)                      |
+| egg_groups             | A list of egg groups this Pokémon species is a member of                                                                                           | list [NamedAPIResource](#namedapiresource) ([EggGroup](#egg-groups))        |
+| color                  | The color of this Pokémon for gimmicky Pokédex search                                                                                              | [NamedAPIResource](#namedapiresource) ([PokemonColor](#pokemon-colors))     |
+| shape                  | The shape of this Pokémon for gimmicky Pokédex search                                                                                              | [NamedAPIResource](#namedapiresource) ([PokemonShape](#pokemon-shapes))     |
+| evolves_from_species   | The Pokémon species that evolves into this Pokemon_species                                                                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species))  |
+| evolution_chain        | The evolution chain this Pokémon species is a member of                                                                                            | [APIResource](#apiresource) ([EvolutionChain](#evolution-chains))           |
 | habitat                | The habitat this Pokémon species can be encountered in                                                                                             | [NamedAPIResource](#namedapiresource) ([PokemonHabitat](#pokemon-habitats)) |
-| generation             | The generation this Pokémon species was introduced in                                                                                              | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
-| names                  | The name of this Pokémon species listed in different languages                                                                                     | list [Name](#resourcename) |
-| pal_park_encounters    | A list of encounters that can be had with this Pokémon species in pal park                                                                         | list [PalParkEncounterArea](#palparkencounterarea) |
-| form_descriptions      | Descriptions of different forms Pokémon take on within the Pokémon species		                                                                      | list [Description](#description) |
-| genera                 | The genus of this Pokémon species listed in multiple languages                                                                                     | list [Genus](#genus) |
-| varieties              | A list of the Pokémon that exist within this Pokémon species                                                                                       | list [PokemonSpeciesVariety] |
+| generation             | The generation this Pokémon species was introduced in                                                                                              | [NamedAPIResource](#namedapiresource) ([Generation](#generations))          |
+| names                  | The name of this Pokémon species listed in different languages                                                                                     | list [Name](#resourcename)                                                  |
+| pal_park_encounters    | A list of encounters that can be had with this Pokémon species in pal park                                                                         | list [PalParkEncounterArea](#palparkencounterarea)                          |
+| form_descriptions      | Descriptions of different forms Pokémon take on within the Pokémon species                                                                         | list [Description](#description)                                            |
+| genera                 | The genus of this Pokémon species listed in multiple languages                                                                                     | list [Genus](#genus)                                                        |
+| varieties              | A list of the Pokémon that exist within this Pokémon species                                                                                       | list [PokemonSpeciesVariety]                                                |
 
 #### Genus
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| genus    | The localized genus for the referenced Pokémon species | string |
+| Name     | Description                                            | Data Type                                                      |
+|:---------|:-------------------------------------------------------|:---------------------------------------------------------------|
+| genus    | The localized genus for the referenced Pokémon species | string                                                         |
 | language | The language this genus is in                          | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 #### PokemonSpeciesDexEntry
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| entry_number | The index number within the Pokédex                        | integer |
+| Name         | Description                                                | Data Type                                                     |
+|:-------------|:-----------------------------------------------------------|:--------------------------------------------------------------|
+| entry_number | The index number within the Pokédex                        | integer                                                       |
 | pokedex      | The Pokédex the referenced Pokémon species can be found in | [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
 
 #### PalParkEncounterArea
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| base_score | The base score given to the player when the referenced Pokémon is caught during a pal park run | integer |
-| rate       | The base rate for encountering the referenced Pokémon in this pal park area                    | integer |
+| Name       | Description                                                                                    | Data Type                                                              |
+|:-----------|:-----------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|
+| base_score | The base score given to the player when the referenced Pokémon is caught during a pal park run | integer                                                                |
+| rate       | The base rate for encountering the referenced Pokémon in this pal park area                    | integer                                                                |
 | area       | The pal park area where this encounter happens                                                 | [NamedAPIResource](#namedapiresource) ([PalParkArea](#pal-park-areas)) |
 
 #### PokemonSpeciesDexEntry
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| is_default | Whether this variety is the default variety | boolean |
-| pokemon    | The Pokémon variety | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
+| Name       | Description                                 | Data Type                                                   |
+|:-----------|:--------------------------------------------|:------------------------------------------------------------|
+| is_default | Whether this variety is the default variety | boolean                                                     |
+| pokemon    | The Pokémon variety                         | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
 
 ## Stats
 Stats determine certain aspects of battles. Each Pokémon has a value for each stat which grows as they gain levels and can be altered momentarily by effects in battles.
@@ -2852,36 +2852,36 @@ Stats determine certain aspects of battles. Each Pokémon has a value for each s
 
 #### Stat
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id                | The identifier for this stat resource                                                       | integer |
-| name              | The name for this stat resource                                                             | string  |
-| game_index        | ID the games use for this stat                                                              | integer |
-| is_battle_only    | Whether this stat only exists within a battle                                               | boolean |
-| affecting_moves   | A detail of moves which affect this stat positively or negatively                           | [MoveStatAffectSets](#movestataffectsets) |
-| affecting_natures | A detail of natures which affect this stat positively or negatively                         | [NatureStatAffectSets](#naturestataffectsets) |
-| characteristics   | A list of characteristics that are set on a Pokémon when its highest base stat is this stat | list [APIResource](#apiresource) ([Characteristic](#characteristics)) |
+| Name              | Description                                                                                 | Data Type                                                                       |
+|:------------------|:--------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id                | The identifier for this stat resource                                                       | integer                                                                         |
+| name              | The name for this stat resource                                                             | string                                                                          |
+| game_index        | ID the games use for this stat                                                              | integer                                                                         |
+| is_battle_only    | Whether this stat only exists within a battle                                               | boolean                                                                         |
+| affecting_moves   | A detail of moves which affect this stat positively or negatively                           | [MoveStatAffectSets](#movestataffectsets)                                       |
+| affecting_natures | A detail of natures which affect this stat positively or negatively                         | [NatureStatAffectSets](#naturestataffectsets)                                   |
+| characteristics   | A list of characteristics that are set on a Pokémon when its highest base stat is this stat | list [APIResource](#apiresource) ([Characteristic](#characteristics))           |
 | move_damage_class | The class of damage this stat is directly related to                                        | [NamedAPIResource](#namedapiresource) ([MoveDamageClass](#move-damage-classes)) |
-| names             | The name of this region listed in different languages                                       | list [Name](#resourcename) |
+| names             | The name of this region listed in different languages                                       | list [Name](#resourcename)                                                      |
 
 #### MoveStatAffectSets
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name     | Description                                             | Data Type                              |
+|:---------|:--------------------------------------------------------|:---------------------------------------|
 | increase | A list of moves and how they change the referenced stat | list [MoveStatAffect](#movestataffect) |
 | decrease | A list of moves and how they change the referenced stat | list [MoveStatAffect](#movestataffect) |
 
 #### MoveStatAffect
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| change     | The maximum amount of change to the referenced stat | integer |
-| move       | The move causing the change                         | [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
+| Name   | Description                                         | Data Type                                              |
+|:-------|:----------------------------------------------------|:-------------------------------------------------------|
+| change | The maximum amount of change to the referenced stat | integer                                                |
+| move   | The move causing the change                         | [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 
 #### NatureStatAffectSets
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name     | Description                                               | Data Type                                                       |
+|:---------|:----------------------------------------------------------|:----------------------------------------------------------------|
 | increase | A list of natures and how they change the referenced stat | list [NamedAPIResource](#namedapiresource) ([Nature](#natures)) |
 | decrease | A list of nature sand how they change the referenced stat | list [NamedAPIResource](#namedapiresource) ([Nature](#natures)) |
 
@@ -2962,29 +2962,29 @@ Types are properties for Pokémon and their moves. Each type has three propertie
 
 #### Type
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id                | The identifier for this type resource                               | integer |
-| name              | The name for this type resource                                     | string  |
-| damage_relations  | A detail of how effective this type is toward others and vice versa | [TypeRelations](#typerelations) |
-| game_indices      | A list of game indices relevent to this item by generation          | list [GenerationGameIndex](#generationgameindex) |
-| generation        | The generation this type was introduced in                          | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
+| Name              | Description                                                         | Data Type                                                                       |
+|:------------------|:--------------------------------------------------------------------|:--------------------------------------------------------------------------------|
+| id                | The identifier for this type resource                               | integer                                                                         |
+| name              | The name for this type resource                                     | string                                                                          |
+| damage_relations  | A detail of how effective this type is toward others and vice versa | [TypeRelations](#typerelations)                                                 |
+| game_indices      | A list of game indices relevent to this item by generation          | list [GenerationGameIndex](#generationgameindex)                                |
+| generation        | The generation this type was introduced in                          | [NamedAPIResource](#namedapiresource) ([Generation](#generations))              |
 | move_damage_class | The class of damage inflicted by this type                          | [NamedAPIResource](#namedapiresource) ([MoveDamageClass](#move-damage-classes)) |
-| names             | The name of this type listed in different languages                 | list [Name](#resourcename) |
-| pokemon           | A list of details of Pokémon that have this type                    | [TypePokemon](#typepokemon) |
-| moves             | A list of moves that have this type                                 | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
+| names             | The name of this type listed in different languages                 | list [Name](#resourcename)                                                      |
+| pokemon           | A list of details of Pokémon that have this type                    | [TypePokemon](#typepokemon)                                                     |
+| moves             | A list of moves that have this type                                 | list [NamedAPIResource](#namedapiresource) ([Move](#moves))                     |
 
 #### TypePokemon
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| slot    | The order the Pokémon's types are listed in | integer |
+| Name    | Description                                 | Data Type                                                   |
+|:--------|:--------------------------------------------|:------------------------------------------------------------|
+| slot    | The order the Pokémon's types are listed in | integer                                                     |
 | pokemon | The Pokémon that has the referenced type    | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
 
 #### TypeRelations
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name               | Description                                                   | Data Type                                                   |
+|:-------------------|:--------------------------------------------------------------|:------------------------------------------------------------|
 | no_damage_to       | A list of types this type has no effect on                    | list [NamedAPIResource](#namedapiresource) ([Type](#types)) |
 | half_damage_to     | A list of types this type is not very effect against          | list [NamedAPIResource](#namedapiresource) ([Type](#types)) |
 | double_damage_to   | A list of types this type is very effect against              | list [NamedAPIResource](#namedapiresource) ([Type](#types)) |
@@ -3022,102 +3022,102 @@ Languages for translations of API resource information.
 
 #### Language
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| id       | The identifier for this language resource                                                     | integer |
-| name     | The name for this language resource                                                           | string  |
-| official | Whether or not the games are published in this language                                       | boolean |
-| iso639   | The two-letter code of the country where this language is spoken. Note that it is not unique. | string  |
-| iso3166  | The two-letter code of the language. Note that it is not unique.                              | string  |
+| Name     | Description                                                                                   | Data Type                  |
+|:---------|:----------------------------------------------------------------------------------------------|:---------------------------|
+| id       | The identifier for this language resource                                                     | integer                    |
+| name     | The name for this language resource                                                           | string                     |
+| official | Whether or not the games are published in this language                                       | boolean                    |
+| iso639   | The two-letter code of the country where this language is spoken. Note that it is not unique. | string                     |
+| iso3166  | The two-letter code of the language. Note that it is not unique.                              | string                     |
 | names    | The name of this language listed in different languages                                       | list [Name](#resourcename) |
 
 ## Common Models
 
 #### APIResource
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| url  | The URL of the referenced resource  | string |
+| Name | Description                        | Data Type |
+|:-----|:-----------------------------------|:----------|
+| url  | The URL of the referenced resource | string    |
 
 #### Description
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| description | The localized description for an API resource in a specific language | string |
+| Name        | Description                                                          | Data Type                                                      |
+|:------------|:---------------------------------------------------------------------|:---------------------------------------------------------------|
+| description | The localized description for an API resource in a specific language | string                                                         |
 | language    | The language this name is in                                         | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 #### Effect
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| effect   | The localized effect text for an API resource in a specific language | string |
+| Name     | Description                                                          | Data Type                                                     |
+|:---------|:---------------------------------------------------------------------|:--------------------------------------------------------------|
+| effect   | The localized effect text for an API resource in a specific language | string                                                        |
 | language | The language this effect is in                                       | [NamedAPIResource](#namedapiresource) ([Language](#language)) |
 
 #### Encounter
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| min_level        | The lowest level the Pokémon could be encountered at                          | integer |
-| max_level        | The highest level the Pokémon could be encountered at                         | integer |
+| Name             | Description                                                                   | Data Type                                                                                           |
+|:-----------------|:------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| min_level        | The lowest level the Pokémon could be encountered at                          | integer                                                                                             |
+| max_level        | The highest level the Pokémon could be encountered at                         | integer                                                                                             |
 | condition_values | A list of condition values that must be in effect for this encounter to occur | list [NamedAPIResource](#namedapiresource) ([EncounterConditionValue](#encounter-condition-values)) |
-| chance           | percent chance that this encounter will occur                                 | integer |
-| method           | The method by which this encounter happens                                    | [NamedAPIResource](#namedapiresource) ([EncounterMethod](#encounter-methods)) |
+| chance           | percent chance that this encounter will occur                                 | integer                                                                                             |
+| method           | The method by which this encounter happens                                    | [NamedAPIResource](#namedapiresource) ([EncounterMethod](#encounter-methods))                       |
 
 #### FlavorText
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| flavor_text | The localized flavor text for an API resource in a specific language | string |
-| language    | The language this name is in                                    		 | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
+| Name        | Description                                                          | Data Type                                                      |
+|:------------|:---------------------------------------------------------------------|:---------------------------------------------------------------|
+| flavor_text | The localized flavor text for an API resource in a specific language | string                                                         |
+| language    | The language this name is in                                         | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 #### GenerationGameIndex
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| game_index | The internal id of an API resource within game data | integer |
+| Name       | Description                                         | Data Type                                                          |
+|:-----------|:----------------------------------------------------|:-------------------------------------------------------------------|
+| game_index | The internal id of an API resource within game data | integer                                                            |
 | generation | The generation relevent to this game index          | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
 
 #### <a id="resourcename"></a>Name
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| name     | The localized name for an API resource in a specific language | string |
+| Name     | Description                                                   | Data Type                                                      |
+|:---------|:--------------------------------------------------------------|:---------------------------------------------------------------|
+| name     | The localized name for an API resource in a specific language | string                                                         |
 | language | The language this name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 #### NamedAPIResource
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| name | The name of the referenced resource | string |
-| url  | The URL of the referenced resource  | string |
+| Name | Description                         | Data Type |
+|:-----|:------------------------------------|:----------|
+| name | The name of the referenced resource | string    |
+| url  | The URL of the referenced resource  | string    |
 
 #### VerboseEffect
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| effect       | The localized effect text for an API resource in a specific language | string |
-| short_effect | The localized effect text in brief                                   | string |
+| Name         | Description                                                          | Data Type                                                      |
+|:-------------|:---------------------------------------------------------------------|:---------------------------------------------------------------|
+| effect       | The localized effect text for an API resource in a specific language | string                                                         |
+| short_effect | The localized effect text in brief                                   | string                                                         |
 | language     | The language this effect is in                                       | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 #### VersionEncounterDetail
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
+| Name              | Description                                     | Data Type                                                    |
+|:------------------|:------------------------------------------------|:-------------------------------------------------------------|
 | version           | The game version this encounter happens in      | [NamedAPIResource](#namedapiresource) ([Version](#versions)) |
-| max_chance        | The total percentage of all encounter potential | integer |
-| encounter_details | A list of encounters and their specifics        | list [Encounter](#encounters) |
+| max_chance        | The total percentage of all encounter potential | integer                                                      |
+| encounter_details | A list of encounters and their specifics        | list [Encounter](#encounters)                                |
 
 #### VersionGameIndex
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| game_index | The internal id of an API resource within game data | integer |
+| Name       | Description                                         | Data Type                                                    |
+|:-----------|:----------------------------------------------------|:-------------------------------------------------------------|
+| game_index | The internal id of an API resource within game data | integer                                                      |
 | version    | The version relevent to this game index             | [NamedAPIResource](#namedapiresource) ([Version](#versions)) |
 
 #### VersionGroupFlavorText
 
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| text          | The localized name for an API resource in a specific language | string |
-| language      | The language this name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
+| Name          | Description                                                   | Data Type                                                               |
+|:--------------|:--------------------------------------------------------------|:------------------------------------------------------------------------|
+| text          | The localized name for an API resource in a specific language | string                                                                  |
+| language      | The language this name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages))          |
 | version_group | The version group which uses this flavor text                 | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |

--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -2362,7 +2362,7 @@ Pokémon are the creatures that inhabit the world of the Pokémon games. They ca
 | forms                    | A list of forms this Pokémon can take on                                                         | list [NamedAPIResource](#namedapiresource) ([PokemonForm](#pokemon-forms)) |
 | game_indices             | A list of game indices relevent to Pokémon item by generation                                    | list [VersionGameIndex](#versiongameindex) |
 | held_items               | A list of items this Pokémon may be holding when encountered                                     | list [PokemonHeldItem](#pokemonhelditem) |
-| location_area_encounters | A link to a list of location areas as well as encounter details pertaining to specific versions  | string (URL to [LocationAreaEncounter](#locationareaencounter)) |
+| location_area_encounters | A link to a list of location areas as well as encounter details pertaining to specific versions  | string (URL to list [LocationAreaEncounter](#locationareaencounter)) |
 | moves                    | A list of moves along with learn methods and level details pertaining to specific version groups | list [PokemonMove](#pokemonmove) |
 | sprites                  | A set of sprites used to depict this Pokémon in the game                                         | [PokemonSprites](#pokemonsprites) |
 | species                  | The species this Pokémon belongs to                                                              | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |

--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -92,10 +92,10 @@ Calling any API endpoint without a resource ID or name will return a paginated l
 
 | Name     | Description | Data Type |
 | -------- | ----------- | --------- |
-| count    | The total number of resources abailable from this API | integer |
-| next     | The url for the next 'page' in the list               | string  |
-| previous | The url for the previous page in the list             | boolean |
-| results  | I list of unnamed API resources                       | list [APIResource](#apiresource) |
+| count    | The total number of resources available from this API | integer |
+| next     | The URL for the next page in the list               | string  |
+| previous | The URL for the previous page in the list             | boolean |
+| results  | A list of unnamed API resources                       | list [APIResource](#apiresource) |
 
 ###### Example response for named resources
 
@@ -115,10 +115,10 @@ Calling any API endpoint without a resource ID or name will return a paginated l
 
 | Name     | Description | Data Type |
 | -------- | ----------- | --------- |
-| count    | The total number of resources abailable from this API | integer |
-| next     | The url for the next 'page' in the list               | string  |
-| previous | The url for the previous page in the list             | boolean |
-| results  | I list of named API resources                    	   | list [NamedAPIResource](#namedapiresource) |
+| count    | The total number of resources available from this API | integer |
+| next     | The URL for the next page in the list               | string  |
+| previous | The URL for the previous page in the list             | boolean |
+| results  | A list of named API resources                    	   | list [NamedAPIResource](#namedapiresource) |
 
 <h1 id="berries-section">Berries</h1>
 
@@ -170,7 +170,7 @@ Berries are small fruits that can provide HP and status condition restoration, s
 | ------------------ | ----------- | --------- |
 | id                 | The identifier for this berry resource                                                                                             | integer |
 | name               | The name for this berry resource                                                                                                   | string  |
-| growth_time        | Time it takes the tree to grow one stage, in hours.  Berry trees go through four of these growth stages before they can be picked. | integer |
+| growth_time        | Time it takes the tree to grow one stage, in hours. Berry trees go through four of these growth stages before they can be picked.  | integer |
 | max_harvest        | The maximum number of these berries that can grow on one tree in Generation IV                                                     | integer |
 | natural_gift_power | The power of the move "Natural Gift" when used with this Berry                                                                     | integer |
 | size               | The size of this Berry, in millimeters                                                                                             | integer |
@@ -314,7 +314,15 @@ Contest types are categories judges used to weigh a Pokémon's condition in Pok�
 | id           | The identifier for this contest type resource               | integer |
 | name         | The name for this contest type resource                     | string  |
 | berry_flavor | The berry flavor that correlates with this contest type     | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
-| names        | The name of this contest type listed in different languages | list [Name](#resourcename) |
+| names        | The name of this contest type listed in different languages | list [ContestName](#contestname) |
+
+#### ContestName
+
+| Name         | Description | Data Type |
+| ------------ | ----------- | --------- |
+| name         | The name for this contest                                   | string  |
+| color        | The color associated with this contest's name               | string  |
+| language     | The language that this name is in                           | [NamedAPIResource](#namedapiresource) ([Language](#language)) |
 
 ## Contest Effects
 Contest effects refer to the effects of moves when used in contests.
@@ -353,7 +361,7 @@ Contest effects refer to the effects of moves when used in contests.
 | Name                | Description | Data Type |
 | ------------------- | ----------- | --------- |
 | id                  | The identifier for this contest type resource                        | integer |
-| appeal              | The base number of hearts the user of this move gets                 | string  |
+| appeal              | The base number of hearts the user of this move gets                 | integer |
 | jam                 | The base number of hearts the user's opponent loses                  | integer |
 | effect_entries      | The result of this contest effect listed in different languages      | list [Effect](#effect) |
 | flavor_text_entries | The flavor text of this contest effect listed in different languages | list [FlavorText](#flavortext) |
@@ -387,10 +395,10 @@ Super contest effects refer to the effects of moves when used in super contests.
 
 #### SuperContestEffect
 
-| Name                | Description | Data Type | 
+| Name                | Description | Data Type |
 | ------------------- | ----------- | --------- |
 | id                  | The identifier for this super contest effect resource                      | integer |
-| appeal              | The level of appeal this super contest effect has                          | string  |
+| appeal              | The level of appeal this super contest effect has                          | integer |
 | flavor_text_entries | The flavor text of this super contest effect listed in different languages | list [FlavorText](#flavortext) |
 | moves               | A list of moves that have the effect when used in super contests           | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 
@@ -578,7 +586,7 @@ Evolution chains are essentially family trees. They start with the lowest stage 
 | ----------------- | ----------- | --------- |
 | is_baby           | Whether or not this link is for a baby Pokémon. This would only ever be true on the base link. | boolean |
 | species           | The Pokémon species at this point in the evolution chain                                       | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| evolution_details | All details regarding the specific details of the referenced Pokémon species evolution         | [EvolutionDetail](#evolutiondetail) |
+| evolution_details | All details regarding the specific details of the referenced Pokémon species evolution         | list [EvolutionDetail](#evolutiondetail) |
 | evolves_to        | A List of chain objects.                                                                       | list [ChainLink](#chainlink) |
 
 #### EvolutionDetail
@@ -587,7 +595,7 @@ Evolution chains are essentially family trees. They start with the lowest stage 
 | ----------------------- | ----------- | --------- |
 | item                    | The item required to cause evolution this into Pokémon species                                                                                                              | [NamedAPIResource](#namedapiresource) ([Item](#items)) |
 | trigger                 | The type of event that triggers evolution into this Pokémon species                                                                                                         | [NamedAPIResource](#namedapiresource) ([EvolutionTrigger](#evolution-triggers)) |
-| gender                  | The gender the evolving Pokémon species must be in order to evolve into this Pokémon species                                                                                | [NamedAPIResource](#namedapiresource) ([Gender](#genders)) |
+| gender                  | The id of the gender of the evolving Pokémon species must be in order to evolve into this Pokémon species                                                                   | integer |
 | held_item               | The item the evolving Pokémon species must be holding during the evolution trigger event to evolve into this Pokémon species                                                | [NamedAPIResource](#namedapiresource) ([Item](#items)) |
 | known_move              | The move that must be known by the evolving Pokémon species during the evolution trigger event in order to evolve into this Pokémon species                                 | [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 | known_move_type         | The evolving Pokémon species must know a move with this type during the evolution trigger event in order to evolve into this Pokémon species                                | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
@@ -597,15 +605,15 @@ Evolution chains are essentially family trees. They start with the lowest stage 
 | min_beauty              | The minimum required level of beauty the evolving Pokémon species to evolve into this Pokémon species                                                                       | integer |
 | min_affection           | The minimum required level of affection the evolving Pokémon species to evolve into this Pokémon species                                                                    | integer |
 | needs_overworld_rain    | Whether or not it must be raining in the overworld to cause evolution this Pokémon species                                                                                  | boolean |
-| party_species           | The pokemon species that must be in the players party in order for the evolving Pokémon species to evolve into this Pokémon species                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| party_type              | The player must have a pokemon of this type in their party during the evolution trigger event in order for the evolving Pokémon species to evolve into this Pokémon species | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
+| party_species           | The Pokémon species that must be in the players party in order for the evolving Pokémon species to evolve into this Pokémon species                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
+| party_type              | The player must have a Pokémon of this type in their party during the evolution trigger event in order for the evolving Pokémon species to evolve into this Pokémon species | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
 | relative_physical_stats | The required relation between the Pokémon's Attack and Defense stats. 1 means Attack > Defense. 0 means Attack = Defense. -1 means Attack < Defense.                        | integer |
 | time_of_day             | The required time of day. Day or night.                                                                                                                                     | string  |
-| trade_species           | Pokémon species for which this one must be traded.                                                                                                                          | [NamedAPIResource](#namedapiresource) ([Pokemon Species](#pokemon-species)) |
+| trade_species           | Pokémon species for which this one must be traded.                                                                                                                          | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 | turn_upside_down        | Whether or not the 3DS needs to be turned upside-down as this Pokémon levels up.                                                                                            | boolean |
 
 ## Evolution Triggers
-Evolution triggers are the events and conditions that cause a pokemon to evolve. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Methods_of_evolution) for greater detail.
+Evolution triggers are the events and conditions that cause a Pokémon to evolve. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Methods_of_evolution) for greater detail.
 
 ### GET api/v2/evolution-trigger/{id or name}
 
@@ -757,19 +765,19 @@ A Pokédex is a handheld electronic encyclopedia device; one which is capable of
 | is_main_series  | Whether or not this Pokédex originated in the main series of the video games | boolean |
 | descriptions    | The description of this Pokédex listed in different languages                | list [Description](#description) |
 | names           | The name of this Pokédex listed in different languages                       | list [Name](#resourcename) |
-| pokemon_entries | A list of pokemon catalogued in this Pokédex and their indexes               | list [PokemonEntry](#pokemonentry) |
-| region          | The region this Pokédex catalogues pokemon for                               | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
-| version_groups  | A list of version groups this Pokédex is relevent to                         | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
+| pokemon_entries | A list of Pokémon catalogued in this Pokédex and their indexes               | list [PokemonEntry](#pokemonentry) |
+| region          | The region this Pokédex catalogues Pokémon for                               | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
+| version_groups  | A list of version groups this Pokédex is relevant to                         | list [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 #### PokemonEntry
 
 | Name            | Description | Data Type |
 | --------------- | ----------- | --------- |
-| entry_number    | The index of this pokemon species entry within the Pokédex | integer |
+| entry_number    | The index of this Pokémon species entry within the Pokédex | integer |
 | pokemon_species | The Pokémon species being encountered                      | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Versions
-Versions of the games, e.g., Red, Blue or Yellow. 
+Versions of the games, e.g., Red, Blue or Yellow.
 
 ### GET api/v2/version/{id or name}
 
@@ -806,7 +814,7 @@ Versions of the games, e.g., Red, Blue or Yellow.
 | version_group | The version group this version belongs to              | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 ## Version Groups
-Version groups categorize highly similar versions of the games. 
+Version groups categorize highly similar versions of the games.
 
 ### GET api/v2/version-group/{id or name}
 
@@ -849,9 +857,8 @@ Version groups categorize highly similar versions of the games.
 | id                 | The identifier for this version group resource                                              | integer |
 | name               | The name for this version group resource                                                    | string  |
 | order              | Order for sorting. Almost by date of release, except similar versions are grouped together. | integer |
-| generation         | The generation this version was introduced in                                               | list [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
+| generation         | The generation this version was introduced in                                               | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
 | move_learn_methods | A list of methods in which Pokémon can learn moves in this version group                    | list [NamedAPIResource](#namedapiresource) ([MoveLearnMethod](#move-learn-methods)) |
-| names              | The name of this version group listed in different languages                                | list [Name](#resourcename) |
 | pokedexes          | A list of Pokédexes introduces in this version group                                        | list [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
 | regions            | A list of regions that can be visited in this version group                                 | list [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
 | versions           | The versions this version group owns                                                        | list [NamedAPIResource](#namedapiresource) ([Version](#versions)) |
@@ -948,7 +955,7 @@ An item is an object in the games which the player can pick up, keep in their ba
 | name                | The name for this item resource                                      | string  |
 | cost                | The price of this item in stores                                     | integer |
 | fling_power         | The power of the move Fling when used with this item.                | integer |
-| fling_effect        | The effect of the move Fling when used with this item                | [ItemFlingEffect](#item-fling-effects) |
+| fling_effect        | The effect of the move Fling when used with this item                | [NamedAPIResource](#namedapiresource) ([ItemFlingEffect](#item-fling-effects)) |
 | attributes          | A list of attributes this item has                                   | list [NamedAPIResource](#namedapiresource) ([ItemAttribute](#item-attributes)) |
 | category            | The category of items this item falls into                           | [ItemCategory](#item-categories) |
 | effect_entries      | The effect of this ability listed in different languages             | list [VerboseEffect](#verboseeffect) |
@@ -956,14 +963,28 @@ An item is an object in the games which the player can pick up, keep in their ba
 | game_indices        | A list of game indices relevent to this item by generation           | list [GenerationGameIndex](#generationgameindex) |
 | names               | The name of this item listed in different languages                  | list [Name](#resourcename) |
 | sprites        	    | A set of sprites used to depict this item in the game                | [ItemSprites](#item-sprites) |
-| held_by_pokemon     | A list of Pokémon that might be found in the wild holding this item  | list [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
+| held_by_pokemon     | A list of Pokémon that might be found in the wild holding this item  | list [ItemHolderPokemon](#itemholderpokemon) |
 | baby_trigger_for    | An evolution chain this item requires to produce a bay during mating | [APIResource](#apiresource) ([EvolutionChain](#evolution-chains)) |
 
-#### Item Sprites
+#### ItemSprites
 
 | Name    | Description | Data Type |
 | ------- | ----------- | --------- |
 | default | The default depiction of this item | string |
+
+#### ItemHolderPokemon
+
+| Name    | Description | Data Type |
+| ------- | ----------- | --------- |
+| pokemon | The Pokémon that holds this item | string |
+| version_details | The details for the version that this item is held in by the Pokémon | list [ItemHolderPokemonVersionDetail](#ItemHolderPokemonVersionDetail) |
+
+#### ItemHolderPokemonVersionDetail
+
+| Name    | Description | Data Type |
+| ------- | ----------- | --------- |
+| rarity  | How often this Pokémon holds this item in this version | string |
+| version | The version that this item is held in by the Pokémon   | [NamedAPIResource](#namedapiresource) ([Version](#version)) |
 
 ## Item Attributes
 Item attributes define particular aspects of items, e.g. "usable in battle" or "consumable".
@@ -1046,7 +1067,7 @@ Item categories determine where items will be placed in the players bag.
 | ------ | ----------- | --------- |
 | id     | The identifier for this item category resource               | integer |
 | name   | The name for this item category resource                     | string  |
-| items  | A list of items that are a part of this category             | list [Item](#items) |
+| items  | A list of items that are a part of this category             | list [NamedAPIResource](#namedapiresource) ([Item](#items)) |
 | names  | The name of this item category listed in different languages | list [Name](#resourcename) |
 | pocket | The pocket items in this category would be put in            | [NamedAPIResource](#namedapiresource) ([ItemPocket](#item-pockets)) |
 
@@ -1081,7 +1102,7 @@ The various effects of the move "Fling" when used with different items.
 
 | Name           | Description | Data Type |
 | -------------- | ----------- | --------- |
-| id             | The identifier for this fling effect resource                 | integer | 
+| id             | The identifier for this fling effect resource                 | integer |
 | name           | The name for this fling effect resource                       | string  |
 | effect_entries | The result of this fling effect listed in different languages | list [Effect](#effect) |
 | items          | A list of items that have this fling effect                   | list [NamedAPIResource](#namedapiresource) ([Item](#items)) |
@@ -1119,7 +1140,7 @@ Pockets within the players bag used for storing items by category.
 | ---------- | ----------- | --------- |
 | id         | The identifier for this item pocket resource                    | integer |
 | name       | The name for this item pocket resource                          | string  |
-| categories | A list of item categories that are relevent to this item pocket | list [NamedAPIResource](#namedapiresource) ([ItemCategory](#item-categories)) |
+| categories | A list of item categories that are relevant to this item pocket | list [NamedAPIResource](#namedapiresource) ([ItemCategory](#item-categories)) |
 | names      | The name of this item pocket listed in different languages      | list [Name](#resourcename) |
 
 <h1 id="moves-section">Moves</h1>
@@ -1241,31 +1262,31 @@ Moves are the skills of Pokémon in battle. In battle, a Pokémon uses one move 
 | power          | The base power of this move with a value of 0 if it does not have a base power                                                                                            | integer |
 | contest_combos | A detail of normal and super contest combos that require this move                                                                                                        | [ContestComboSets](#contestcombosets) |
 | contest_type   | The type of appeal this move gives a Pokémon when used in a contest                                                                                                       | [NamedAPIResource](#namedapiresource) ([ContestType](#contest-types)) |
-| contest_effect | The effect the move has when used in a contest                                                                                                                            | [NamedAPIResource](#namedapiresource) ([ContestEffect](#contest-effects)) |
+| contest_effect | The effect the move has when used in a contest                                                                                                                            | [APIResource](#apiresource) ([ContestEffect](#contest-effects)) |
 | damage_class   | The type of damage the move inflicts on the target, e.g. physical                                                                                                         | [NamedAPIResource](#namedapiresource) ([MoveDamageClass](#move-damage-classes)) |
 | effect_entries | The effect of this move listed in different languages                                                                                                                     | list [VerboseEffect](#verboseeffect) |
 | effect_changes | The list of previous effects this move has had across version groups of the games                                                                                         | list [AbilityEffectChange](#abilityeffectchange) |
 | generation     | The generation in which this move was introduced                                                                                                                          | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
 | meta           | Metadata about this move                                                                                                                                                  | [MoveMetaData](#movemetadata) |
 | names          | The name of this move listed in different languages                                                                                                                       | list [Name](#resourcename) |
-| past_values    | A list of move resource value changes across ersion groups of the game                                                                                                    | list [PastMoveStatValues](#pastmovestatvalues) |
+| past_values    | A list of move resource value changes across version groups of the game                                                                                                    | list [PastMoveStatValues](#pastmovestatvalues) |
 | stat_changes   | A list of stats this moves effects and how much it effects them                                                                                                           | list [MoveStatChange](#movestatchange) |
 | super_contest_effect | The effect the move has when used in a super contest                                                                                                                      | [APIResource](#apiresource) ([SuperContestEffect](#super-contest-effects)) |
-| target         | The type of target that will recieve the effects of the attack                                                                                                            | [NamedAPIResource](#namedapiresource) ([MoveTarget](#move-targets)) |
+| target         | The type of target that will receive the effects of the attack                                                                                                            | [NamedAPIResource](#namedapiresource) ([MoveTarget](#move-targets)) |
 | type           | The elemental type of this move                                                                                                                                           | [NamedAPIResource](#namedapiresource) ([Type](#types)) |
 
 #### ContestComboSets
- 
+
 | Name   | Description | Data Type |
 | ------ | ----------- | --------- |
-| normal | A detail of moves this move can be used before or after, granting additional appeal points in contests       | list [ContestComboDetail](#contestcombodetail) |
-| super  | A detail of moves this move can be used before or after, granting additional appeal points in super contests | list [ContestComboDetail](#contestcombodetail) |
+| normal | A detail of moves this move can be used before or after, granting additional appeal points in contests       | [ContestComboDetail](#contestcombodetail) |
+| super  | A detail of moves this move can be used before or after, granting additional appeal points in super contests | [ContestComboDetail](#contestcombodetail) |
 
 #### ContestComboDetail
 
 | Name       | Description | Data Type |
 | ---------- | ----------- | --------- |
-| use_before | A list of moves to use before this move | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) | 
+| use_before | A list of moves to use before this move | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 | use_after  | A list of moves to use after this move  | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 
 #### MoveMetaData
@@ -1279,11 +1300,11 @@ Moves are the skills of Pokémon in battle. In battle, a Pokémon uses one move 
 | min_turns      | The minimum number of turns this move continues to take effect. Null if it always only lasts one turn. | integer |
 | max_turns      | The maximum number of turns this move continues to take effect. Null if it always only lasts one turn. | integer |
 | drain          | HP drain (if positive) or Recoil damage (if negative), in percent of damage done                       | integer |
-| healing        | The amount of hp gained by the attacking pokemon, in percent of it's maximum HP                        | integer |
+| healing        | The amount of hp gained by the attacking Pokemon, in percent of it's maximum HP                        | integer |
 | crit_rate      | Critical hit rate bonus                                                                                | integer |
-| ailment_chance | The likelyhood this attack will cause an ailment                                                       | integer |
-| flinch_chance  | The likelyhood this attack will cause the target pokemon to flinch                                     | integer |
-| stat_chance    | The likelyhood this attack will cause a stat change in the target pokemon                              | integer |
+| ailment_chance | The likelihood this attack will cause an ailment                                                       | integer |
+| flinch_chance  | The likelihood this attack will cause the target Pokémon to flinch                                     | integer |
+| stat_chance    | The likelihood this attack will cause a stat change in the target Pokémon                              | integer |
 
 #### MoveStatChange
 
@@ -1581,7 +1602,7 @@ Locations that can be visited within the games. Locations make up sizable portio
 | region       | The region this location can be found in                       | [NamedAPIResource](#namedapiresource) ([Region](#regions)) |
 | names        | The name of this language listed in different languages        | list [Name](#resourcename) |
 | game_indices | A list of game indices relevent to this location by generation | list [GenerationGameIndex](#generationgameindex) |
-| areas        | Areas that can be found within this location                   | [APIResource](#apiresource) ([LocationArea](#location-areas)) |
+| areas        | Areas that can be found within this location                   | list [NamedAPIResource](#namedapiresource) ([LocationArea](#location-areas)) |
 
 ## Location Areas
 Location areas are sections of areas, such as floors in a building or cave. Each area has its own set of possible Pokémon encounters.
@@ -1663,7 +1684,7 @@ Location areas are sections of areas, such as floors in a building or cave. Each
 
 | Name             | Description | Data Type |
 | ---------------- | ----------- | --------- |
-| encounter_method | The method in which Pokémon may be encountered in an area.     | [EncounterMethod](#encountermehtod) |
+| encounter_method | The method in which Pokémon may be encountered in an area.     | [NamedAPIResource](#namedapiresource) ([EncounterMethod](#encountermehtod)) |
 | version_details  | The chance of the encounter to occur on a version of the game. | list [EncounterVersionDetails](#encounterversiondetails) |
 
 #### EncounterVersionDetails
@@ -1672,7 +1693,7 @@ Location areas are sections of areas, such as floors in a building or cave. Each
 | ------- | ----------- | --------- |
 | rate    | The chance of an encounter to occur.                                            | integer |
 | version | The version of the game in which the encounter can occur with the given chance. | [NamedAPIResource](#namedapiresource) ([Version](#version)) |
- 
+
 #### PokemonEncounter
 
 | Name            | Description | Data Type |
@@ -1773,7 +1794,7 @@ A region is an organized area of the Pokémon world. Most often, the main differ
 | --------------- | ----------- | --------- |
 | id              | The identifier for this region resource                   | integer |
 | name            | The name for this region resource                         | string |
-| locations       | A list of locations that can be found in this region      | [NamedAPIResource](#namedapiresource) ([Location](#locations)) |
+| locations       | A list of locations that can be found in this region      | list [NamedAPIResource](#namedapiresource) ([Location](#locations)) |
 | main_generation | The generation this region was introduced in              | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
 | names           | The name of this region listed in different languages     | list [Name](#resourcename) |
 | pokedexes       | A list of pokédexes that catalogue Pokémon in this region | list [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
@@ -1783,7 +1804,7 @@ A region is an organized area of the Pokémon world. Most often, the main differ
 
 ## Abilities
 
-Abilities provide passive effects for Pokémon in battle or in the overworld. Pokémon have mutiple possible abilities but can have only one ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability) for greater detail.
+Abilities provide passive effects for Pokémon in battle or in the overworld. Pokémon have multiple possible abilities but can have only one ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability) for greater detail.
 
 ### GET api/v2/ability/{id or name}
 
@@ -1861,17 +1882,17 @@ Abilities provide passive effects for Pokémon in battle or in the overworld. Po
 | names               | The name of this ability listed in different languages                       | list [Name](#resourcename) |
 | effect_entries      | The effect of this ability listed in different languages                     | list [VerboseEffect](#verboseeffect) |
 | effect_changes      | The list of previous effects this ability has had across version groups      | list [AbilityEffectChange](#abilityeffectchange) |
-| flavor_text_entries | The flavor text of this ability listed in different languages                | list [VersionGroupFlavorText](#versiongroupflavortext) |
+| flavor_text_entries | The flavor text of this ability listed in different languages                | list [AbilityFlavorText](#abilityflavortext) |
 | pokemon             | A list of Pokémon that could potentially have this ability                   | list [AbilityPokemon](#abilitypokemon) |
 
 #### AbilityEffectChange
 
 | Name           | Description | Data Type |
 | -------------- | ----------- | --------- |
-| effect_entries | The previous effect of this ability listed in different languages         | [Effect](#effect) |
+| effect_entries | The previous effect of this ability listed in different languages         | list [Effect](#effect) |
 | version_group  | The version group in which the previous effect of this ability originated | [NamedAPIResource](#namedapiresource) ([VersionGroup](#versiongroups)) |
 
-#### AbilityFlavorText 
+#### AbilityFlavorText
 
 | Name          | Description | Data Type |
 | ------------- | ----------- | --------- |
@@ -1963,7 +1984,7 @@ Egg Groups are categories which determine which Pokémon are able to interbreed.
 | pokemon_species | A list of all Pokémon species that are members of this egg group | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Genders
-Genders were introduced in Generation II for the purposes of breeding Pokémon but can also result in visual differences or even different evolutionary lines. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Gender) for greater detail. 
+Genders were introduced in Generation II for the purposes of breeding Pokémon but can also result in visual differences or even different evolutionary lines. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Gender) for greater detail.
 
 ### GET api/v2/gender/{id or name}
 
@@ -2007,7 +2028,7 @@ Genders were introduced in Generation II for the purposes of breeding Pokémon b
 | pokemon_species | A Pokémon species that can be the referenced gender                       | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
 ## Growth Rates
-Growth rates are the speed with which Pokémon gain levels through experience. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Experience) for greater detail. 
+Growth rates are the speed with which Pokémon gain levels through experience. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Experience) for greater detail.
 
 ### GET api/v2/growth-rate/{id or name}
 
@@ -2116,7 +2137,7 @@ Natures influence how a Pokémon's stats grow. See [Bulbapedia](http://bulbapedi
 | ---- | ----------- | --------- |
 | id                            | The identifier for this nature resource                                                                               | integer |
 | name                          | The name for this nature resource                                                                                     | string  |
-| decreased_stat                | The stat decreased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats)) | 
+| decreased_stat                | The stat decreased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats)) |
 | increased_stat                | The stat increased by 10% in Pokémon with this nature                                                                 | [NamedAPIResource](#namedapiresource) ([Stat](#stats)) |
 | hates_flavor                  | The flavor hated by Pokémon with this nature                                                                          | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
 | likes_flavor                  | The flavor liked by Pokémon with this nature                                                                          | [NamedAPIResource](#namedapiresource) ([BerryFlavor](#berry-flavors)) |
@@ -2128,8 +2149,8 @@ Natures influence how a Pokémon's stats grow. See [Bulbapedia](http://bulbapedi
 
 | Name   | Description | Data Type |
 | ------ | ----------- | --------- |
-| change | The amount of change    | integer |
-| stat   | The stat being affected | [NamedAPIResource](#namedapiresource) ([PokeathlonStat](#pokeathlon-stats)) |
+| max_change | The amount of change    | integer |
+| pokeathlon_stat | The stat being affected | [NamedAPIResource](#namedapiresource) ([PokeathlonStat](#pokeathlon-stats)) |
 
 #### MoveBattleStylePreference
 
@@ -2340,12 +2361,12 @@ Pokémon are the creatures that inhabit the world of the Pokémon games. They ca
 | abilities                | A list of abilities this Pokémon could potentially have                                          | list [PokemonAbility](#pokemonability) |
 | forms                    | A list of forms this Pokémon can take on                                                         | list [NamedAPIResource](#namedapiresource) ([PokemonForm](#pokemon-forms)) |
 | game_indices             | A list of game indices relevent to Pokémon item by generation                                    | list [VersionGameIndex](#versiongameindex) |
-| held_items               | A list of items this Pokémon may be holding when encountered                                     | list [NamedAPIResource](#namedapiresource) ([Item](#items)) |
-| location_area_encounters | A list of location areas as well as encounter details pertaining to specific versions 		    	  | list [LocationAreaEncounter](#locationareaencounter) |
-| moves                    | A list of moves along with learn methods and level details pertaining to specific version groups | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
+| held_items               | A list of items this Pokémon may be holding when encountered                                     | list [PokemonHeldItem](#pokemonhelditem) |
+| location_area_encounters | A link to a list of location areas as well as encounter details pertaining to specific versions  | string (URL to [LocationAreaEncounter](#locationareaencounter)) |
+| moves                    | A list of moves along with learn methods and level details pertaining to specific version groups | list [PokemonMove](#pokemonmove) |
 | sprites                  | A set of sprites used to depict this Pokémon in the game                                         | [PokemonSprites](#pokemonsprites) |
 | species                  | The species this Pokémon belongs to                                                              | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
-| stats                    | A list of base stat values for this Pokémon                                                      | list [NamedAPIResource](#namedapiresource) ([Stat](#stats)) | 
+| stats                    | A list of base stat values for this Pokémon                                                      | list [PokemonStat](#pokemonstat) |
 | types                    | A list of details showing types this Pokémon has                                                 | list [PokemonType](#pokemontype) |
 
 #### PokemonAbility
@@ -2362,6 +2383,43 @@ Pokémon are the creatures that inhabit the world of the Pokémon games. They ca
 | ---- | ----------- | --------- |
 | slot | The order the Pokémon's types are listed in | integer |
 | type | The type the referenced Pokémon has         | string  |
+
+#### PokemonHeldItem
+
+| Name | Description | Data Type |
+| ---- | ----------- | --------- |
+| item | The item the referenced Pokémon holds | [NamedAPIResource](#namedapiresource) ([Item](#item)) |
+| version_details | The details of the different versions in which the item is held | list [PokemonHeldItemVersion](#pokemonhelditemversion)  |
+
+#### PokemonHeldItemVersion
+
+| Name | Description | Data Type |
+| ---- | ----------- | --------- |
+| version | The version in which the item is held | [NamedAPIResource](#namedapiresource) ([Version](#version)) |
+| rarity | How often the item is held | integer  |
+
+#### PokemonMove
+
+| Name | Description | Data Type |
+| ---- | ----------- | --------- |
+| move | The move the Pokémon can learn | [NamedAPIResource](#namedapiresource) ([Move](#move)) |
+| version_group_details | The details of the version in which the Pokémon can learn the move         | list [PokemonMoveVersion](#pokemonmoveversion)  |
+
+#### PokemonMoveVersion
+
+| Name | Description | Data Type |
+| ---- | ----------- | --------- |
+| move_learn_method | The method by which the move is learned | [NamedAPIResource](#namedapiresource) ([MoveLearnMethod](#move-learn-method)) |
+| version_group | The version group in which the move is learned        | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-group))  |
+| level_learned_at | The minimum level to learn the move       | string  |
+
+#### PokemonStat
+
+| Name | Description | Data Type |
+| ---- | ----------- | --------- |
+| stat | The stat the Pokémon has | [NamedAPIResource](#namedapiresource) ([Stat](#stat)) |
+| effort | The effort points the Pokémon has in the stat         | integer  |
+| base_stat | The base value of the stst   | integer  |
 
 #### PokemonSprites
 
@@ -2380,10 +2438,10 @@ Pokémon are the creatures that inhabit the world of the Pokémon games. They ca
 
 | Name | Description | Data Type |
 | ---- | ----------- | --------- |
-| location_area   | The location area the referenced Pokémon can be encountered in                  | [APIResource](#apiresource) ([LocationArea](#location-areas)) |
+| location_area   | The location area the referenced Pokémon can be encountered in                  | [NamedAPIResource](#apiresource) ([LocationArea](#location-areas)) |
 | version_details | A list of versions and encounters with the referenced Pokémon that might happen | list [VersionEncounterDetail](#versionencounterdetail) |
 
-## Pokemon Colors
+## Pokémon Colors
 Colors used for sorting Pokémon in a Pokédex. The color listed in the Pokédex is usually the color most apparent or covering each Pokémon's body. No orange category exists; Pokémon that are primarily orange are listed as red or brown.
 
 ### GET api/v2/pokemon-color/{id or name}
@@ -2419,7 +2477,7 @@ Colors used for sorting Pokémon in a Pokédex. The color listed in the Pokédex
 | names           | The name of this Pokémon color listed in different languages | list [Name](#resourcename) |
 | pokemon_species | A list of the Pokémon species that have this color           | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
-## Pokemon Forms
+## Pokémon Forms
 Some Pokémon have the ability to take on different forms. At times, these differences are purely cosmetic and have no bearing on the difference in the Pokémon's stats from another; however, several Pokémon differ in stats (other than HP), type, and Ability depending on their form.
 
 ### GET api/v2/pokemon-form/{id or name}
@@ -2480,7 +2538,7 @@ Some Pokémon have the ability to take on different forms. At times, these diffe
 | back_default  | The default depiction of this Pokémon form from the back in battle  | string |
 | back_shiny    | The shiny depiction of this Pokémon form from the back in battle    | string |
 
-## Pokemon Habitats
+## Pokémon Habitats
 Habitats are generally different terrain Pokémon can be found in but can also be areas designated for rare or legendary Pokémon.
 
 ### GET api/v2/pokemon-habitat/{id or name}
@@ -2520,8 +2578,8 @@ Habitats are generally different terrain Pokémon can be found in but can also b
 | names           | The name of this Pokémon habitat listed in different languages  | list [Name](#resourcename) |
 | pokemon_species | A list of the Pokémon species that can be found in this habitat | list [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 
-## Pokemon Shapes
-Shapes used for sorting Pokémon in a Pokédex. 
+## Pokémon Shapes
+Shapes used for sorting Pokémon in a Pokédex.
 
 ### GET api/v2/pokemon-shape/{id or name}
 
@@ -2577,7 +2635,7 @@ Shapes used for sorting Pokémon in a Pokédex.
 | awesome_name | The localized "scientific" name for an API resource in a specific language | string |
 | language     | The language this "scientific" name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
-## Pokemon Species
+## Pokémon Species
 A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Pokémon species are shared across all varieties of Pokémon within the species. A good example is Wormadam; Wormadam is the species which can be found in three different varieties, Wormadam-Trash, Wormadam-Sandy and Wormadam-Plant.  
 
 ### GET api/v2/pokemon-species/{id or name}
@@ -2678,9 +2736,9 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 
 #### PokemonSpecies
 
-| Name | Description | Data Type | 
+| Name | Description | Data Type |
 | ---- | ----------- | --------- |
-| id                     | The identifier for this Pokémon species resource                                                                                                   | integer | 
+| id                     | The identifier for this Pokémon species resource                                                                                                   | integer |
 | name                   | The name for this Pokémon species resource                                                                                                         | string  |
 | order                  | The order in which species should be sorted.  Based on National Dex order, except families are grouped together and sorted by stage.               | integer |
 | gender_rate            | The chance of this Pokémon being female, in eighths; or -1 for genderless                                                                          | integer |
@@ -2691,26 +2749,25 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 | has_gender_differences | Whether or not this Pokémon can have different genders                                                                                             | boolean |
 | forms_switchable       | Whether or not this Pokémon has multiple forms and can switch between them                                                                         | boolean |
 | growth_rate            | The rate at which this Pokémon species gains levels                                                                                                | [NamedAPIResource](#namedapiresource) ([GrowthRate](#growth-rates)) |
-| pokedex_numbers        | A list of pokedexes and the indexes reserved within them for this Pokémon species                                                                  | list [PokemonSpeciesDexEntry](#pokemonspeciesdexentry) |
+| pokedex_numbers        | A list of Pokedexes and the indexes reserved within them for this Pokémon species                                                                  | list [PokemonSpeciesDexEntry](#pokemonspeciesdexentry) |
 | egg_groups             | A list of egg groups this Pokémon species is a member of                                                                                           | list [NamedAPIResource](#namedapiresource) ([EggGroup](#egg-groups)) |
-| color                  | The color of this Pokémon for gimmicky Pokédex search                                                                                              | list [NamedAPIResource](#namedapiresource) ([PokemonColor](#pokemon-colors)) |
-| shape                  | The shape of this Pokémon for gimmicky Pokédex search                                                                                              | list [NamedAPIResource](#namedapiresource) ([PokemonShape](#pokemon-shapes)) |
-| evolves_from_species   | The Pokémon species that evolves into this pokemon_species                                                                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
+| color                  | The color of this Pokémon for gimmicky Pokédex search                                                                                              | [NamedAPIResource](#namedapiresource) ([PokemonColor](#pokemon-colors)) |
+| shape                  | The shape of this Pokémon for gimmicky Pokédex search                                                                                              | [NamedAPIResource](#namedapiresource) ([PokemonShape](#pokemon-shapes)) |
+| evolves_from_species   | The Pokémon species that evolves into this Pokemon_species                                                                                         | [NamedAPIResource](#namedapiresource) ([PokemonSpecies](#pokemon-species)) |
 | evolution_chain        | The evolution chain this Pokémon species is a member of                                                                                            | [APIResource](#apiresource) ([EvolutionChain](#evolution-chains)) |
 | habitat                | The habitat this Pokémon species can be encountered in                                                                                             | [NamedAPIResource](#namedapiresource) ([PokemonHabitat](#pokemon-habitats)) |
 | generation             | The generation this Pokémon species was introduced in                                                                                              | [NamedAPIResource](#namedapiresource) ([Generation](#generations)) |
 | names                  | The name of this Pokémon species listed in different languages                                                                                     | list [Name](#resourcename) |
 | pal_park_encounters    | A list of encounters that can be had with this Pokémon species in pal park                                                                         | list [PalParkEncounterArea](#palparkencounterarea) |
-| flavor_text_entries    | The flavor text of this flavor text listed in different languages																			           	                                | list [PokemonSpeciesFlavorText](#pokemonspeciesflavortext) |
 | form_descriptions      | Descriptions of different forms Pokémon take on within the Pokémon species		                                                                      | list [Description](#description) |
-| genera                 | The genus of this Pokémon species listed in multiple languages                                                                                     | [Genus](#genus) |
-| varieties              | A list of the Pokémon that exist within this Pokémon species                                                                                       | list [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
+| genera                 | The genus of this Pokémon species listed in multiple languages                                                                                     | list [Genus](#genus) |
+| varieties              | A list of the Pokémon that exist within this Pokémon species                                                                                       | list [PokemonSpeciesVariety] |
 
 #### Genus
 
 | Name | Description | Data Type |
 | ---- | ----------- | --------- |
-| genus    | The localized genus for the referenced pokemon species | string |
+| genus    | The localized genus for the referenced Pokémon species | string |
 | language | The language this genus is in                          | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 #### PokemonSpeciesDexEntry
@@ -2718,7 +2775,7 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 | Name | Description | Data Type |
 | ---- | ----------- | --------- |
 | entry_number | The index number within the Pokédex                        | integer |
-| name         | The Pokédex the referenced Pokémon species can be found in | [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
+| pokedex      | The Pokédex the referenced Pokémon species can be found in | [NamedAPIResource](#namedapiresource) ([Pokedex](#pokedexes)) |
 
 #### PalParkEncounterArea
 
@@ -2728,13 +2785,12 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 | rate       | The base rate for encountering the referenced Pokémon in this pal park area                    | integer |
 | area       | The pal park area where this encounter happens                                                 | [NamedAPIResource](#namedapiresource) ([PalParkArea](#pal-park-areas)) |
 
-#### PokemonSpeciesFlavorText
+#### PokemonSpeciesDexEntry
 
 | Name | Description | Data Type |
 | ---- | ----------- | --------- |
-| flavor_text | The localized flavor text for an API resource in a specific language | string |
-| language    | The language this name is in                                  	 	   | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
-| version     | The version this flavor text entry is used in 					           	 | [NamedAPIResource](#namedapiresource) ([Version](#versions)) |
+| is_default | Whether this variety is the default variety | boolean |
+| pokemon    | The Pokémon variety | [NamedAPIResource](#namedapiresource) ([Pokemon](#pokemon)) |
 
 ## Stats
 Stats determine certain aspects of battles. Each Pokémon has a value for each stat which grows as they gain levels and can be altered momentarily by effects in battles.
@@ -2819,22 +2875,15 @@ Stats determine certain aspects of battles. Each Pokémon has a value for each s
 
 | Name | Description | Data Type |
 | ---- | ----------- | --------- |
-| max_change | The maximum amount of change to the referenced stat | integer |
+| change     | The maximum amount of change to the referenced stat | integer |
 | move       | The move causing the change                         | [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 
 #### NatureStatAffectSets
 
 | Name | Description | Data Type |
 | ---- | ----------- | --------- |
-| increase | A list of natures and how they change the referenced stat | list [NatureStatAffect](#naturestataffect) |
-| decrease | A list of nature sand how they change the referenced stat | list [NatureStatAffect](#naturestataffect) |
-
-#### NatureStatAffect
-
-| Name | Description | Data Type |
-| ---- | ----------- | --------- |
-| max_change | The maximum amount of change to the referenced stat | integer |
-| nature     | The nature causing the change                       | [NamedAPIResource](#namedapiresource) ([Nature](#natures)) |
+| increase | A list of natures and how they change the referenced stat | list [NamedAPIResource](#namedapiresource) ([Nature](#natures)) |
+| decrease | A list of nature sand how they change the referenced stat | list [NamedAPIResource](#namedapiresource) ([Nature](#natures)) |
 
 ## Types
 Types are properties for Pokémon and their moves. Each type has three properties: which types of Pokémon it is super effective against, which types of Pokémon it is not very effective against, and which types of Pokémon it is completely ineffective against.
@@ -2934,7 +2983,7 @@ Types are properties for Pokémon and their moves. Each type has three propertie
 
 #### TypeRelations
 
-| Name | Description | Data Type | 
+| Name | Description | Data Type |
 | ---- | ----------- | --------- |
 | no_damage_to       | A list of types this type has no effect on                    | list [NamedAPIResource](#namedapiresource) ([Type](#types)) |
 | half_damage_to     | A list of types this type is not very effect against          | list [NamedAPIResource](#namedapiresource) ([Type](#types)) |
@@ -2992,7 +3041,7 @@ Languages for translations of API resource information.
 
 #### Description
 
-| Name | Description | Data Type | 
+| Name | Description | Data Type |
 | ---- | ----------- | --------- |
 | description | The localized description for an API resource in a specific language | string |
 | language    | The language this name is in                                         | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
@@ -3037,7 +3086,7 @@ Languages for translations of API resource information.
 
 #### NamedAPIResource
 
-| Name | Description | Data Type | 
+| Name | Description | Data Type |
 | ---- | ----------- | --------- |
 | name | The name of the referenced resource | string |
 | url  | The URL of the referenced resource  | string |


### PR DESCRIPTION
 - Fix incorrect types (fixes #195 and a bunch of other wrong types)
 - Fix various typos/spelling errors
 - Add some inner types that were missing
 - Auto format Markdown tables