### PR TITLE
Add pokeapi-scala to wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ This k8s setup creates all k8s resources inside the _Namespace_ `pokeapi`, run `
 | Swift | [kinkofer/PokemonAPI](https://github.com/kinkofer/PokemonAPI) | |
 | Typescript server-side/client-side | [Gabb-c/Pokenode-ts](https://github.com/Gabb-c/pokenode-ts) | _Auto caching_ |
 | Python | [beastmatser/aiopokeapi](https://github.com/beastmatser/aiopokeapi) | _Auto caching, asynchronous_
+| Scala | [juliano/pokeapi-scala](https://github.com/juliano/pokeapi-scala) | _Auto caching_ |
 
 ## Donations
 


### PR DESCRIPTION
I've written a [wrapper to the api in Scala 3](https://github.com/juliano/pokeapi-scala), this pr adds the [already published](https://search.maven.org/artifact/io.github.juliano/pokeapi-scala_3/0.1.0/jar) library to the list of wrapper libraries.