### PR TITLE
Update pokemon_species_names.csv

### DIFF
--- a/data/v2/csv/pokemon_species_names.csv
+++ b/data/v2/csv/pokemon_species_names.csv
@@ -9993,7 +9993,7 @@ pokemon_species_id,local_language_id,name,genus
 910,11,アチゲータ,
 910,12,炙烫鳄,火鳄宝可梦
 911,1,ラウドボーン,シンガーポケモン
-911,2,Loudbone,
+911,2,Laudbon,
 911,3,라우드본,
 911,4,骨紋巨聲鱷,歌手寶可夢
 911,5,Flâmigator,
@@ -10047,7 +10047,7 @@ pokemon_species_id,local_language_id,name,genus
 916,11,パフュートン,
 916,12,飘香豚,猪宝可梦
 917,1,タマンチュラ,いとだまポケモン
-917,2,Tamanchura,
+917,2,Tamantula,
 917,3,타랜툴라,
 917,4,團珠蛛,線球寶可夢
 917,5,Tissenboule,
@@ -10056,7 +10056,7 @@ pokemon_species_id,local_language_id,name,genus
 917,11,タマンチュラ,
 917,12,团珠蛛,线球宝可梦
 918,1,ワナイダー,トラップポケモン
-918,2,Wanaidā,
+918,2,Wanaider,
 918,3,트래피더,
 918,4,操陷蛛,陷阱寶可夢
 918,5,Filentrappe,
@@ -10128,7 +10128,7 @@ pokemon_species_id,local_language_id,name,genus
 925,11,イッカネズミ,
 925,12,一家鼠,家族宝可梦
 926,1,パピモッチ,こいぬポケモン
-926,2,Papimocchi,
+926,2,Pupimocchi,
 926,3,쫀도기,
 926,4,狗仔包,小狗寶可夢
 926,5,Pâtachiot,
@@ -10146,7 +10146,7 @@ pokemon_species_id,local_language_id,name,genus
 927,11,バウッツェル,
 927,12,麻花犬,狗宝可梦
 928,1,ミニーブ,オリーブポケモン
-928,2,Minību,
+928,2,Minive,
 928,3,미니브,
 928,4,迷你芙,橄欖寶可夢
 928,5,Olivini,
@@ -10155,7 +10155,7 @@ pokemon_species_id,local_language_id,name,genus
 928,11,ミニーブ,
 928,12,迷你芙,橄榄宝可梦
 929,1,オリーニョ,オリーブポケモン
-929,2,Orīnyo,
+929,2,Olinyo,
 929,3,올리뇨,
 929,4,奧利紐,橄欖寶可夢
 929,5,Olivado,
@@ -10164,7 +10164,7 @@ pokemon_species_id,local_language_id,name,genus
 929,11,オリーニョ,
 929,12,奥利纽,橄榄宝可梦
 930,1,オリーヴァ,オリーブポケモン
-930,2,Orīva,
+930,2,Oliva,
 930,3,올리르바,
 930,4,奧利瓦,橄欖寶可夢
 930,5,Arboliva,
@@ -10191,7 +10191,7 @@ pokemon_species_id,local_language_id,name,genus
 932,11,コジオ,
 932,12,盐石宝,岩盐宝可梦
 933,1,ジオヅム,がんえんポケモン
-933,2,Jiozumu,
+933,2,Jiodumu,
 933,3,스태솔트,
 933,4,鹽石壘,岩鹽寶可夢
 933,5,Amassel,
@@ -10200,7 +10200,7 @@ pokemon_species_id,local_language_id,name,genus
 933,11,ジオヅム,
 933,12,盐石垒,岩盐宝可梦
 934,1,キョジオーン,がんえんポケモン
-934,2,Kyojiōn,
+934,2,Kyojiohn,
 934,3,콜로솔트,
 934,4,鹽石巨靈,岩鹽寶可夢
 934,5,Gigansel,
@@ -10245,7 +10245,7 @@ pokemon_species_id,local_language_id,name,genus
 938,11,ズピカ,
 938,12,光蚪仔,电蝌蚪宝可梦
 939,1,ハラバリー,でんきがえるポケモン
-939,2,Harabarī,
+939,2,Harabarie,
 939,3,찌리배리,
 939,4,電肚蛙,電蛙寶可夢
 939,5,Ampibidou,
