### PR TITLE
Fix #565

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1348,8 +1348,22 @@ def _build_pokemons():
 
     build_generic((Pokemon,), "pokemon.csv", csv_record_to_objects)
 
+    def try_image_names(info):
+        poke_sprites = "pokemon/{0}"
+        if "-" in info[1]:
+            file_name_png_str = "%s.png" % (info[2] + "-" + info[1].split("-", 1)[1],)
+            file_name_png_int = "%s.png" % info[0]
+            file_name_png = (
+                file_name_png_str
+                if file_path_or_none(poke_sprites.format(file_name_png_str))
+                else file_name_png_int
+            )
+        else:
+            file_name_png = "%s.png" % info[0]
+        return file_name_png
+
     def csv_record_to_objects(info):
-        file_name_png = "%s.png" % info[0]
+        file_name_png = try_image_names(info)
         file_name_gif = "%s.gif" % info[0]
         file_name_svg = "%s.svg" % info[0]
         poke_sprites = "pokemon/{0}"
@@ -2032,17 +2046,20 @@ def _build_pokemons():
 
     def csv_record_to_objects(info):
         pokemon = Pokemon.objects.get(pk=int(info[3]))
+        poke_sprites = "pokemon/{0}"
         if info[2]:
-            if re.search(r"^mega", info[2]):
-                file_name = "%s.png" % info[3]
-            else:
-                file_name = "%s-%s.png" % (
-                    getattr(pokemon, "pokemon_species_id"),
-                    info[2],
-                )
+            file_name_str = "%s-%s.png" % (
+                getattr(pokemon, "pokemon_species_id"),
+                info[2],
+            )
+            file_name_int = "%s.png" % info[3]
+            file_name = (
+                file_name_str
+                if file_path_or_none(poke_sprites.format(file_name_str))
+                else file_name_int
+            )
         else:
             file_name = "%s.png" % getattr(pokemon, "pokemon_species_id")
