### PR TITLE
Replaces `nobody` with custom user

### DIFF
--- a/Resources/docker/app/Dockerfile
+++ b/Resources/docker/app/Dockerfile
@@ -15,6 +15,9 @@ RUN \
     apk --purge del .build-deps
 ADD . /code/
 
-USER nobody
+RUN addgroup -g 1000 -S pokeapi && \
+    adduser -u 1000 -S pokeapi -G pokeapi
+
+USER pokeapi
 CMD gunicorn config.wsgi:application -c gunicorn.py.ini
 EXPOSE 80

--- a/Resources/docker/app/README.md
+++ b/Resources/docker/app/README.md
@@ -16,6 +16,8 @@
 
 - [`latest`](https://github.com/PokeAPI/pokeapi/blob/master/Resources/docker/app/Dockerfile)
 
+> `pokeapi` uses `python:3.7-alpine` as base image.
+
 ## What is PokeAPI?
 
 PokeAPI is a full RESTful API linked to an extensive database detailing everything about the Pokémon main game series.
@@ -30,6 +32,19 @@ This container connects to a Postgres database via the environment variables `PO
 
 The container connects to a Redis cache via the environment variable `REDIS_CONNECTION_STRING`.
 
-### Run the container using Compose
+### Run the container
 
-The container exposes port `80`. It's recommended to use the provided [docker-compose.yml](https://github.com/PokeAPI/pokeapi/blob/master/docker-compose.yml) to start a container from this image.
+The container exposes port `80`. It needs a PostgreSQL and a Redis instance to connect to. Refer to the section [How to use this image](./how-to-use-this-image) for mapping the environment variables.
+
+It's recommended to use the provided [docker-compose.yml](https://github.com/PokeAPI/pokeapi/blob/master/docker-compose.yml) to start a container from this image.
+
+### Build the data
+
+Pokémon data isn't automatically present in this image. All Pokémon data is persisted in a PostgreSQL database and thus needs to be built.
+
+When the container is up and running, run the following shell commands:
+
+```sh
+docker exec pokeapi python manage.py migrate --settings=config.docker-compose
+docker exec pokeapi sh -c 'echo "from data.v2.build import build_all; build_all()" | python manage.py shell --settings=config.docker-compose'
+```

--- a/Resources/scripts/updater.sh
+++ b/Resources/scripts/updater.sh
@@ -175,7 +175,7 @@ run_updater() {
   fi
 
   # Run the updater
-  docker run --privileged -e REPO_POKEAPI_CHECKOUT_OBJECT="$CIRCLE_SHA1" -e COMMIT_EMAIL="$email" -e COMMIT_NAME="$username" -e BRANCH_NAME="$branch_name" -e REPO_POKEAPI="https://github.com/$org/$engine_repo.git" -e REPO_DATA="https://$MACHINE_USER_GITHUB_API_TOKEN@github.com/$org/$data_repo.git" -e RUN_AS=root pokeapi-updater
+  docker run --privileged -e REPO_POKEAPI_CHECKOUT_OBJECT="$CIRCLE_SHA1" -e COMMIT_EMAIL="$email" -e COMMIT_NAME="$username" -e BRANCH_NAME="$branch_name" -e REPO_POKEAPI="https://github.com/$org/$engine_repo.git" -e REPO_DATA="https://$MACHINE_USER_GITHUB_API_TOKEN@github.com/$org/$data_repo.git" -e RUN_AS='root' pokeapi-updater
   return_code=$?
   if [ "$return_code" -eq 2 ]; then
     cleanexit 'no-new-data' "Generated data is the same as old data, skipping deploy"

--- a/Resources/scripts/updater.sh
+++ b/Resources/scripts/updater.sh
@@ -175,7 +175,7 @@ run_updater() {
   fi
 
   # Run the updater
-  docker run --privileged -e REPO_POKEAPI_CHECKOUT_OBJECT="$CIRCLE_SHA1" -e COMMIT_EMAIL="$email" -e COMMIT_NAME="$username" -e BRANCH_NAME="$branch_name" -e REPO_POKEAPI="https://github.com/$org/$engine_repo.git" -e REPO_DATA="https://$MACHINE_USER_GITHUB_API_TOKEN@github.com/$org/$data_repo.git" pokeapi-updater
+  docker run --privileged -e REPO_POKEAPI_CHECKOUT_OBJECT="$CIRCLE_SHA1" -e COMMIT_EMAIL="$email" -e COMMIT_NAME="$username" -e BRANCH_NAME="$branch_name" -e REPO_POKEAPI="https://github.com/$org/$engine_repo.git" -e REPO_DATA="https://$MACHINE_USER_GITHUB_API_TOKEN@github.com/$org/$data_repo.git" -e RUN_AS=root pokeapi-updater
   return_code=$?
   if [ "$return_code" -eq 2 ]; then
     cleanexit 'no-new-data' "Generated data is the same as old data, skipping deploy"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build:
       context: .
       dockerfile: ./Resources/docker/app/Dockerfile
-    user: {RUN_AS:-pokeapi}
+    user: ${RUN_AS:-pokeapi}
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pokemon}
       POSTGRES_USER: ${POSTGRES_USER:-ash}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     build:
       context: .
       dockerfile: ./Resources/docker/app/Dockerfile
+    user: {RUN_AS:-pokeapi}
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pokemon}
       POSTGRES_USER: ${POSTGRES_USER:-ash}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

CircleCI apparently kills our container if it's not run by `root`. I don't know why but the only way to make it work is to run it as root.

Recently I merged a PR that changed the user running the container to `nobody`. This PR drops the use of `nobody`, adds a new `pokeapi` user, and allows in our `docker-compose.yml` to overwrite it with `root` so that CircleCI doesn't kill us.