@@ -10281,7 +10281,7 @@ pokemon_species_id,local_language_id,name,genus
 942,11,オラチフ,
 942,12,偶叫獒,小辈宝可梦
 943,1,マフィティフ,おやぶんポケモン
-943,2,Mafitifu,
+943,2,Mafitiff,
 943,3,마피티프,
 943,4,獒教父,大佬寶可夢
 943,5,Dogrino,
@@ -10290,7 +10290,7 @@ pokemon_species_id,local_language_id,name,genus
 943,11,マフィティフ,
 943,12,獒教父,大佬宝可梦
 944,1,シルシュルー,どくねずみポケモン
-944,2,Shirushurū,
+944,2,Shirushrew,
 944,3,땃쭈르,
 944,4,滋汁鼴,毒鼠寶可夢
 944,5,Gribouraigne,
@@ -10299,7 +10299,7 @@ pokemon_species_id,local_language_id,name,genus
 944,11,シルシュルー,
 944,12,滋汁鼹,毒鼠宝可梦
 945,1,タギングル,どくざるポケモン
-945,2,Taginguru,
+945,2,Taggingru,
 945,3,태깅구르,
 945,4,塗標客,毒猴寶可夢
 945,5,Tag-Tag,
@@ -10353,7 +10353,7 @@ pokemon_species_id,local_language_id,name,genus
 950,11,ガケガニ,
 950,12,毛崖蟹,埋伏宝可梦
 951,1,カプサイジ,ハバネロポケモン
-951,2,Kapusaiji,
+951,2,Capsaiji,
 951,3,캡싸이,
 951,4,熱辣娃,熱辣寶可夢
 951,5,Pimito,
@@ -10362,7 +10362,7 @@ pokemon_species_id,local_language_id,name,genus
 951,11,カプサイジ,
 951,12,热辣娃,热辣宝可梦
 952,1,スコヴィラン,ハバネロポケモン
-952,2,Sukoviran,
+952,2,Scovillain,
 952,3,스코빌런,
 952,4,狠辣椒,熱辣寶可夢
 952,5,Scovilain,
@@ -10380,7 +10380,7 @@ pokemon_species_id,local_language_id,name,genus
 953,11,シガロコ,
 953,12,虫滚泥,滚动宝可梦
 954,1,ベラカス,ころがしポケモン
-954,2,Berakasu,
+954,2,Beracas,
 954,3,베라카스,
 954,4,蟲甲聖,滾動寶可夢
 954,5,Bérasca,
@@ -10398,7 +10398,7 @@ pokemon_species_id,local_language_id,name,genus
 955,11,ヒラヒナ,
 955,12,飘飘雏,褶边宝可梦
 956,1,クエスパトラ,ダチョウポケモン
-956,2,Kaesupatora,
+956,2,Cuespatra,
 956,3,클레스퍼트라,
 956,4,超能艷鴕,鴕鳥寶可夢
 956,5,Cléopsytra,
@@ -10488,7 +10488,7 @@ pokemon_species_id,local_language_id,name,genus
 965,11,ブロロン,
 965,12,噗隆隆,单汽缸宝可梦
 966,1,ブロロローム,たきとうポケモン
-966,2,Burororōmu,
+966,2,Burororoom,
 966,3,부르르룸,
 966,4,普隆隆姆,多汽缸寶可夢
 966,5,Vrombotor,
@@ -10515,7 +10515,7 @@ pokemon_species_id,local_language_id,name,genus
 968,11,ミミズズ,
 968,12,拖拖蚓,蚯蚓宝可梦
 969,1,キラーメ,こうせきポケモン
-969,2,Kirāme,
+969,2,Kirame,
 969,3,초롱순,
 969,4,晶光芽,礦石寶可夢
 969,5,Germéclat,
@@ -10524,7 +10524,7 @@ pokemon_species_id,local_language_id,name,genus
 969,11,キラーメ,
 969,12,晶光芽,矿石宝可梦
 970,1,キラフロル,こうせきポケモン
-970,2,Kirafuroru,
+970,2,Kiraflor,
 970,3,킬라플로르,
 970,4,晶光花,礦石寶可夢
 970,5,Floréclat,