-        poke_sprites = "pokemon/{0}"
         sprites = {
             "front_default": file_path_or_none(poke_sprites.format(file_name)),
             "front_shiny": file_path_or_none(poke_sprites.format("shiny/" + file_name)),

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1354,15 +1354,15 @@ def _build_pokemons():
         identifier = info[1]
         species_id = info[2]
         if "-" in identifier:
-            file_name_str = "%s.%s" % (
+            form_file_name = "%s.%s" % (
                 species_id + "-" + identifier.split("-", 1)[1],
                 extension,
             )
-            file_name_int = "%s.%s" % (pokemon_id, extension)
+            id_file_name = "%s.%s" % (pokemon_id, extension)
             file_name = (
-                file_name_int
-                if file_path_or_none(path + file_name_int)
-                else file_name_str
+                id_file_name
+                if file_path_or_none(path + id_file_name)
+                else form_file_name
             )
         else:
             file_name = "%s.%s" % (info[0], extension)
@@ -1908,15 +1908,15 @@ def _build_pokemons():
         species_id = getattr(pokemon, "pokemon_species_id")
         is_default = int(info[5])
         if form_identifier:
-            file_name_str = "%s-%s.%s" % (species_id, form_identifier, extension)
-            file_name_int = "%s.%s" % (pokemon_id, extension)
+            form_file_name = "%s-%s.%s" % (species_id, form_identifier, extension)
+            id_file_name = "%s.%s" % (pokemon_id, extension)
             file_name = (
-                file_name_int
-                if file_path_or_none(path + file_name_int)
-                else file_name_str
+                id_file_name
+                if file_path_or_none(path + id_file_name)
+                else form_file_name
             )
-            if file_name_int and file_name_str and (not is_default):
-                file_name = file_name_str
+            if id_file_name and form_file_name and (not is_default):
+                file_name = form_file_name
         else:
             file_name = "%s.%s" % (species_id, extension)
         return file_path_or_none(path + file_name)

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1906,6 +1906,7 @@ def _build_pokemons():
         pokemon_id = info[3]
         pokemon = Pokemon.objects.get(pk=int(pokemon_id))
         species_id = getattr(pokemon, "pokemon_species_id")
+        is_default = int(info[5])
         if form_identifier:
             file_name_str = "%s-%s.%s" % (species_id, form_identifier, extension)
             file_name_int = "%s.%s" % (pokemon_id, extension)
@@ -1914,6 +1915,8 @@ def _build_pokemons():
                 if file_path_or_none(path + file_name_int)
                 else file_name_str
             )
+            if file_name_int and file_name_str and (not is_default):
+                file_name = file_name_str
         else:
             file_name = "%s.%s" % (species_id, extension)
         return file_path_or_none(path + file_name)

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1348,623 +1348,436 @@ def _build_pokemons():
 
     build_generic((Pokemon,), "pokemon.csv", csv_record_to_objects)
 
-    def try_image_names(info):
-        poke_sprites = "pokemon/{0}"
-        if "-" in info[1]:
-            file_name_png_str = "%s.png" % (info[2] + "-" + info[1].split("-", 1)[1],)
-            file_name_png_int = "%s.png" % info[0]
-            file_name_png = (
-                file_name_png_str
-                if file_path_or_none(poke_sprites.format(file_name_png_str))
-                else file_name_png_int
+    def try_image_names(path, info, extension):
+        # poke_sprites = "pokemon/{0}"
+        pokemon_id = info[0]
+        identifier = info[1]
+        species_id = info[2]
+        if "-" in identifier:
+            file_name_str = "%s.%s" % (
+                species_id + "-" + identifier.split("-", 1)[1],
+                extension,
+            )
+            file_name_int = "%s.%s" % (pokemon_id, extension)
+            file_name = (
+                file_name_int
+                if file_path_or_none(path + file_name_int)
+                else file_name_str
             )
         else:
-            file_name_png = "%s.png" % info[0]
-        return file_name_png
+            file_name = "%s.%s" % (info[0], extension)
+        return file_path_or_none(path + file_name)
 
     def csv_record_to_objects(info):
-        file_name_png = try_image_names(info)
-        file_name_gif = "%s.gif" % info[0]
-        file_name_svg = "%s.svg" % info[0]
-        poke_sprites = "pokemon/{0}"
-        dream_world = "other/dream-world/{0}"
-        official_art = "other/official-artwork/{0}"
-        gen_i = "versions/generation-i/{0}"
-        gen_ii = "versions/generation-ii/{0}"
-        gen_iii = "versions/generation-iii/{0}"
-        gen_iv = "versions/generation-iv/{0}"
-        gen_v = "versions/generation-v/{0}"
-        gen_vi = "versions/generation-vi/{0}"
-        gen_vii = "versions/generation-vii/{0}"
-        gen_viii = "versions/generation-viii/{0}"
+        poke_sprites = "pokemon/"
+        dream_world = "other/dream-world/"
+        official_art = "other/official-artwork/"
+        gen_i = "versions/generation-i/"
+        gen_ii = "versions/generation-ii/"
+        gen_iii = "versions/generation-iii/"
+        gen_iv = "versions/generation-iv/"
+        gen_v = "versions/generation-v/"
+        gen_vi = "versions/generation-vi/"
+        gen_vii = "versions/generation-vii/"
+        gen_viii = "versions/generation-viii/"
         sprites = {
-            "front_default": file_path_or_none(poke_sprites.format(file_name_png)),
-            "front_female": file_path_or_none(
-                poke_sprites.format("female/" + file_name_png)
+            "front_default": try_image_names(poke_sprites, info, "png"),
+            "front_female": try_image_names(poke_sprites + "female/", info, "png"),
+            "front_shiny": try_image_names(poke_sprites + "shiny/", info, "png"),
+            "front_shiny_female": try_image_names(
+                poke_sprites + "shiny/female/", info, "png"
             ),
-            "front_shiny": file_path_or_none(
-                poke_sprites.format("shiny/" + file_name_png)
-            ),
-            "front_shiny_female": file_path_or_none(
-                poke_sprites.format("shiny/female/" + file_name_png)
-            ),
-            "back_default": file_path_or_none(
-                poke_sprites.format("back/" + file_name_png)
-            ),
-            "back_female": file_path_or_none(
-                poke_sprites.format("back/female/" + file_name_png)
-            ),
-            "back_shiny": file_path_or_none(
-                poke_sprites.format("back/shiny/" + file_name_png)
-            ),
-            "back_shiny_female": file_path_or_none(
-                poke_sprites.format("back/shiny/female/" + file_name_png)
+            "back_default": try_image_names(poke_sprites + "back/", info, "png"),
+            "back_female": try_image_names(poke_sprites + "back/female/", info, "png"),
+            "back_shiny": try_image_names(poke_sprites + "back/shiny/", info, "png"),
+            "back_shiny_female": try_image_names(
+                poke_sprites + "back/shiny/female/", info, "png"
             ),
             "other": {
                 "dream_world": {
-                    "front_default": file_path_or_none(
-                        poke_sprites.format(dream_world.format(file_name_svg))
+                    "front_default": try_image_names(
+                        poke_sprites + dream_world, info, 'svg'
                     ),
-                    "front_female": file_path_or_none(
-                        poke_sprites.format(
-                            dream_world.format("female/" + file_name_svg)
-                        )
+                    "front_female": try_image_names(
+                        poke_sprites + dream_world + "female/", info, 'svg'
                     ),
                 },
                 "official-artwork": {
-                    "front_default": file_path_or_none(
-                        poke_sprites.format(official_art.format(file_name_png))
+                    "front_default": try_image_names(
+                        poke_sprites + official_art, info, 'png'
                     )
                 },
             },
             "versions": {
                 "generation-i": {
                     "red-blue": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("red-blue/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_i + "red-blue/", info, 'png'
                         ),
-                        "front_gray": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("red-blue/gray/" + file_name_png)
-                            )
+                        "front_gray": try_image_names(
+                            poke_sprites + gen_i + "red-blue/gray/", info, 'png'
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("red-blue/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_i + "red-blue/back/", info, 'png'
                         ),
-                        "back_gray": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("red-blue/back/gray/" + file_name_png)
-                            )
+                        "back_gray": try_image_names(
+                            poke_sprites + gen_i + "red-blue/back/gray/", info, 'png'
                         ),
                     },
                     "yellow": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(gen_i.format("yellow/" + file_name_png))
+                        "front_default": try_image_names(
+                            poke_sprites + gen_i + "yellow/", info, 'png'
                         ),
-                        "front_gray": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("yellow/gray/" + file_name_png)
-                            )
+                        "front_gray": try_image_names(
+                            poke_sprites + gen_i + "yellow/gray/", info, 'png'
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("yellow/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_i + "yellow/back/", info, 'png'
                         ),
-                        "back_gray": file_path_or_none(
-                            poke_sprites.format(
-                                gen_i.format("yellow/back/gray/" + file_name_png)
-                            )
+                        "back_gray": try_image_names(
+                            poke_sprites + gen_i + "yellow/back/gray/", info, 'png'
                         ),
                     },
                 },
                 "generation-ii": {
                     "crystal": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("crystal/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_ii + "crystal/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("crystal/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_ii + "crystal/shiny/", info, 'png'
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("crystal/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_ii + "crystal/back/", info, 'png'
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("crystal/back/shiny/" + file_name_png)
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_ii + "crystal/back/shiny/", info, 'png'
                         ),
                     },
                     "gold": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(gen_ii.format("gold/" + file_name_png))
+                        "front_default": try_image_names(
+                            poke_sprites + gen_ii + "gold/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("gold/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_ii + "gold/shiny/", info, 'png'
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("gold/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_ii + "gold/back/", info, 'png'
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("gold/back/shiny/" + file_name_png)
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_ii + "gold/back/shiny/", info, 'png'
                         ),
                     },
                     "silver": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("silver/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_ii + "silver/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("silver/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_ii + "silver/shiny/", info, 'png'
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("silver/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_ii + "silver/back/", info, 'png'
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_ii.format("silver/back/shiny/" + file_name_png)
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_ii + "silver/back/shiny/", info, 'png'
                         ),
                     },
                 },
                 "generation-iii": {
                     "emerald": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format("emerald/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_iii + "emerald/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format("emerald/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_iii + "emerald/shiny/", info, 'png'
                         ),
                     },
                     "firered-leafgreen": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format("firered-leafgreen/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_iii + "firered-leafgreen/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format(
-                                    "firered-leafgreen/shiny/" + file_name_png
-                                )
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_iii + "firered-leafgreen/shiny/",
+                            info, 'png',
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format(
-                                    "firered-leafgreen/back/" + file_name_png
-                                )
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_iii + "firered-leafgreen/back/",
+                            info, 'png',
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format(
-                                    "firered-leafgreen/back/shiny/" + file_name_png
-                                )
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_iii + "firered-leafgreen/back/shiny/",
+                            info, 'png',
                         ),
                     },
                     "ruby-sapphire": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format("ruby-sapphire/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_iii + "ruby-sapphire/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format("ruby-sapphire/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_iii + "ruby-sapphire/shiny/",
+                            info, 'png',
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format("ruby-sapphire/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_iii + "ruby-sapphire/back/",
+                            info, 'png',
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iii.format(
-                                    "ruby-sapphire/back/shiny/" + file_name_png
-                                )
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_iii + "ruby-sapphire/back/shiny/",
+                            info, 'png',
                         ),
                     },
                 },
                 "generation-iv": {
                     "diamond-pearl": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("diamond-pearl/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/", info, 'png'
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("diamond-pearl/female/" + file_name_png)
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/female/",
+                            info, 'png',
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("diamond-pearl/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/shiny/",
+                            info, 'png',
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "diamond-pearl/shiny/female/" + file_name_png
-                                )
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/shiny/female/",
+                            info, 'png',
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("diamond-pearl/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/back/", info, 'png'
                         ),
-                        "back_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "diamond-pearl/back/female/" + file_name_png
-                                )
-                            )
+                        "back_female": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/back/female/",
+                            info, 'png',
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "diamond-pearl/back/shiny/" + file_name_png
-                                )
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/back/shiny/",
+                            info, 'png',
                         ),
-                        "back_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "diamond-pearl/back/shiny/female/" + file_name_png
-                                )
-                            )
+                        "back_shiny_female": try_image_names(
+                            poke_sprites + gen_iv + "diamond-pearl/back/shiny/female/",
+                            info, 'png',
                         ),
                     },
                     "heartgold-soulsilver": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("heartgold-soulsilver/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_iv + "heartgold-soulsilver/",
+                            info, 'png',
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/female/" + file_name_png
-                                )
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_iv + "heartgold-soulsilver/female/",
+                            info, 'png',
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/shiny/" + file_name_png
-                                )
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_iv + "heartgold-soulsilver/shiny/",
+                            info, 'png',
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/shiny/female/" + file_name_png
-                                )
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites
+                            + gen_iv
+                            + "heartgold-soulsilver/shiny/female/",
+                            info, 'png',
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/back/" + file_name_png
-                                )
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_iv + "heartgold-soulsilver/back/",
+                            info, 'png',
                         ),
