### PR TITLE
move flavor texts now available

### DIFF
--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -2011,16 +2011,17 @@ class MoveEffectChangeSerializer(serializers.ModelSerializer):
         model = MoveEffectChange
         fields = ('version_group', 'effect_entries')
 
+
 class MoveFlavorTextSerializer(serializers.ModelSerializer):
 
     flavor_text = serializers.CharField()
     language = LanguageSummarySerializer()
     version_group = VersionGroupSummarySerializer()
 
-
     class Meta:
         model = MoveFlavorText
         fields = ('flavor_text', 'language', 'version_group')
+
 
 class MoveDetailSerializer(serializers.ModelSerializer):
 
@@ -2040,7 +2041,8 @@ class MoveDetailSerializer(serializers.ModelSerializer):
     past_values = MoveChangeSerializer(many=True, read_only=True, source="movechange")
     effect_changes = serializers.SerializerMethodField('get_effect_change_text')
     machines = serializers.SerializerMethodField('get_move_machines')
-    flavor_text_entries = MoveFlavorTextSerializer(many=True, read_only=True, source="moveflavortext")
+    flavor_text_entries = MoveFlavorTextSerializer(
+        many=True, read_only=True, source="moveflavortext")
 
     class Meta:
         model = Move

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -2011,6 +2011,16 @@ class MoveEffectChangeSerializer(serializers.ModelSerializer):
         model = MoveEffectChange
         fields = ('version_group', 'effect_entries')
 
+class MoveFlavorTextSerializer(serializers.ModelSerializer):
+
+    flavor_text = serializers.CharField()
+    language = LanguageSummarySerializer()
+    version_group = VersionGroupSummarySerializer()
+
+
+    class Meta:
+        model = MoveFlavorText
+        fields = ('flavor_text', 'language', 'version_group')
 
 class MoveDetailSerializer(serializers.ModelSerializer):
 
@@ -2030,6 +2040,7 @@ class MoveDetailSerializer(serializers.ModelSerializer):
     past_values = MoveChangeSerializer(many=True, read_only=True, source="movechange")
     effect_changes = serializers.SerializerMethodField('get_effect_change_text')
     machines = serializers.SerializerMethodField('get_move_machines')
+    flavor_text_entries = MoveFlavorTextSerializer(many=True, read_only=True, source="moveflavortext")
 
     class Meta:
         model = Move
@@ -2056,6 +2067,7 @@ class MoveDetailSerializer(serializers.ModelSerializer):
             'target',
             'type',
             'machines',
+            'flavor_text_entries',
         )
 
     def get_move_machines(self, obj):

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -1123,10 +1123,10 @@ class APIData():
             name='lang for '+flavor_text)
 
         move_flavor_text = MoveFlavorText.objects.create(
-            move = move,
-            version_group = version_group,
-            language = language,
-            flavor_text = flavor_text
+            move=move,
+            version_group=version_group,
+            language=language,
+            flavor_text=flavor_text
         )
         move_flavor_text.save()
 
@@ -3651,12 +3651,20 @@ class APITests(APIData, APITestCase):
             '{}{}/language/{}/'.format(
                 test_host, api_v2, move_effect_change_effect_text.language.pk))
         # flavor text params
-        self.assertEqual(response.data['flavor_text_entries'][0]['flavor_text'], move_flavor_text.flavor_text)
-        self.assertEqual(response.data['flavor_text_entries'][0]['language']['name'], move_flavor_text.language.name)
-        self.assertEqual(response.data['flavor_text_entries'][0]['language']['url'], '{}{}/language/{}/'.format(test_host, api_v2, move_flavor_text.language.pk))
-        self.assertEqual(response.data['flavor_text_entries'][0]['version_group']['name'], move_flavor_text.version_group.name)
-        self.assertEqual(response.data['flavor_text_entries'][0]['version_group']['url'], '{}{}/version-group/{}/'.format(test_host, api_v2, move_flavor_text.version_group.pk))
-
+        self.assertEqual(
+            response.data['flavor_text_entries'][0]['flavor_text'], move_flavor_text.flavor_text)
+        self.assertEqual(
+            response.data['flavor_text_entries'][0]['language']['name'],
+            move_flavor_text.language.name)
+        self.assertEqual(
+            response.data['flavor_text_entries'][0]['language']['url'],
+            '{}{}/language/{}/'.format(test_host, api_v2, move_flavor_text.language.pk))
+        self.assertEqual(
+            response.data['flavor_text_entries'][0]['version_group']['name'],
+            move_flavor_text.version_group.name)
+        self.assertEqual(
+            response.data['flavor_text_entries'][0]['version_group']['url'],
+            '{}{}/version-group/{}/'.format(test_host, api_v2, move_flavor_text.version_group.pk))
 
     # Stat Tests
     def test_stat_api(self):

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -1115,6 +1115,24 @@ class APIData():
         return super_contest_combo
 
     @classmethod
