### PR TITLE
'characteristic' endpoint now contains 31 in 'possible_values' when appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 *.env
 Resources/nginx/ssl/*
 !Resources/nginx/ssl/*.sample.*
+.idea*

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -487,7 +487,7 @@ class CharacteristicDetailSerializer(serializers.ModelSerializer):
 
         mod = obj.gene_mod_5
         values = []
-        while mod <= 30:
+        while mod <= 31:
             values.append(mod)
             mod += 5
 

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -4338,7 +4338,6 @@ class APITests(APIData, APITestCase):
         )
 
     def test_characteristic_values(self):
-        l = []
         # check for all 5 possible values of gene_modulo
         for modulo in range(5):
             characteristic = self.setup_characteristic_data(gene_mod_5=modulo)

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -4337,6 +4337,21 @@ class APITests(APIData, APITestCase):
             "{}{}/stat/{}/".format(TEST_HOST, API_V2, characteristic.stat.pk),
         )
 
+    def test_characteristic_values(self):
+        l = []
+        # check for all 5 possible values of gene_modulo
+        for modulo in range(5):
+            characteristic = self.setup_characteristic_data(gene_mod_5=modulo)
+            # note that 'possible_values' is computed solely from gene_modulo
+            # thus it is fine that our test characteristics are indexed 1-5
+            result = self.client.get(
+                "{}/characteristic/{}/".format(API_V2, characteristic.pk))
+            for i in range(len(result.data['possible_values'])):
+                self.assertEqual(
+                    result.data['possible_values'][i], characteristic.gene_mod_5 + i * 5
+                )
+
+
     # Nature Tests
     def test_nature_api(self):
 

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -11,7 +11,7 @@ API_V2 = "/api/v2"
 
 
 class APIData:
-    """ Data Initializers"""
+    """Data Initializers"""
 
     # Gender Data
     @classmethod
@@ -4345,12 +4345,12 @@ class APITests(APIData, APITestCase):
             # note that 'possible_values' is computed solely from gene_modulo
             # thus it is fine that our test characteristics are indexed 1-5
             result = self.client.get(
-                "{}/characteristic/{}/".format(API_V2, characteristic.pk))
-            for i in range(len(result.data['possible_values'])):
+                "{}/characteristic/{}/".format(API_V2, characteristic.pk)
+            )
+            for i in range(len(result.data["possible_values"])):
                 self.assertEqual(
-                    result.data['possible_values'][i], characteristic.gene_mod_5 + i * 5
+                    result.data["possible_values"][i], characteristic.gene_mod_5 + i * 5
                 )
-
 
     # Nature Tests
     def test_nature_api(self):


### PR DESCRIPTION
The while loop which generates the 'possible_values' field for the 'characteristic' endpoint does not allow for a value of 31 (the maximum IV value) to be added to 'possible_values'. Adjusting the value this loop compares against rectifies the issue. This specifically affects the second row in the table on https://bulbapedia.bulbagarden.net/wiki/Characteristic , which corresponds to the characteristics with IDs 7-12. Previously their 'possible_values' fields returned [1,6,11,16,21,26]. After changes, they return [1,6,11,16,21,26,31].

Also included is a new test, which tests that 'possible_values' contains the correct values for each of the 5 possible values of 'gene_modulo'.

All tests pass after changes, and when running the API locally, produces the expected results.