-                        "back_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/back/female/" + file_name_png
-                                )
-                            )
+                        "back_female": try_image_names(
+                            poke_sprites + gen_iv + "heartgold-soulsilver/back/female/",
+                            info, 'png',
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/back/shiny/" + file_name_png
-                                )
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_iv + "heartgold-soulsilver/back/shiny/",
+                            info, 'png',
                         ),
-                        "back_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "heartgold-soulsilver/back/shiny/female/"
-                                    + file_name_png
-                                )
-                            )
+                        "back_shiny_female": try_image_names(
+                            poke_sprites
+                            + gen_iv
+                            + "heartgold-soulsilver/back/shiny/female/",
+                            info, 'png',
                         ),
                     },
                     "platinum": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_iv + "platinum/", info, 'png'
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/female/" + file_name_png)
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_iv + "platinum/female/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_iv + "platinum/shiny/", info, 'png'
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/shiny/female/" + file_name_png)
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites + gen_iv + "platinum/shiny/female/",
+                            info, 'png',
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_iv + "platinum/back/", info, 'png'
                         ),
-                        "back_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/back/female/" + file_name_png)
-                            )
+                        "back_female": try_image_names(
+                            poke_sprites + gen_iv + "platinum/back/female/",
+                            info, 'png',
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format("platinum/back/shiny/" + file_name_png)
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_iv + "platinum/back/shiny/",
+                            info, 'png',
                         ),
