### PR TITLE
dictionary from encounters subresource (#332)

### DIFF
--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -487,4 +487,4 @@ class PokemonEncounterView(APIView):
                 'version_details': version_details_list
             })
 
-        return Response(encounters_list)
+        return Response({'results': encounters_list})

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -4250,6 +4250,14 @@ class APITests(APIData, APITestCase):
         self.assertEqual(
             response.data['forms'][0]['url'],
             '{}{}/pokemon-form/{}/'.format(test_host, api_v2, pokemon_form.pk))
+        # encounters parameters
+        self.assertEqual(
+            response.data['location_area_encounters'],
+            '{}/pokemon/{}/encounters'.format(api_v2, response.data['id']))
+        # Can't do this because sqlite doesn't support distinct()
+        # which is used by the API call
+        #encounters_response= self.client.get(
+        #    '{}/pokemon/{}/encounters'.format(api_v2, pokemon.pk), HTTP_HOST='testserver')
         # sprite params
         self.assertEqual(
             response.data['sprites']['front_default'],


### PR DESCRIPTION
This makes it consistent with the every other resource
Unfortunately this isn't tested or testable in the current framework,
as distinct() is not supported by the sqlite3 backend