### PR TITLE
Update version of psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ gunicorn==19.4.5
 markdown2==2.3.4
 mimeparse==0.1.3
 pilkit==2.0
-psycopg2==2.5.4
+psycopg2==2.7.5
 python-dateutil==2.6.1
 python-mimeparse==1.6.0
 simplejson==3.11.1


### PR DESCRIPTION
Versions below 2.7 no longer work on recent version of Ubuntu.
See https://github.com/psycopg/psycopg2/issues/594.

I've tested locally and nothing breaks with the new dependency version.