### PR TITLE
Fix official_artwork missing shiny

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1432,7 +1432,10 @@ def _build_pokemons():
                 "official-artwork": {
                     "front_default": try_image_names(
                         poke_sprites + official_art, info, "png"
-                    )
+                    ),
+                    "front_shiny": try_image_names(
+                        poke_sprites + official_art + "shiny/", info, "png"
+                    ),
                 },
             },
             "versions": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->
This should be a fix for the issue [93](https://github.com/PokeAPI/sprites/issues/93) on the [sprites repository](https://github.com/PokeAPI/sprites/issues), but as discussed it will not totally fix the mismatching images.