### PR TITLE
Prevent server error on large integer lookup

### DIFF
--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -44,6 +44,10 @@ class NameOrIdRetrieval:
         lookup = self.kwargs["pk"]
 
         if self.idPattern.match(lookup):
+            lookup_id = int(lookup)
+            if abs(lookup_id) > 2147483647:
+                raise Http404
+
             resp = get_object_or_404(queryset, pk=lookup)
 
         elif self.namePattern.match(lookup):

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -5438,3 +5438,10 @@ class APITests(APIData, APITestCase):
             response.data["pokemon_encounters"][0]["pokemon_species"]["url"],
             "{}{}/pokemon-species/{}/".format(TEST_HOST, API_V2, pokemon_species.pk),
         )
+
+    # ID Range Tests
+    def test_id_range_api(self):
+
+        response = self.client.get("{}/pokemon/{}/".format(API_V2, 2147483648))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This PR implements an app-solution to issue #487, in which:

> Because sqlite does not support large integers, using a too-large integer as an id (ie /api/v2/version-group/9223372036854775808/) will cause the server to 500.

According to the [IntegerField entry on Django docs](https://docs.djangoproject.com/en/2.1/ref/models/fields/#django.db.models.IntegerField) (which is the field type used for primary keys on models), 

> Values from -2147483648 to 2147483647 are safe in all databases supported by Django.

I think it is safe to assume that, for a long time, no data category on the PokéApi will reach more than 2147483647 entries.

The implemented fix simply checks that numeric lookup values are less than 2147483647 in absolute value. If the validation fails, a 404 error is directly raised. Otherwise, the database query proceeds as expected.

A new test has been added to the tests files, in order to check this case. All tests passed successfully in my local environment.

This is my first PR here, hope everything's okay, and of course I'm open to changes and/or suggestions!

If merged, this PR fixes and closes #487