### PR TITLE
Run staging deploy every week

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,3 +51,16 @@ workflows:
               only: 
                 - master
                 - staging
+  weekly:
+    jobs:
+      - test
+      - deploy:
+          requires:
+            - test
+    triggers:
+      - schedule:
+          cron: "0 0 * * 1"
+          filters:
+            branches:
+              only:
+                - staging


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

CircleCI [deletes](https://support.circleci.com/hc/en-us/articles/115014004948-Uses-for-artifacts-and-limitations-) our artifacts after 30 days. Thus if we don't merge anything in the `master` branch for more than a month then we won't have any artifacts in CircleCI. Both the artifacts of pokeapi and pokeapi.co are required when deploying. If they are not there the deploy phase breaks. 

So this PR simply recreates the CircleCI artifacts of pokeapi every week.