+    def setup_move_flavor_text_data(self, move, flavor_text='move flvr txt'):
+        version_group = self.setup_version_group_data(
+            name='ver grp for '+flavor_text)
+
+        language = self.setup_language_data(
+            name='lang for '+flavor_text)
+
+        move_flavor_text = MoveFlavorText.objects.create(
+            move = move,
+            version_group = version_group,
+            language = language,
+            flavor_text = flavor_text
+        )
+        move_flavor_text.save()
+
+        return move_flavor_text
+
+    @classmethod
     def setup_move_data(self, contest_type=None, contest_effect=None, super_contest_effect=None,
                         generation=None, move_damage_class=None, move_effect=None,
                         move_target=None, type=None, name='mv', power=20, pp=20,
@@ -3488,6 +3506,7 @@ class APITests(APIData, APITestCase):
         self.setup_contest_combo_data(before_move, move)
         self.setup_super_contest_combo_data(move, after_move)
         self.setup_super_contest_combo_data(before_move, move)
+        move_flavor_text = self.setup_move_flavor_text_data(move, flavor_text='flvr text for move')
 
         response = self.client.get('{}/move/{}/'.format(api_v2, move.pk))
 
@@ -3631,6 +3650,13 @@ class APITests(APIData, APITestCase):
             response.data['effect_changes'][0]['effect_entries'][0]['language']['url'],
             '{}{}/language/{}/'.format(
                 test_host, api_v2, move_effect_change_effect_text.language.pk))
+        # flavor text params
+        self.assertEqual(response.data['flavor_text_entries'][0]['flavor_text'], move_flavor_text.flavor_text)
+        self.assertEqual(response.data['flavor_text_entries'][0]['language']['name'], move_flavor_text.language.name)
+        self.assertEqual(response.data['flavor_text_entries'][0]['language']['url'], '{}{}/language/{}/'.format(test_host, api_v2, move_flavor_text.language.pk))
+        self.assertEqual(response.data['flavor_text_entries'][0]['version_group']['name'], move_flavor_text.version_group.name)
+        self.assertEqual(response.data['flavor_text_entries'][0]['version_group']['url'], '{}{}/version-group/{}/'.format(test_host, api_v2, move_flavor_text.version_group.pk))
+
 
     # Stat Tests
     def test_stat_api(self):

--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -1317,6 +1317,7 @@ Moves are the skills of Pokémon in battle. In battle, a Pokémon uses one move 
 | damage_class         | The type of damage the move inflicts on the target, e.g. physical                                                                                                         | [NamedAPIResource](#namedapiresource) ([MoveDamageClass](#move-damage-classes)) |
 | effect_entries       | The effect of this move listed in different languages                                                                                                                     | list [VerboseEffect](#verboseeffect)                                            |
 | effect_changes       | The list of previous effects this move has had across version groups of the games                                                                                         | list [AbilityEffectChange](#abilityeffectchange)                                |
+| flavor_text_entries  | The flavor text of this move listed in different languages                                                                                                                | [Move](#moveflavortext)                                                         |
 | generation           | The generation in which this move was introduced                                                                                                                          | [NamedAPIResource](#namedapiresource) ([Generation](#generations))              |
 | machines             | A list of the machines that teach this move                                                                                                                               | list [MachineVersionDetail](#machineversiondetail)                              |
 | meta                 | Metadata about this move                                                                                                                                                  | [MoveMetaData](#movemetadata)                                                   |
@@ -1340,6 +1341,14 @@ Moves are the skills of Pokémon in battle. In battle, a Pokémon uses one move 
 |:-----------|:----------------------------------------|:------------------------------------------------------------|
 | use_before | A list of moves to use before this move | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
 | use_after  | A list of moves to use after this move  | list [NamedAPIResource](#namedapiresource) ([Move](#moves)) |
+
+#### MoveFlavorText
+
+| Name          | Description                                                          | Data Type                                                               |
+|:--------------|:---------------------------------------------------------------------|:------------------------------------------------------------------------|
+| flavor_text   | The localized flavor text for an api resource in a specific language | string                                                                  |
+| language      | The language this name is in                                  		   | [NamedAPIResource](#namedapiresource) ([Language](#languages))          |
+| version_group | The version group that uses this flavor text                         | [NamedAPIResource](#namedapiresource) ([VersionGroup](#version-groups)) |
 
 #### MoveMetaData
 
@@ -2690,7 +2699,7 @@ Shapes used for sorting Pokémon in a Pokédex.
 | language     | The language this "scientific" name is in                                  | [NamedAPIResource](#namedapiresource) ([Language](#languages)) |
 
 ## Pokémon Species
-A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Pokémon species are shared across all varieties of Pokémon within the species. A good example is Wormadam; Wormadam is the species which can be found in three different varieties, Wormadam-Trash, Wormadam-Sandy and Wormadam-Plant.  
+A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Pokémon species are shared across all varieties of Pokémon within the species. A good example is Wormadam; Wormadam is the species which can be found in three different varieties, Wormadam-Trash, Wormadam-Sandy and Wormadam-Plant.
 
 ### GET api/v2/pokemon-species/{id or name}
 

--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -1281,7 +1281,20 @@ Moves are the skills of Pokémon in battle. In battle, a Pokémon uses one move 
 	"type": {
 		"name": "normal",
 		"url": "http://pokeapi.co/api/v2/type/1/"
-	}
+	},
+  "flavor_text_entries": [
+		{
+			"flavor_text": "Pounds with fore­\nlegs or tail.",
+			"language": {
+				"url": "http://localhost:8000/api/v2/language/9/",
+				"name": "en"
+			},
+			"version_group": {
+				"url": "http://localhost:8000/api/v2/version-group/3/",
+				"name": "gold-silver"
+			}
+		},
+  }]
 }
 ```
 


### PR DESCRIPTION
I noticed that the flavor texts for moves were not currently being provided by the API, but that the data was already present. I added functionality to return them (modeled after the species flavor text as per #111, except that I didn't put in the sections of documentation equivalent to the ones removed in 4bc45830 about species flavor text). The new assertions in `test_move_api` are also modeled after those in #111.

Let me know if you need me to change something! I tried to follow the style used in similar places in the code, but being new to this code and having no prior experience with Django, there may be some areas that can be improved.