-                        "back_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_iv.format(
-                                    "platinum/back/shiny/female/" + file_name_png
-                                )
-                            )
+                        "back_shiny_female": try_image_names(
+                            poke_sprites + gen_iv + "platinum/back/shiny/female/",
+                            info, 'png',
                         ),
                     },
                 },
                 "generation-v": {
                     "black-white": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format("black-white/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_v + "black-white/", info, 'png'
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format("black-white/female/" + file_name_png)
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_v + "black-white/female/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format("black-white/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_v + "black-white/shiny/", info, 'png'
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format(
-                                    "black-white/shiny/female/" + file_name_png
-                                )
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites + gen_v + "black-white/shiny/female/",
+                            info, 'png',
                         ),
-                        "back_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format("black-white/back/" + file_name_png)
-                            )
+                        "back_default": try_image_names(
+                            poke_sprites + gen_v + "black-white/back/", info, 'png'
                         ),
-                        "back_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format("black-white/back/female/" + file_name_png)
-                            )
+                        "back_female": try_image_names(
+                            poke_sprites + gen_v + "black-white/back/female/",
+                            info, 'png',
                         ),
-                        "back_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format("black-white/back/shiny/" + file_name_png)
-                            )
+                        "back_shiny": try_image_names(
+                            poke_sprites + gen_v + "black-white/back/shiny/",
+                            info, 'png',
                         ),
-                        "back_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_v.format(
-                                    "black-white/back/shiny/female/" + file_name_png
-                                )
-                            )
+                        "back_shiny_female": try_image_names(
+                            poke_sprites + gen_v + "black-white/back/shiny/female/",
+                            info, 'png',
                         ),
                         "animated": {
-                            "front_default": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/" + file_name_gif
-                                    )
-                                )
+                            "front_default": try_image_names(
+                                poke_sprites + gen_v + "black-white/animated/",
+                                info, 'gif',
                             ),
-                            "front_female": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/female/" + file_name_gif
-                                    )
-                                )
+                            "front_female": try_image_names(
+                                poke_sprites + gen_v + "black-white/animated/female/",
+                                info, 'gif',
                             ),
-                            "front_shiny": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/shiny/" + file_name_gif
-                                    )
-                                )
+                            "front_shiny": try_image_names(
+                                poke_sprites + gen_v + "black-white/animated/shiny/",
+                                info, 'gif',
                             ),
-                            "front_shiny_female": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/shiny/female/"
-                                        + file_name_gif
-                                    )
-                                )
+                            "front_shiny_female": try_image_names(
+                                poke_sprites
+                                + gen_v
+                                + "black-white/animated/shiny/female/"
+                                , info, 'gif'
                             ),
-                            "back_default": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/back/" + file_name_gif
-                                    )
-                                )
+                            "back_default": try_image_names(
+                                poke_sprites + gen_v + "black-white/animated/back/",
+                                info, 'gif',
                             ),
-                            "back_female": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/back/female/"
-                                        + file_name_gif
-                                    )
-                                )
+                            "back_female": try_image_names(
+                                poke_sprites
+                                + gen_v
+                                + "black-white/animated/back/female/"
+                                , info, 'gif'
                             ),
-                            "back_shiny": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/back/shiny/"
-                                        + file_name_gif
-                                    )
-                                )
+                            "back_shiny": try_image_names(
+                                poke_sprites
+                                + gen_v
+                                + "black-white/animated/back/shiny/"
+                                , info, 'gif'
                             ),
-                            "back_shiny_female": file_path_or_none(
-                                poke_sprites.format(
-                                    gen_v.format(
-                                        "black-white/animated/back/shiny/female/"
-                                        + file_name_gif
-                                    )
-                                )
+                            "back_shiny_female": try_image_names(
+                                poke_sprites
+                                + gen_v
+                                + "black-white/animated/back/shiny/female/"
+                                , info, 'gif'
                             ),
                         },
                     }
                 },
                 "generation-vi": {
                     "omegaruby-alphasapphire": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format(
-                                    "omegaruby-alphasapphire/" + file_name_png
-                                )
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_vi + "omegaruby-alphasapphire/",
+                            info, 'png',
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format(
-                                    "omegaruby-alphasapphire/female/" + file_name_png
-                                )
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_vi + "omegaruby-alphasapphire/female/",
+                            info, 'png',
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format(
-                                    "omegaruby-alphasapphire/shiny/" + file_name_png
-                                )
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_vi + "omegaruby-alphasapphire/shiny/",
+                            info, 'png',
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format(
-                                    "omegaruby-alphasapphire/shiny/female/"
-                                    + file_name_png
-                                )
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites
+                            + gen_vi
+                            + "omegaruby-alphasapphire/shiny/female/",
+                            info, 'png',
                         ),
                     },
                     "x-y": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(gen_vi.format("x-y/" + file_name_png))
