### PR TITLE
Updating MoveDetailSerializer to change $effect_chance to actual number

### DIFF
--- a/data/v2/csv/move_effect_prose.csv
+++ b/data/v2/csv/move_effect_prose.csv
@@ -153,9 +153,7 @@ This move cannot be copied by []{move:mimic} or []{move:mirror-move}, nor select
 The user takes damage instead of being healed if the target has []{ability:liquid-ooze}.
 
 []{move:rapid-spin} will remove this effect.
-
-This effect is passed on by []{move:baton-pass}."
-86,9,Does nothing.,"Does nothing.
+7,9,Has a $e.
 
 This move cannot be used while []{move:gravity} is in effect."
 87,9,Disables the target's last used move for 1-8 turns.,"Disables the target's last used move, preventing its use for 4–7 turns, selected at random, or until the target leaves the [field]{mechanic:field}.  If the target hasn't used a move since entering the [field]{mechanic:field}, if it tried to use a move this turn and [failed]{mechanic:failed},  if its last used move has 0 PP remaining, or if it already has a move disabled, this move will fail."

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -2343,7 +2343,12 @@ class MoveDetailSerializer(serializers.ModelSerializer):
         data = MoveEffectEffectTextSerializer(
             effect_texts, many=True, context=self.context
         ).data
-
+        effect_entries = data[0]
+        for i, k in enumerate(effect_entries):
+            print(i, k)
+            if '$effect_chance%' in effect_entries[k]:
+                data[0][k] = effect_entries[k].replace('$effect_chance', f'{obj.move_effect_chance}')
+    
         return data
 
     def get_effect_change_text(self, obj):


### PR DESCRIPTION
resolve #1024 

Take effects text from the seralizer and loop over dictionary looking for "effect_chance" when it is found, replace it with move_effect_chance.

I know the build file was mentioned in the comments of the issue but I don't see a way to edit the build that can be dynamically edited later. It definitely could be possible but will have to be done b someone with more knowledge on the build file than me.

To test this, it can be deployed to Staging and the endpoints can be hit to confirm changes.