### PR TITLE
Fix v2 database build script to work on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 db.*
 venv*
 node_modules
+.vscode

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -39,7 +39,9 @@ imageDir = os.getcwd() + '/data/v2/sprites/'
 resourceImages = []
 for root, dirs, files in os.walk(imageDir):
     for file in files:
-        resourceImages.append(os.path.join(root.replace(imageDir, ""), file))
+        image_path = os.path.join(root.replace(imageDir, ""), file)
+        image_path = image_path.replace("\\", "/") # convert Windows-style path to Unix
+        resourceImages.append(image_path)
 
 
 mediaDir = '/media/sprites/{0}'


### PR DESCRIPTION
Image sprite paths should be Unix-style, but the build script used the OS default, so the process would fail on Windows.