+                        "front_default": try_image_names(
+                            poke_sprites + gen_vi + "x-y/", info, 'png'
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format("x-y/female/" + file_name_png)
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_vi + "x-y/female/", info, 'png'
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format("x-y/shiny/" + file_name_png)
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_vi + "x-y/shiny/", info, 'png'
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vi.format("x-y/shiny/female/" + file_name_png)
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites + gen_vi + "x-y/shiny/female/", info, 'png'
                         ),
                     },
                 },
                 "generation-vii": {
                     "ultra-sun-ultra-moon": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vii.format("ultra-sun-ultra-moon/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_vii + "ultra-sun-ultra-moon/",
+                            info, 'png',
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vii.format(
-                                    "ultra-sun-ultra-moon/female/" + file_name_png
-                                )
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_vii + "ultra-sun-ultra-moon/female/",
+                            info, 'png',
                         ),
-                        "front_shiny": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vii.format(
-                                    "ultra-sun-ultra-moon/shiny/" + file_name_png
-                                )
-                            )
+                        "front_shiny": try_image_names(
+                            poke_sprites + gen_vii + "ultra-sun-ultra-moon/shiny/",
+                            info, 'png',
                         ),
-                        "front_shiny_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vii.format(
-                                    "ultra-sun-ultra-moon/shiny/female/" + file_name_png
-                                )
-                            )
+                        "front_shiny_female": try_image_names(
+                            poke_sprites
+                            + gen_vii
+                            + "ultra-sun-ultra-moon/shiny/female/",
+                            info, 'png',
                         ),
                     },
                     "icons": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vii.format("icons/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_vii + "icons/", info, 'png'
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_vii.format("icons/female/" + file_name_png)
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_vii + "icons/female/", info, 'png'
                         ),
                     },
                 },
                 "generation-viii": {
                     "icons": {
-                        "front_default": file_path_or_none(
-                            poke_sprites.format(
-                                gen_viii.format("icons/" + file_name_png)
-                            )
+                        "front_default": try_image_names(
+                            poke_sprites + gen_viii + "icons/", info, 'png'
                         ),
-                        "front_female": file_path_or_none(
-                            poke_sprites.format(
-                                gen_viii.format("icons/female/" + file_name_png)
-                            )
+                        "front_female": try_image_names(
+                            poke_sprites + gen_viii + "icons/female/", info, 'png'
                         ),
-                    }
+                    },
                 },
             },
         }
@@ -2044,28 +1857,41 @@ def _build_pokemons():
 
     build_generic((PokemonForm,), "pokemon_forms.csv", csv_record_to_objects)
 
