### PR TITLE
Update Farfetch'd's species name

### DIFF
--- a/data/v2/csv/pokemon_species_names.csv
+++ b/data/v2/csv/pokemon_species_names.csv
@@ -907,9 +907,9 @@ pokemon_species_id,local_language_id,name,genus
 83,4,大蔥鴨,黃嘴鴨寶可夢
 83,5,Canarticho,Pokémon Canard Fou
 83,6,Porenta,Wildente
-83,7,Farfetch’d,Pokémon Pato Salvaje
-83,8,Farfetch’d,Pokémon Selvanatra
-83,9,Farfetch’d,Wild Duck Pokémon
+83,7,Farfetch'd,Pokémon Pato Salvaje
+83,8,Farfetch'd,Pokémon Selvanatra
+83,9,Farfetch'd,Wild Duck Pokémon
 83,11,カモネギ,かるがもポケモン
 83,12,大葱鸭,黄嘴鸭宝可梦
 84,1,ドードー,ふたごどりポケモン


### PR DESCRIPTION
Starting in Sword and Shield, Farfetch'd's species name now uses the apostrophe `'` character instead of the right single quote `’` character as it had since Gen 1. This matches the naming of the "Sirfetch'd" species and "Galarian Farfetch'd" form which PokeAPI already accounts for correctly.

Note that this is only relevant to Farfetch'd's English, Spanish, and Italian names as, in other languages, its name doesn't contain an apostrophe. The `"names"` tags for these languages have been changed to account for this.