### PR TITLE
Added link to v2docs for a Python wrapper.

### DIFF
--- a/templates/pages/docsv2.html
+++ b/templates/pages/docsv2.html
@@ -150,6 +150,7 @@
       <li><b>Kotlin (and Java)</b> - <a href="https://github.com/PokeAPI/pokekotlin">PokeKotlin</a> by sargunster</li>
       <li><b>Swift</b> - <a href="https://github.com/ContinuousLearning/PokemonKit">PokemonKit</a> by darkcl</li>
       <li><b>PHP</b> - <a href="https://github.com/danrovito/pokephp">PokePHP</a> by Dan Rovito</li>
+      <li><b>Python</b> - <a href="https://github.com/GregHilmes/pokebase">PokeBase</a> by Greg Hilmes</li>
     </ul>
 
     {% markdown %}


### PR DESCRIPTION
I aded a link to my Python wrapper for the API. The link is added to the template for the v2 docs page. It'd be cool to see my repo eventually inlcuded under the github organization, if possible. [Here](https://github.com/GregHilmes/pokebase) is a link to the repo. Thanks!