-    def csv_record_to_objects(info):
-        pokemon = Pokemon.objects.get(pk=int(info[3]))
-        poke_sprites = "pokemon/{0}"
-        if info[2]:
-            file_name_str = "%s-%s.png" % (
-                getattr(pokemon, "pokemon_species_id"),
-                info[2],
+    def try_image_names(path, info, extension):
+        form_identifier = info[2]
+        pokemon_id = info[3]
+        pokemon = Pokemon.objects.get(pk=int(pokemon_id))
+        species_id = getattr(pokemon, "pokemon_species_id")
+        if form_identifier:
+            file_name_str = "%s-%s.%s" % (
+                species_id,
+                form_identifier,
+                extension
             )
-            file_name_int = "%s.png" % info[3]
+            file_name_int = "%s.%s" % (pokemon_id, extension)
             file_name = (
-                file_name_str
-                if file_path_or_none(poke_sprites.format(file_name_str))
-                else file_name_int
+                file_name_int
+                if file_path_or_none(path + file_name_int)
+                else file_name_str
             )
         else:
-            file_name = "%s.png" % getattr(pokemon, "pokemon_species_id")
+            file_name = "%s.%s" % (species_id, extension)
+        return file_path_or_none(path + file_name)
+
+    def csv_record_to_objects(info):
+        poke_sprites = "pokemon/"
         sprites = {
-            "front_default": file_path_or_none(poke_sprites.format(file_name)),
-            "front_shiny": file_path_or_none(poke_sprites.format("shiny/" + file_name)),
-            "back_default": file_path_or_none(poke_sprites.format("back/" + file_name)),
-            "back_shiny": file_path_or_none(
-                poke_sprites.format("back/shiny/" + file_name)
+            "front_default": try_image_names(poke_sprites, info, 'png'),
+            "front_shiny": try_image_names(poke_sprites + "shiny/", info, 'png'),
+            "back_default": try_image_names(poke_sprites + "back/", info, 'png'),
+            "back_shiny": try_image_names(poke_sprites + "back/shiny/", info, 'png'),
+            "front_female": try_image_names(poke_sprites + "female/", info, "png"),
+            "front_shiny_female": try_image_names(
+                poke_sprites + "shiny/female/", info, "png"
+            ),
+            "back_female": try_image_names(poke_sprites + "back/female/", info, "png"),
+            "back_shiny_female": try_image_names(
+                poke_sprites + "back/shiny/female/", info, "png"
             ),
         }
         yield PokemonFormSprites(

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1396,15 +1396,15 @@ def _build_pokemons():
             "other": {
                 "dream_world": {
                     "front_default": try_image_names(
-                        poke_sprites + dream_world, info, 'svg'
+                        poke_sprites + dream_world, info, "svg"
                     ),
                     "front_female": try_image_names(
-                        poke_sprites + dream_world + "female/", info, 'svg'
+                        poke_sprites + dream_world + "female/", info, "svg"
                     ),
                 },
                 "official-artwork": {
                     "front_default": try_image_names(
-                        poke_sprites + official_art, info, 'png'
+                        poke_sprites + official_art, info, "png"
                     )
                 },
             },
@@ -1412,293 +1412,329 @@ def _build_pokemons():
                 "generation-i": {
                     "red-blue": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_i + "red-blue/", info, 'png'
+                            poke_sprites + gen_i + "red-blue/", info, "png"
                         ),
                         "front_gray": try_image_names(
-                            poke_sprites + gen_i + "red-blue/gray/", info, 'png'
+                            poke_sprites + gen_i + "red-blue/gray/", info, "png"
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_i + "red-blue/back/", info, 'png'
+                            poke_sprites + gen_i + "red-blue/back/", info, "png"
                         ),
                         "back_gray": try_image_names(
-                            poke_sprites + gen_i + "red-blue/back/gray/", info, 'png'
+                            poke_sprites + gen_i + "red-blue/back/gray/", info, "png"
                         ),
                     },
                     "yellow": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_i + "yellow/", info, 'png'
+                            poke_sprites + gen_i + "yellow/", info, "png"
                         ),
                         "front_gray": try_image_names(
-                            poke_sprites + gen_i + "yellow/gray/", info, 'png'
+                            poke_sprites + gen_i + "yellow/gray/", info, "png"
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_i + "yellow/back/", info, 'png'
+                            poke_sprites + gen_i + "yellow/back/", info, "png"
                         ),
                         "back_gray": try_image_names(
-                            poke_sprites + gen_i + "yellow/back/gray/", info, 'png'
+                            poke_sprites + gen_i + "yellow/back/gray/", info, "png"
                         ),
                     },
                 },
                 "generation-ii": {
                     "crystal": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_ii + "crystal/", info, 'png'
+                            poke_sprites + gen_ii + "crystal/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_ii + "crystal/shiny/", info, 'png'
+                            poke_sprites + gen_ii + "crystal/shiny/", info, "png"
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_ii + "crystal/back/", info, 'png'
+                            poke_sprites + gen_ii + "crystal/back/", info, "png"
                         ),
                         "back_shiny": try_image_names(
-                            poke_sprites + gen_ii + "crystal/back/shiny/", info, 'png'
+                            poke_sprites + gen_ii + "crystal/back/shiny/", info, "png"
                         ),
                     },
                     "gold": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_ii + "gold/", info, 'png'
+                            poke_sprites + gen_ii + "gold/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_ii + "gold/shiny/", info, 'png'
+                            poke_sprites + gen_ii + "gold/shiny/", info, "png"
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_ii + "gold/back/", info, 'png'
+                            poke_sprites + gen_ii + "gold/back/", info, "png"
                         ),
                         "back_shiny": try_image_names(
-                            poke_sprites + gen_ii + "gold/back/shiny/", info, 'png'
+                            poke_sprites + gen_ii + "gold/back/shiny/", info, "png"
                         ),
                     },
                     "silver": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_ii + "silver/", info, 'png'
+                            poke_sprites + gen_ii + "silver/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_ii + "silver/shiny/", info, 'png'
+                            poke_sprites + gen_ii + "silver/shiny/", info, "png"
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_ii + "silver/back/", info, 'png'
+                            poke_sprites + gen_ii + "silver/back/", info, "png"
                         ),
                         "back_shiny": try_image_names(
-                            poke_sprites + gen_ii + "silver/back/shiny/", info, 'png'
+                            poke_sprites + gen_ii + "silver/back/shiny/", info, "png"
                         ),
                     },
                 },
                 "generation-iii": {
                     "emerald": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_iii + "emerald/", info, 'png'
+                            poke_sprites + gen_iii + "emerald/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_iii + "emerald/shiny/", info, 'png'
+                            poke_sprites + gen_iii + "emerald/shiny/", info, "png"
                         ),
                     },
                     "firered-leafgreen": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_iii + "firered-leafgreen/", info, 'png'
