### PR TITLE
Map Gen-I sprites

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1351,6 +1351,7 @@ def _build_pokemons():
         file_name_svg = "%s.svg" % info[0]
         poke_sprites = "pokemon/{0}"
         dream_world = "other/dream-world/{0}"
+        gen_i = "versions/generation-i/{0}"
         sprites = {
             "front_default": file_path_or_none(poke_sprites.format(file_name_png)),
             "front_female": file_path_or_none(
@@ -1384,6 +1385,32 @@ def _build_pokemons():
                             dream_world.format("female/" + file_name_svg)
                         )
                     ),
+                }
+            },
+            "versions": {
+                "generation-i": {
+                    "red-blue": {
+                        "front_default": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("red-blue/" + file_name_png)
+                            )
+                        ),
+                        "back_default": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("red-blue/back/" + file_name_png)
+                            )
+                        ),
+                    },
+                    "yellow": {
+                        "front_default": file_path_or_none(
+                            poke_sprites.format(gen_i.format("yellow/" + file_name_png))
+                        ),
+                        "back_default": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("yellow/back/" + file_name_png)
+                            )
+                        ),
+                    },
                 }
             },
         }

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1395,9 +1395,19 @@ def _build_pokemons():
                                 gen_i.format("red-blue/" + file_name_png)
                             )
                         ),
+                        "front_gray": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("red-blue/gray/" + file_name_png)
+                            )
+                        ),
                         "back_default": file_path_or_none(
                             poke_sprites.format(
                                 gen_i.format("red-blue/back/" + file_name_png)
+                            )
+                        ),
+                        "back_gray": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("red-blue/back/gray/" + file_name_png)
                             )
                         ),
                     },
@@ -1405,9 +1415,19 @@ def _build_pokemons():
                         "front_default": file_path_or_none(
                             poke_sprites.format(gen_i.format("yellow/" + file_name_png))
                         ),
+                        "front_gray": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("yellow/gray/" + file_name_png)
+                            )
+                        ),
                         "back_default": file_path_or_none(
                             poke_sprites.format(
                                 gen_i.format("yellow/back/" + file_name_png)
+                            )
+                        ),
+                        "back_gray": file_path_or_none(
+                            poke_sprites.format(
+                                gen_i.format("yellow/back/gray/" + file_name_png)
                             )
                         ),
                     },


### PR DESCRIPTION
Extend pokemon sprites to include gen-i images. I didn't map the `gray` version of the images because I wasn't sure if I should or not.