### PR TITLE
add libstdc++ and g++ to fix

### DIFF
--- a/Resources/docker/app/Dockerfile
+++ b/Resources/docker/app/Dockerfile
@@ -10,8 +10,8 @@ VOLUME /code
 
 ADD requirements.txt /code/
 RUN \
-    apk add --no-cache postgresql-libs && \
-    apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
+    apk add --no-cache postgresql-libs libstdc++ && \
+    apk add --no-cache --virtual .build-deps gcc g++ musl-dev postgresql-dev && \
     python3 -m pip install -r requirements.txt --no-cache-dir && \
     apk --purge del .build-deps
 ADD . /code/


### PR DESCRIPTION
failing pip installation using Docker