@@ -10542,7 +10542,7 @@ pokemon_species_id,local_language_id,name,genus
 971,11,ボチ,
 971,12,墓仔狗,鬼犬宝可梦
 972,1,ハカドッグ,おばけいぬポケモン
-972,2,Hakadoggu,
+972,2,Hakadog,
 972,3,묘두기,
 972,4,墓揚犬,鬼犬寶可夢
 972,5,Tomberro,
@@ -10569,7 +10569,7 @@ pokemon_species_id,local_language_id,name,genus
 974,11,アルクジラ,
 974,12,走鲸,陆鲸宝可梦
 975,1,ハルクジラ,りくくじらポケモン
-975,2,Harukajira,
+975,2,Hulkujira,
 975,3,우락고래,
 975,4,浩大鯨,陸鯨寶可夢
 975,5,Balbalèze,
@@ -10578,7 +10578,7 @@ pokemon_species_id,local_language_id,name,genus
 975,11,ハルクジラ,
 975,12,浩大鲸,陆鲸宝可梦
 976,1,ミガルーサ,きりはなしポケモン
-976,2,Migarūsa,
+976,2,Migalusa,
 976,3,가비루사,
 976,4,輕身鱈,卸除寶可夢
 976,5,Délestin,
@@ -10623,7 +10623,7 @@ pokemon_species_id,local_language_id,name,genus
 980,11,ドオー,
 980,12,土王,刺鱼宝可梦
 981,1,リキキリン,くびながポケモン
-981,2,Rikikirn,
+981,2,Rikikirin,
 981,3,키키링,
 981,4,奇麒麟,長頸寶可夢
 981,5,Farigiraf,
@@ -10632,7 +10632,7 @@ pokemon_species_id,local_language_id,name,genus
 981,11,リキキリン,
 981,12,奇麒麟,长颈宝可梦
 982,1,ノココッチ,つちへびポケモン
-982,2,Nokokotchi,
+982,2,Nokokocchi,
 982,3,노고고치,
 982,4,土龍節節,地蛇寶可夢
 982,5,Deusolourdo,
@@ -10650,7 +10650,7 @@ pokemon_species_id,local_language_id,name,genus
 983,11,ドドゲザン,
 983,12,仆刀将军,大刀宝可梦
 984,1,イダイナキバ,パラドックスポケモン
-984,2,Idaina Kiba,
+984,2,Idainakiba,
 984,3,위대한엄니,
 984,4,雄偉牙,悖謬寶可夢
 984,5,Fort-Ivoire,
@@ -10677,7 +10677,7 @@ pokemon_species_id,local_language_id,name,genus
 986,11,アラブルタケ,
 986,12,猛恶菇,悖谬宝可梦
 987,1,ハバタクカミ,パラドックスポケモン
-987,2,Habtakukami,
+987,2,Habatakukami,
 987,3,날개치는머리,
 987,4,振翼髮,悖謬寶可夢
 987,5,Flotte-Mèche,
@@ -10686,7 +10686,7 @@ pokemon_species_id,local_language_id,name,genus
 987,11,ハバタクカミ,
 987,12,振翼发,悖谬宝可梦
 988,1,チヲハウハネ,パラドックスポケモン
-988,2,Chiohauhane,
+988,2,Chiwohauhane,
 988,3,땅을기는날개,
 988,4,爬地翅,悖謬寶可夢
 988,5,Rampe-Ailes,
@@ -10767,7 +10767,7 @@ pokemon_species_id,local_language_id,name,genus
 996,11,セビエ,
 996,12,凉脊龙,冰鳍宝可梦
 997,1,セゴール,こおりビレポケモン
-997,2,Segōru,
+997,2,Segohru,
 997,3,드니꽁,
 997,4,凍脊龍,冰鰭寶可夢
 997,5,Cryodo,
@@ -10830,7 +10830,7 @@ pokemon_species_id,local_language_id,name,genus
 1003,11,ディンルー,
 1003,12,古鼎鹿,灾厄宝可梦
 1004,1,イーユイ,さいやくポケモン
-1004,2,Īyui,
+1004,2,Yiyui,
 1004,3,위유이,
 1004,4,古玉魚,災厄寶可夢
 1004,5,Yuyu,


### PR DESCRIPTION
As detailed in issue #893
Changed trademarked Japanese names for many ninth-generation Pokémon.