+                            poke_sprites + gen_iii + "firered-leafgreen/", info, "png"
                         ),
                         "front_shiny": try_image_names(
                             poke_sprites + gen_iii + "firered-leafgreen/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_default": try_image_names(
                             poke_sprites + gen_iii + "firered-leafgreen/back/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny": try_image_names(
                             poke_sprites + gen_iii + "firered-leafgreen/back/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                     "ruby-sapphire": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_iii + "ruby-sapphire/", info, 'png'
+                            poke_sprites + gen_iii + "ruby-sapphire/", info, "png"
                         ),
                         "front_shiny": try_image_names(
                             poke_sprites + gen_iii + "ruby-sapphire/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_default": try_image_names(
                             poke_sprites + gen_iii + "ruby-sapphire/back/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny": try_image_names(
                             poke_sprites + gen_iii + "ruby-sapphire/back/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                 },
                 "generation-iv": {
                     "diamond-pearl": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_iv + "diamond-pearl/", info, 'png'
+                            poke_sprites + gen_iv + "diamond-pearl/", info, "png"
                         ),
                         "front_female": try_image_names(
                             poke_sprites + gen_iv + "diamond-pearl/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny": try_image_names(
                             poke_sprites + gen_iv + "diamond-pearl/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny_female": try_image_names(
                             poke_sprites + gen_iv + "diamond-pearl/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_iv + "diamond-pearl/back/", info, 'png'
+                            poke_sprites + gen_iv + "diamond-pearl/back/", info, "png"
                         ),
                         "back_female": try_image_names(
                             poke_sprites + gen_iv + "diamond-pearl/back/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny": try_image_names(
                             poke_sprites + gen_iv + "diamond-pearl/back/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny_female": try_image_names(
                             poke_sprites + gen_iv + "diamond-pearl/back/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                     "heartgold-soulsilver": {
                         "front_default": try_image_names(
                             poke_sprites + gen_iv + "heartgold-soulsilver/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_female": try_image_names(
                             poke_sprites + gen_iv + "heartgold-soulsilver/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny": try_image_names(
                             poke_sprites + gen_iv + "heartgold-soulsilver/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny_female": try_image_names(
                             poke_sprites
                             + gen_iv
                             + "heartgold-soulsilver/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_default": try_image_names(
                             poke_sprites + gen_iv + "heartgold-soulsilver/back/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_female": try_image_names(
                             poke_sprites + gen_iv + "heartgold-soulsilver/back/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny": try_image_names(
                             poke_sprites + gen_iv + "heartgold-soulsilver/back/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny_female": try_image_names(
                             poke_sprites
                             + gen_iv
                             + "heartgold-soulsilver/back/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                     "platinum": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_iv + "platinum/", info, 'png'
+                            poke_sprites + gen_iv + "platinum/", info, "png"
                         ),
                         "front_female": try_image_names(
-                            poke_sprites + gen_iv + "platinum/female/", info, 'png'
+                            poke_sprites + gen_iv + "platinum/female/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_iv + "platinum/shiny/", info, 'png'
+                            poke_sprites + gen_iv + "platinum/shiny/", info, "png"
                         ),
                         "front_shiny_female": try_image_names(
                             poke_sprites + gen_iv + "platinum/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_iv + "platinum/back/", info, 'png'
+                            poke_sprites + gen_iv + "platinum/back/", info, "png"
                         ),
                         "back_female": try_image_names(
                             poke_sprites + gen_iv + "platinum/back/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny": try_image_names(
                             poke_sprites + gen_iv + "platinum/back/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny_female": try_image_names(
                             poke_sprites + gen_iv + "platinum/back/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                 },
                 "generation-v": {
                     "black-white": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_v + "black-white/", info, 'png'
+                            poke_sprites + gen_v + "black-white/", info, "png"
                         ),
                         "front_female": try_image_names(
-                            poke_sprites + gen_v + "black-white/female/", info, 'png'
+                            poke_sprites + gen_v + "black-white/female/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_v + "black-white/shiny/", info, 'png'
+                            poke_sprites + gen_v + "black-white/shiny/", info, "png"
                         ),
                         "front_shiny_female": try_image_names(
                             poke_sprites + gen_v + "black-white/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_default": try_image_names(
-                            poke_sprites + gen_v + "black-white/back/", info, 'png'
+                            poke_sprites + gen_v + "black-white/back/", info, "png"
                         ),
                         "back_female": try_image_names(
                             poke_sprites + gen_v + "black-white/back/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny": try_image_names(
                             poke_sprites + gen_v + "black-white/back/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "back_shiny_female": try_image_names(
                             poke_sprites + gen_v + "black-white/back/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "animated": {
                             "front_default": try_image_names(
                                 poke_sprites + gen_v + "black-white/animated/",
-                                info, 'gif',
+                                info,
+                                "gif",
                             ),
                             "front_female": try_image_names(
                                 poke_sprites + gen_v + "black-white/animated/female/",
-                                info, 'gif',
+                                info,
+                                "gif",
                             ),
                             "front_shiny": try_image_names(
                                 poke_sprites + gen_v + "black-white/animated/shiny/",
-                                info, 'gif',
+                                info,
+                                "gif",
                             ),
                             "front_shiny_female": try_image_names(
                                 poke_sprites
                                 + gen_v
-                                + "black-white/animated/shiny/female/"
-                                , info, 'gif'
+                                + "black-white/animated/shiny/female/",
+                                info,
+                                "gif",
                             ),
                             "back_default": try_image_names(
                                 poke_sprites + gen_v + "black-white/animated/back/",
-                                info, 'gif',
+                                info,
+                                "gif",
                             ),
                             "back_female": try_image_names(
                                 poke_sprites
                                 + gen_v
-                                + "black-white/animated/back/female/"
-                                , info, 'gif'
+                                + "black-white/animated/back/female/",
+                                info,
+                                "gif",
                             ),
                             "back_shiny": try_image_names(
                                 poke_sprites
                                 + gen_v
-                                + "black-white/animated/back/shiny/"
-                                , info, 'gif'
+                                + "black-white/animated/back/shiny/",
+                                info,
+                                "gif",
                             ),
                             "back_shiny_female": try_image_names(
                                 poke_sprites
                                 + gen_v
-                                + "black-white/animated/back/shiny/female/"
-                                , info, 'gif'
+                                + "black-white/animated/back/shiny/female/",
+                                info,
+                                "gif",
                             ),
                         },
                     }
@@ -1707,35 +1743,39 @@ def _build_pokemons():
                     "omegaruby-alphasapphire": {
                         "front_default": try_image_names(
                             poke_sprites + gen_vi + "omegaruby-alphasapphire/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_female": try_image_names(
                             poke_sprites + gen_vi + "omegaruby-alphasapphire/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny": try_image_names(
                             poke_sprites + gen_vi + "omegaruby-alphasapphire/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny_female": try_image_names(
                             poke_sprites
                             + gen_vi
                             + "omegaruby-alphasapphire/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                     "x-y": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_vi + "x-y/", info, 'png'
+                            poke_sprites + gen_vi + "x-y/", info, "png"
                         ),
                         "front_female": try_image_names(
-                            poke_sprites + gen_vi + "x-y/female/", info, 'png'
+                            poke_sprites + gen_vi + "x-y/female/", info, "png"
                         ),
                         "front_shiny": try_image_names(
-                            poke_sprites + gen_vi + "x-y/shiny/", info, 'png'
+                            poke_sprites + gen_vi + "x-y/shiny/", info, "png"
                         ),
                         "front_shiny_female": try_image_names(
-                            poke_sprites + gen_vi + "x-y/shiny/female/", info, 'png'
+                            poke_sprites + gen_vi + "x-y/shiny/female/", info, "png"
                         ),
                     },
                 },
@@ -1743,39 +1783,43 @@ def _build_pokemons():
                     "ultra-sun-ultra-moon": {
                         "front_default": try_image_names(
                             poke_sprites + gen_vii + "ultra-sun-ultra-moon/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_female": try_image_names(
                             poke_sprites + gen_vii + "ultra-sun-ultra-moon/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny": try_image_names(
                             poke_sprites + gen_vii + "ultra-sun-ultra-moon/shiny/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                         "front_shiny_female": try_image_names(
                             poke_sprites
                             + gen_vii
                             + "ultra-sun-ultra-moon/shiny/female/",
-                            info, 'png',
+                            info,
+                            "png",
                         ),
                     },
                     "icons": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_vii + "icons/", info, 'png'
+                            poke_sprites + gen_vii + "icons/", info, "png"
                         ),
                         "front_female": try_image_names(
-                            poke_sprites + gen_vii + "icons/female/", info, 'png'
+                            poke_sprites + gen_vii + "icons/female/", info, "png"
                         ),
                     },
                 },
                 "generation-viii": {
                     "icons": {
                         "front_default": try_image_names(
-                            poke_sprites + gen_viii + "icons/", info, 'png'
+                            poke_sprites + gen_viii + "icons/", info, "png"
                         ),
                         "front_female": try_image_names(
-                            poke_sprites + gen_viii + "icons/female/", info, 'png'
+                            poke_sprites + gen_viii + "icons/female/", info, "png"
                         ),
                     },
                 },
@@ -1863,11 +1907,7 @@ def _build_pokemons():
         pokemon = Pokemon.objects.get(pk=int(pokemon_id))
         species_id = getattr(pokemon, "pokemon_species_id")
         if form_identifier:
-            file_name_str = "%s-%s.%s" % (
-                species_id,
-                form_identifier,
-                extension
-            )
+            file_name_str = "%s-%s.%s" % (species_id, form_identifier, extension)
             file_name_int = "%s.%s" % (pokemon_id, extension)
             file_name = (
                 file_name_int
@@ -1881,10 +1921,10 @@ def _build_pokemons():
     def csv_record_to_objects(info):
         poke_sprites = "pokemon/"
         sprites = {
-            "front_default": try_image_names(poke_sprites, info, 'png'),
-            "front_shiny": try_image_names(poke_sprites + "shiny/", info, 'png'),
-            "back_default": try_image_names(poke_sprites + "back/", info, 'png'),
-            "back_shiny": try_image_names(poke_sprites + "back/shiny/", info, 'png'),
+            "front_default": try_image_names(poke_sprites, info, "png"),
+            "front_shiny": try_image_names(poke_sprites + "shiny/", info, "png"),
+            "back_default": try_image_names(poke_sprites + "back/", info, "png"),
+            "back_shiny": try_image_names(poke_sprites + "back/shiny/", info, "png"),
             "front_female": try_image_names(poke_sprites + "female/", info, "png"),
             "front_shiny_female": try_image_names(
                 poke_sprites + "shiny/female/", info, "png"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

Checks both naming conventions when linking images for both the `/pokemon` and `/pokemon-form` endpoints. This results in more sprites served to the public.

More details here: https://github.com/PokeAPI/sprites/pull/42
