### PR TITLE
Added new official wrapper for Spring Boot with auto caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Once you've signed up visit [PokéAPI on Slack](https://pokeapi.slack.com)
 * Go [mtslzr/pokeapi-go](https://github.com/mtslzr/pokeapi-go) | _Auto caching_
 * Dart [prathanbomb/pokedart](https://github.com/prathanbomb/pokedart)
 * Rust [lunik1/pokerust](https://gitlab.com/lunik1/pokerust) | _Auto caching_
+* Spring Boot [dlfigueira/spring-pokeapi](https://gitlab.com/dlfigueira/spring-pokeapi) | _Auto caching_
 
 ## Setup [![pyVersion37](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/download/releases/3.7/)
 


### PR DESCRIPTION
Added new wrapper for PokeAPI ([Spring-Pokeapi](https://github.com/dlfigueira/spring-pokeapi)).

I am aware that an existing official wrapper for Kotlin already exists, but, to the best of my knowledge, it does not have auto caching supported.

Furthermore, this wrapper is developed with Spring Boot in mind. This means that every resource is exposed as a Spring component, which can then be autowired.