### PR TITLE
Update requirements.txt for virtual python enviroments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ djangorestframework==3.9.4
 drf-ujson==1.2.0
 gunicorn==20.1.0
 mimeparse==0.1.3
-psycopg2==2.8.6
+psycopg2-binary==2.9.5
 python-dateutil==2.8.1
 python-mimeparse==1.6.0
 simplejson==3.17.2


### PR DESCRIPTION
Fix error when execute `make install` in virtual python enviroment.

When executing `make install` in a virtual python enviroment they give a error on psycog2 package, saying:

```
Collecting psycopg2==2.8.6
  Downloading psycopg2-2.8.6.tar.gz (383 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 383.8/383.8 kB 22.6 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      /home/guikipt/Servers/pokeapi/venv/lib/python3.11/site-packages/setuptools/config/setupcfg.py:520: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
        warnings.warn(msg, warning_class)
      running egg_info
      creating /tmp/pip-pip-egg-info-nuqa31gi/psycopg2.egg-info
      writing /tmp/pip-pip-egg-info-nuqa31gi/psycopg2.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-nuqa31gi/psycopg2.egg-info/dependency_links.txt
      writing top-level names to /tmp/pip-pip-egg-info-nuqa31gi/psycopg2.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-nuqa31gi/psycopg2.egg-info/SOURCES.txt'
      
      Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
      
      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
make: *** [Makefile:13: install] Erro 1
```

I fixed it changing to psycopg2-binary like the description of the error say to use instead psycog2