### PR TITLE
Fix duplicated model name in docsv2 document

### DIFF
--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -2825,7 +2825,7 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 | flavor_text_entries    | A list of flavor text entries for this Pokémon species                                                                                             | list [FlavorText](#flavortext)                                              | 
 | form_descriptions      | Descriptions of different forms Pokémon take on within the Pokémon species                                                                         | list [Description](#description)                                            |
 | genera                 | The genus of this Pokémon species listed in multiple languages                                                                                     | list [Genus](#genus)                                                        |
-| varieties              | A list of the Pokémon that exist within this Pokémon species                                                                                       | list [PokemonSpeciesVariety]                                                |
+| varieties              | A list of the Pokémon that exist within this Pokémon species                                                                                       | list [PokemonSpeciesVariety](#pokemonspeciesvariety)                        |
 
 #### Genus
 

--- a/templates/pages/docsv2.md
+++ b/templates/pages/docsv2.md
@@ -2849,7 +2849,7 @@ A Pokémon Species forms the basis for at least one Pokémon. Attributes of a Po
 | rate       | The base rate for encountering the referenced Pokémon in this pal park area                    | integer                                                                |
 | area       | The pal park area where this encounter happens                                                 | [NamedAPIResource](#namedapiresource) ([PalParkArea](#pal-park-areas)) |
 
-#### PokemonSpeciesDexEntry
+#### PokemonSpeciesVariety
 
 | Name       | Description                                 | Data Type                                                   |
 |:-----------|:--------------------------------------------|:------------------------------------------------------------|


### PR DESCRIPTION
Apparently writing a thing to parse the models/types into Haskell data types is a good way to find this kind of stuff ;)