### PR TITLE
Disables throttling

### DIFF
--- a/Resources/nginx/nginx.conf
+++ b/Resources/nginx/nginx.conf
@@ -38,8 +38,6 @@ http {
         server app:8000 fail_timeout=0;
     }
 
-    # limit_req_zone $binary_remote_addr zone=api:10m rate=2r/s;
-
     server {
         listen 80 deferred;
         server_name _;
@@ -71,8 +69,6 @@ http {
             expires 1m; # client-side caching, one minute for each API resource
             add_header Cache-Control "public";
             add_header Pragma public;
-
-            # limit_req zone=api burst=10;
 
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/Resources/nginx/nginx.conf
+++ b/Resources/nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
         server app:8000 fail_timeout=0;
     }
 
-    limit_req_zone $binary_remote_addr zone=api:10m rate=2r/s;
+    # limit_req_zone $binary_remote_addr zone=api:10m rate=2r/s;
 
     server {
         listen 80 deferred;
@@ -72,7 +72,7 @@ http {
             add_header Cache-Control "public";
             add_header Pragma public;
 
-            limit_req zone=api burst=10;
+            # limit_req zone=api burst=10;
 
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/config/settings.py
+++ b/config/settings.py
@@ -126,11 +126,5 @@ REST_FRAMEWORK = {
 
     'PAGE_SIZE': 20,
 
-    'PAGINATE_BY': 20,
-    # 'DEFAULT_THROTTLE_CLASSES': (
-    #     'rest_framework.throttling.AnonRateThrottle',
-    # ),
-    # 'DEFAULT_THROTTLE_RATES': {
-    #     'anon': '1000/hour'
-    # }
+    'PAGINATE_BY': 20
 }

--- a/config/settings.py
+++ b/config/settings.py
@@ -127,10 +127,10 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 20,
 
     'PAGINATE_BY': 20,
-    'DEFAULT_THROTTLE_CLASSES': (
-        'rest_framework.throttling.AnonRateThrottle',
-    ),
-    'DEFAULT_THROTTLE_RATES': {
-        'anon': '1000/hour'
-    }
+    # 'DEFAULT_THROTTLE_CLASSES': (
+    #     'rest_framework.throttling.AnonRateThrottle',
+    # ),
+    # 'DEFAULT_THROTTLE_RATES': {
+    #     'anon': '1000/hour'
+    # }
 }


### PR DESCRIPTION
Since the entire API is now static files, we don't need anymore any throttling. This simplifies also updating data in the `api-data` repo.