### PR TITLE
Open api support

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -126,7 +126,7 @@ SPECTACULAR_SETTINGS = {
         "All the Pokémon data you'll ever need in one place,"
         "easily accessible through a modern free open-source RESTful API."
     ),
-    "VERSION": "2.8.0",
+    "VERSION": "2.7.0",
 }
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -99,6 +99,7 @@ INSTALLED_APPS = (
     "corsheaders",
     "rest_framework",
     "cachalot",
+    "drf_spectacular",
 ) + CUSTOM_APPS
 
 
@@ -116,6 +117,13 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 20,
     "PAGINATE_BY": 20,
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+# TODO: setting metadata
+SPECTACULAR_SETTINGS = {
+    "TITLE": "The RESTful Pokémon API",
+    "VERSION": "2.7.0",
 }
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -120,10 +120,13 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
-# TODO: setting metadata
 SPECTACULAR_SETTINGS = {
-    "TITLE": "The RESTful Pokémon API",
-    "VERSION": "2.7.0",
+    "TITLE": "Pokémon API",
+    "DESCRIPTION": (
+        "All the Pokémon data you'll ever need in one place,"
+        "easily accessible through a modern free open-source RESTful API."
+    ),
+    "VERSION": "2.8.0",
 }
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,7921 @@
+openapi: 3.0.3
+info:
+  title: Pokémon API
+  version: 2.7.0
+  description: All the Pokémon data you'll ever need in one place,easily accessible
+    through a modern free open-source RESTful API.
+paths:
+  /api/v2/ability/:
+    get:
+      operationId: ability_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - ability
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAbilitySummaryList'
+          description: ''
+  /api/v2/ability/{id}/:
+    get:
+      operationId: ability_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - ability
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AbilityDetail'
+          description: ''
+  /api/v2/berry/:
+    get:
+      operationId: berry_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - berry
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBerrySummaryList'
+          description: ''
+  /api/v2/berry-firmness/:
+    get:
+      operationId: berry_firmness_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - berry-firmness
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBerryFirmnessSummaryList'
+          description: ''
+  /api/v2/berry-firmness/{id}/:
+    get:
+      operationId: berry_firmness_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - berry-firmness
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BerryFirmnessDetail'
+          description: ''
+  /api/v2/berry-flavor/:
+    get:
+      operationId: berry_flavor_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - berry-flavor
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBerryFlavorSummaryList'
+          description: ''
+  /api/v2/berry-flavor/{id}/:
+    get:
+      operationId: berry_flavor_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - berry-flavor
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BerryFlavorDetail'
+          description: ''
+  /api/v2/berry/{id}/:
+    get:
+      operationId: berry_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - berry
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BerryDetail'
+          description: ''
+  /api/v2/characteristic/:
+    get:
+      operationId: characteristic_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - characteristic
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCharacteristicSummaryList'
+          description: ''
+  /api/v2/characteristic/{id}/:
+    get:
+      operationId: characteristic_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this characteristic.
+        required: true
+      tags:
+      - characteristic
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacteristicDetail'
+          description: ''
+  /api/v2/contest-effect/:
+    get:
+      operationId: contest_effect_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - contest-effect
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedContestEffectSummaryList'
+          description: ''
+  /api/v2/contest-effect/{id}/:
+    get:
+      operationId: contest_effect_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this contest effect.
+        required: true
+      tags:
+      - contest-effect
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContestEffectDetail'
+          description: ''
+  /api/v2/contest-type/:
+    get:
+      operationId: contest_type_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - contest-type
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedContestTypeSummaryList'
+          description: ''
+  /api/v2/contest-type/{id}/:
+    get:
+      operationId: contest_type_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this contest type.
+        required: true
+      tags:
+      - contest-type
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContestTypeDetail'
+          description: ''
+  /api/v2/egg-group/:
+    get:
+      operationId: egg_group_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - egg-group
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEggGroupSummaryList'
+          description: ''
+  /api/v2/egg-group/{id}/:
+    get:
+      operationId: egg_group_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - egg-group
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EggGroupDetail'
+          description: ''
+  /api/v2/encounter-condition/:
+    get:
+      operationId: encounter_condition_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - encounter-condition
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEncounterConditionSummaryList'
+          description: ''
+  /api/v2/encounter-condition-value/:
+    get:
+      operationId: encounter_condition_value_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - encounter-condition-value
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEncounterConditionValueSummaryList'
+          description: ''
+  /api/v2/encounter-condition-value/{id}/:
+    get:
+      operationId: encounter_condition_value_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - encounter-condition-value
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncounterConditionValueDetail'
+          description: ''
+  /api/v2/encounter-condition/{id}/:
+    get:
+      operationId: encounter_condition_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - encounter-condition
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncounterConditionDetail'
+          description: ''
+  /api/v2/encounter-method/:
+    get:
+      operationId: encounter_method_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - encounter-method
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEncounterMethodSummaryList'
+          description: ''
+  /api/v2/encounter-method/{id}/:
+    get:
+      operationId: encounter_method_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - encounter-method
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncounterMethodDetail'
+          description: ''
+  /api/v2/evolution-chain/:
+    get:
+      operationId: evolution_chain_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - evolution-chain
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEvolutionChainSummaryList'
+          description: ''
+  /api/v2/evolution-chain/{id}/:
+    get:
+      operationId: evolution_chain_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this evolution chain.
+        required: true
+      tags:
+      - evolution-chain
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvolutionChainDetail'
+          description: ''
+  /api/v2/evolution-trigger/:
+    get:
+      operationId: evolution_trigger_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - evolution-trigger
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEvolutionTriggerSummaryList'
+          description: ''
+  /api/v2/evolution-trigger/{id}/:
+    get:
+      operationId: evolution_trigger_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - evolution-trigger
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvolutionTriggerDetail'
+          description: ''
+  /api/v2/gender/:
+    get:
+      operationId: gender_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - gender
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGenderSummaryList'
+          description: ''
+  /api/v2/gender/{id}/:
+    get:
+      operationId: gender_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - gender
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenderDetail'
+          description: ''
+  /api/v2/generation/:
+    get:
+      operationId: generation_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - generation
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGenerationSummaryList'
+          description: ''
+  /api/v2/generation/{id}/:
+    get:
+      operationId: generation_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - generation
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationDetail'
+          description: ''
+  /api/v2/growth-rate/:
+    get:
+      operationId: growth_rate_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - growth-rate
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGrowthRateSummaryList'
+          description: ''
+  /api/v2/growth-rate/{id}/:
+    get:
+      operationId: growth_rate_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - growth-rate
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrowthRateDetail'
+          description: ''
+  /api/v2/item/:
+    get:
+      operationId: item_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - item
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemSummaryList'
+          description: ''
+  /api/v2/item-attribute/:
+    get:
+      operationId: item_attribute_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - item-attribute
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemAttributeSummaryList'
+          description: ''
+  /api/v2/item-attribute/{id}/:
+    get:
+      operationId: item_attribute_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - item-attribute
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemAttributeDetail'
+          description: ''
+  /api/v2/item-category/:
+    get:
+      operationId: item_category_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - item-category
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemCategorySummaryList'
+          description: ''
+  /api/v2/item-category/{id}/:
+    get:
+      operationId: item_category_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - item-category
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemCategoryDetail'
+          description: ''
+  /api/v2/item-fling-effect/:
+    get:
+      operationId: item_fling_effect_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - item-fling-effect
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemFlingEffectSummaryList'
+          description: ''
+  /api/v2/item-fling-effect/{id}/:
+    get:
+      operationId: item_fling_effect_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - item-fling-effect
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemFlingEffectDetail'
+          description: ''
+  /api/v2/item-pocket/:
+    get:
+      operationId: item_pocket_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - item-pocket
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemPocketSummaryList'
+          description: ''
+  /api/v2/item-pocket/{id}/:
+    get:
+      operationId: item_pocket_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - item-pocket
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemPocketDetail'
+          description: ''
+  /api/v2/item/{id}/:
+    get:
+      operationId: item_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - item
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemDetail'
+          description: ''
+  /api/v2/language/:
+    get:
+      operationId: language_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - language
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedLanguageSummaryList'
+          description: ''
+  /api/v2/language/{id}/:
+    get:
+      operationId: language_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - language
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LanguageDetail'
+          description: ''
+  /api/v2/location/:
+    get:
+      operationId: location_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - location
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedLocationSummaryList'
+          description: ''
+  /api/v2/location-area/:
+    get:
+      operationId: location_area_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - location-area
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedLocationAreaSummaryList'
+          description: ''
+  /api/v2/location-area/{id}/:
+    get:
+      operationId: location_area_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this location area.
+        required: true
+      tags:
+      - location-area
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationAreaDetail'
+          description: ''
+  /api/v2/location/{id}/:
+    get:
+      operationId: location_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this location.
+        required: true
+      tags:
+      - location
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationDetail'
+          description: ''
+  /api/v2/machine/:
+    get:
+      operationId: machine_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - machine
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMachineSummaryList'
+          description: ''
+  /api/v2/machine/{id}/:
+    get:
+      operationId: machine_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this machine.
+        required: true
+      tags:
+      - machine
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MachineDetail'
+          description: ''
+  /api/v2/move/:
+    get:
+      operationId: move_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveSummaryList'
+          description: ''
+  /api/v2/move-ailment/:
+    get:
+      operationId: move_ailment_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move-ailment
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveMetaAilmentSummaryList'
+          description: ''
+  /api/v2/move-ailment/{id}/:
+    get:
+      operationId: move_ailment_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move-ailment
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveMetaAilmentDetail'
+          description: ''
+  /api/v2/move-battle-style/:
+    get:
+      operationId: move_battle_style_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move-battle-style
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveBattleStyleSummaryList'
+          description: ''
+  /api/v2/move-battle-style/{id}/:
+    get:
+      operationId: move_battle_style_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move-battle-style
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveBattleStyleDetail'
+          description: ''
+  /api/v2/move-category/:
+    get:
+      operationId: move_category_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move-category
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveMetaCategorySummaryList'
+          description: ''
+  /api/v2/move-category/{id}/:
+    get:
+      operationId: move_category_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move-category
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveMetaCategoryDetail'
+          description: ''
+  /api/v2/move-damage-class/:
+    get:
+      operationId: move_damage_class_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move-damage-class
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveDamageClassSummaryList'
+          description: ''
+  /api/v2/move-damage-class/{id}/:
+    get:
+      operationId: move_damage_class_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move-damage-class
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveDamageClassDetail'
+          description: ''
+  /api/v2/move-learn-method/:
+    get:
+      operationId: move_learn_method_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move-learn-method
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveLearnMethodSummaryList'
+          description: ''
+  /api/v2/move-learn-method/{id}/:
+    get:
+      operationId: move_learn_method_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move-learn-method
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveLearnMethodDetail'
+          description: ''
+  /api/v2/move-target/:
+    get:
+      operationId: move_target_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - move-target
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMoveTargetSummaryList'
+          description: ''
+  /api/v2/move-target/{id}/:
+    get:
+      operationId: move_target_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move-target
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveTargetDetail'
+          description: ''
+  /api/v2/move/{id}/:
+    get:
+      operationId: move_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - move
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveDetail'
+          description: ''
+  /api/v2/nature/:
+    get:
+      operationId: nature_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - nature
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedNatureSummaryList'
+          description: ''
+  /api/v2/nature/{id}/:
+    get:
+      operationId: nature_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - nature
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NatureDetail'
+          description: ''
+  /api/v2/pal-park-area/:
+    get:
+      operationId: pal_park_area_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pal-park-area
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPalParkAreaSummaryList'
+          description: ''
+  /api/v2/pal-park-area/{id}/:
+    get:
+      operationId: pal_park_area_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pal-park-area
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PalParkAreaDetail'
+          description: ''
+  /api/v2/pokeathlon-stat/:
+    get:
+      operationId: pokeathlon_stat_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokeathlon-stat
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokeathlonStatSummaryList'
+          description: ''
+  /api/v2/pokeathlon-stat/{id}/:
+    get:
+      operationId: pokeathlon_stat_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokeathlon-stat
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokeathlonStatDetail'
+          description: ''
+  /api/v2/pokedex/:
+    get:
+      operationId: pokedex_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokedex
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokedexSummaryList'
+          description: ''
+  /api/v2/pokedex/{id}/:
+    get:
+      operationId: pokedex_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokedex
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokedexDetail'
+          description: ''
+  /api/v2/pokemon/:
+    get:
+      operationId: pokemon_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokemon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokemonSummaryList'
+          description: ''
+  /api/v2/pokemon-color/:
+    get:
+      operationId: pokemon_color_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokemon-color
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokemonColorSummaryList'
+          description: ''
+  /api/v2/pokemon-color/{id}/:
+    get:
+      operationId: pokemon_color_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokemon-color
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokemonColorDetail'
+          description: ''
+  /api/v2/pokemon-form/:
+    get:
+      operationId: pokemon_form_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokemon-form
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokemonFormSummaryList'
+          description: ''
+  /api/v2/pokemon-form/{id}/:
+    get:
+      operationId: pokemon_form_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokemon-form
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokemonFormDetail'
+          description: ''
+  /api/v2/pokemon-habitat/:
+    get:
+      operationId: pokemon_habitat_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokemon-habitat
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokemonHabitatSummaryList'
+          description: ''
+  /api/v2/pokemon-habitat/{id}/:
+    get:
+      operationId: pokemon_habitat_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokemon-habitat
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokemonHabitatDetail'
+          description: ''
+  /api/v2/pokemon-shape/:
+    get:
+      operationId: pokemon_shape_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokemon-shape
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokemonShapeSummaryList'
+          description: ''
+  /api/v2/pokemon-shape/{id}/:
+    get:
+      operationId: pokemon_shape_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokemon-shape
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokemonShapeDetail'
+          description: ''
+  /api/v2/pokemon-species/:
+    get:
+      operationId: pokemon_species_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - pokemon-species
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPokemonSpeciesSummaryList'
+          description: ''
+  /api/v2/pokemon-species/{id}/:
+    get:
+      operationId: pokemon_species_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokemon-species
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokemonSpeciesDetail'
+          description: ''
+  /api/v2/pokemon/{id}/:
+    get:
+      operationId: pokemon_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - pokemon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PokemonDetail'
+          description: ''
+  /api/v2/pokemon/{pokemon_id}/encounters:
+    get:
+      operationId: pokemon_encounters_retrieve
+      description: Handles Pokemon Encounters as a sub-resource.
+      parameters:
+      - in: path
+        name: pokemon_id
+        schema:
+          type: string
+          pattern: ^\d+$
+        required: true
+      tags:
+      - pokemon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    location_area:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+                    version_details:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          version:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              url:
+                                type: string
+                          max_chance:
+                            type: integer
+                          encounter_details:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                min_level:
+                                  type: integer
+                                max_level:
+                                  type: integer
+                                condition_values:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      url:
+                                        type: string
+                                chance:
+                                  type: integer
+                                method:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    url:
+                                      type: string
+          description: ''
+  /api/v2/region/:
+    get:
+      operationId: region_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - region
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRegionSummaryList'
+          description: ''
+  /api/v2/region/{id}/:
+    get:
+      operationId: region_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - region
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegionDetail'
+          description: ''
+  /api/v2/schema/:
+    get:
+      operationId: schema_retrieve
+      description: |-
+        OpenApi3 schema for this API. Format can be selected via content negotiation.
+
+        - YAML: application/vnd.oai.openapi
+        - JSON: application/vnd.oai.openapi+json
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - json
+          - yaml
+      - in: query
+        name: lang
+        schema:
+          type: string
+          enum:
+          - af
+          - ar
+          - ar-dz
+          - ast
+          - az
+          - be
+          - bg
+          - bn
+          - br
+          - bs
+          - ca
+          - cs
+          - cy
+          - da
+          - de
+          - dsb
+          - el
+          - en
+          - en-au
+          - en-gb
+          - eo
+          - es
+          - es-ar
+          - es-co
+          - es-mx
+          - es-ni
+          - es-ve
+          - et
+          - eu
+          - fa
+          - fi
+          - fr
+          - fy
+          - ga
+          - gd
+          - gl
+          - he
+          - hi
+          - hr
+          - hsb
+          - hu
+          - hy
+          - ia
+          - id
+          - ig
+          - io
+          - is
+          - it
+          - ja
+          - ka
+          - kab
+          - kk
+          - km
+          - kn
+          - ko
+          - ky
+          - lb
+          - lt
+          - lv
+          - mk
+          - ml
+          - mn
+          - mr
+          - my
+          - nb
+          - ne
+          - nl
+          - nn
+          - os
+          - pa
+          - pl
+          - pt
+          - pt-br
+          - ro
+          - ru
+          - sk
+          - sl
+          - sq
+          - sr
+          - sr-latn
+          - sv
+          - sw
+          - ta
+          - te
+          - tg
+          - th
+          - tk
+          - tr
+          - tt
+          - udm
+          - uk
+          - ur
+          - uz
+          - vi
+          - zh-hans
+          - zh-hant
+      tags:
+      - schema
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/vnd.oai.openapi:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/yaml:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/vnd.oai.openapi+json:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/v2/stat/:
+    get:
+      operationId: stat_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - stat
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedStatSummaryList'
+          description: ''
+  /api/v2/stat/{id}/:
+    get:
+      operationId: stat_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - stat
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatDetail'
+          description: ''
+  /api/v2/super-contest-effect/:
+    get:
+      operationId: super_contest_effect_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - super-contest-effect
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSuperContestEffectSummaryList'
+          description: ''
+  /api/v2/super-contest-effect/{id}/:
+    get:
+      operationId: super_contest_effect_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this super contest effect.
+        required: true
+      tags:
+      - super-contest-effect
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuperContestEffectDetail'
+          description: ''
+  /api/v2/type/:
+    get:
+      operationId: type_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - type
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTypeSummaryList'
+          description: ''
+  /api/v2/type/{id}/:
+    get:
+      operationId: type_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - type
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypeDetail'
+          description: ''
+  /api/v2/version/:
+    get:
+      operationId: version_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - version
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedVersionSummaryList'
+          description: ''
+  /api/v2/version-group/:
+    get:
+      operationId: version_group_list
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - version-group
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedVersionGroupSummaryList'
+          description: ''
+  /api/v2/version-group/{id}/:
+    get:
+      operationId: version_group_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - version-group
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionGroupDetail'
+          description: ''
+  /api/v2/version/{id}/:
+    get:
+      operationId: version_retrieve
+      description: |-
+        Mixin to allow association with separate serializers
+        for list or detail view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: This parameter can be a string or an integer.
+        required: true
+      tags:
+      - version
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionDetail'
+          description: ''
+components:
+  schemas:
+    AbilityChange:
+      type: object
+      properties:
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityChangeEffectText'
+          readOnly: true
+      required:
+      - effect_entries
+      - version_group
+    AbilityChangeEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+    AbilityDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        is_main_series:
+          type: boolean
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityName'
+          readOnly: true
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityEffectText'
+          readOnly: true
+        effect_changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityChange'
+          readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityFlavorText'
+          readOnly: true
+        pokemon:
+          type: array
+          items:
+            type: object
+            properties:
+              is_hidden:
+                type: boolean
+              slot:
+                type: integer
+              pokemon:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+      required:
+      - effect_changes
+      - effect_entries
+      - flavor_text_entries
+      - generation
+      - id
+      - name
+      - names
+      - pokemon
+    AbilityEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        short_effect:
+          type: string
+          maxLength: 300
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+      - short_effect
+    AbilityFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+      required:
+      - flavor_text
+      - language
+      - version_group
+    AbilityName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    AbilitySummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    BerryDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        growth_time:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        max_harvest:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        natural_gift_power:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        size:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        smoothness:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        soil_dryness:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        firmness:
+          $ref: '#/components/schemas/BerryFirmnessSummary'
+        flavors:
+          type: array
+          items:
+            type: object
+            properties:
+              potency:
+                type: integer
+              flavor:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        item:
+          $ref: '#/components/schemas/ItemSummary'
+        natural_gift_type:
+          $ref: '#/components/schemas/TypeSummary'
+      required:
+      - firmness
+      - flavors
+      - growth_time
+      - id
+      - item
+      - max_harvest
+      - name
+      - natural_gift_power
+      - natural_gift_type
+      - size
+      - smoothness
+      - soil_dryness
+    BerryFirmnessDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        berries:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerrySummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerryFirmnessName'
+          readOnly: true
+      required:
+      - berries
+      - id
+      - name
+      - names
+    BerryFirmnessName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    BerryFirmnessSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    BerryFlavorDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        berries:
+          type: array
+          items:
+            type: object
+            properties:
+              potency:
+                type: integer
+              berry:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        contest_type:
+          $ref: '#/components/schemas/ContestTypeSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerryFlavorName'
+          readOnly: true
+      required:
+      - berries
+      - contest_type
+      - id
+      - name
+      - names
+    BerryFlavorName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    BerryFlavorSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    BerrySummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    CharacteristicDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    CharacteristicDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        gene_modulo:
+          type: integer
+        possible_values:
+          type: array
+          items:
+            type: integer
+          readOnly: true
+        highest_stat:
+          $ref: '#/components/schemas/StatSummary'
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicDescription'
+          readOnly: true
+      required:
+      - descriptions
+      - gene_modulo
+      - highest_stat
+      - id
+      - possible_values
+    CharacteristicSummary:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - url
+    ContestEffectDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        appeal:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        jam:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContestEffectEffectText'
+          readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContestEffectFlavorText'
+          readOnly: true
+      required:
+      - appeal
+      - effect_entries
+      - flavor_text_entries
+      - id
+      - jam
+    ContestEffectEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+    ContestEffectFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+          maxLength: 500
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - flavor_text
+      - language
+    ContestEffectSummary:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - url
+    ContestTypeDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        berry_flavor:
+          allOf:
+          - $ref: '#/components/schemas/BerryFlavorSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContestTypeName'
+          readOnly: true
+      required:
+      - berry_flavor
+      - id
+      - name
+      - names
+    ContestTypeName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        color:
+          type: string
+          maxLength: 10
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - color
+      - language
+      - name
+    ContestTypeSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    EggGroupDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/EggGroupName'
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+      - pokemon_species
+    EggGroupName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    EggGroupSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    EncounterConditionDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterConditionValueSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterConditionName'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+      - values
+    EncounterConditionName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    EncounterConditionSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    EncounterConditionValueDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        condition:
+          $ref: '#/components/schemas/EncounterConditionSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterConditionValueName'
+          readOnly: true
+      required:
+      - condition
+      - id
+      - name
+      - names
+    EncounterConditionValueName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    EncounterConditionValueSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    EncounterMethodDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterMethodName'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+    EncounterMethodName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    EncounterMethodSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    EvolutionChainDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        baby_trigger_item:
+          $ref: '#/components/schemas/ItemSummary'
+        chain:
+          type: object
+          properties:
+            is_baby:
+              type: boolean
+            species:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+            evolution_details:
+              type: array
+              items:
+                type: object
+                properties:
+                  item:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  trigger:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  gender: {}
+                  held_item:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  known_move:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  known_move_type:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  location:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  min_level:
+                    type: integer
+                  min_happiness:
+                    type: integer
+                  min_beauty:
+                    type: integer
+                  min_affection:
+                    type: integer
+                  needs_overworld_rain:
+                    type: boolean
+                  party_species:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  party_type:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  relative_physical_stats:
+                    type: integer
+                  time_of_day:
+                    type: string
+                  trade_species:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  turn_upside_down:
+                    type: boolean
+            evolves_to:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+      required:
+      - baby_trigger_item
+      - chain
+      - id
+    EvolutionChainSummary:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - url
+    EvolutionTriggerDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvolutionTriggerName'
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+      - pokemon_species
+    EvolutionTriggerName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    EvolutionTriggerSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    Experience:
+      type: object
+      properties:
+        level:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        experience:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+      required:
+      - experience
+      - level
+    GenderDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        pokemon_species_details:
+          type: array
+          items:
+            type: object
+            properties:
+              rate:
+                type: integer
+              pokemon_species:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        required_for_evolution:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - id
+      - name
+      - pokemon_species_details
+      - required_for_evolution
+    GenderSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    GenerationDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        abilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilitySummary'
+          readOnly: true
+        main_region:
+          $ref: '#/components/schemas/RegionSummary'
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenerationName'
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+        types:
+          type: array
+          items:
+            $ref: '#/components/schemas/TypeSummary'
+          readOnly: true
+        version_groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionGroupSummary'
+          readOnly: true
+      required:
+      - abilities
+      - id
+      - main_region
+      - moves
+      - name
+      - names
+      - pokemon_species
+      - types
+      - version_groups
+    GenerationName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    GenerationSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    GrowthRateDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    GrowthRateDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        formula:
+          type: string
+          maxLength: 500
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrowthRateDescription'
+          readOnly: true
+        levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/Experience'
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - descriptions
+      - formula
+      - id
+      - levels
+      - name
+      - pokemon_species
+    GrowthRateSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    ItemAttributeDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    ItemAttributeDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemAttributeDescription'
+          readOnly: true
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemAttributeName'
+          readOnly: true
+      required:
+      - descriptions
+      - id
+      - items
+      - name
+      - names
+    ItemAttributeName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    ItemAttributeSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    ItemCategoryDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemCategoryName'
+          readOnly: true
+        pocket:
+          $ref: '#/components/schemas/ItemPocketSummary'
+      required:
+      - id
+      - items
+      - name
+      - names
+      - pocket
+    ItemCategoryName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    ItemCategorySummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    ItemDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        cost:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        fling_power:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        fling_effect:
+          $ref: '#/components/schemas/ItemFlingEffectSummary'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemAttributeSummary'
+          readOnly: true
+        category:
+          $ref: '#/components/schemas/ItemCategorySummary'
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemEffectText'
+          readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemFlavorText'
+          readOnly: true
+        game_indices:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemGameIndex'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemName'
+          readOnly: true
+        held_by_pokemon:
+          type: array
+          items:
+            type: object
+            properties:
+              pokemon:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              version_details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    rarity:
+                      type: integer
+                    version:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+          readOnly: true
+        sprites:
+          type: object
+          properties:
+            default:
+              type: string
+          readOnly: true
+        baby_trigger_for:
+          allOf:
+          - $ref: '#/components/schemas/EvolutionChainSummary'
+          readOnly: true
+        machines:
+          type: array
+          items:
+            type: object
+            properties:
+              machine:
+                type: string
+              version_group:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+      required:
+      - attributes
+      - baby_trigger_for
+      - category
+      - effect_entries
+      - flavor_text_entries
+      - fling_effect
+      - game_indices
+      - held_by_pokemon
+      - id
+      - machines
+      - name
+      - names
+      - sprites
+    ItemEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        short_effect:
+          type: string
+          maxLength: 300
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+      - short_effect
+    ItemFlavorText:
+      type: object
+      properties:
+        text:
+          type: string
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - text
+      - version_group
+    ItemFlingEffectDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemFlingEffectEffectText'
+          readOnly: true
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemSummary'
+          readOnly: true
+      required:
+      - effect_entries
+      - id
+      - items
+      - name
+    ItemFlingEffectEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+    ItemFlingEffectSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    ItemGameIndex:
+      type: object
+      properties:
+        game_index:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+      required:
+      - game_index
+      - generation
+    ItemName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    ItemPocketDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemCategorySummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemPocketName'
+          readOnly: true
+      required:
+      - categories
+      - id
+      - name
+      - names
+    ItemPocketName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    ItemPocketSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    ItemSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    LanguageDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        official:
+          type: boolean
+        iso639:
+          type: string
+          maxLength: 10
+        iso3166:
+          type: string
+          maxLength: 2
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/LanguageName'
+          readOnly: true
+      required:
+      - id
+      - iso3166
+      - iso639
+      - name
+      - names
+    LanguageName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    LanguageSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    LocationAreaDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        game_index:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        encounter_method_rates:
+          type: array
+          items:
+            type: object
+            properties:
+              encounter_method:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              version_details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    rate:
+                      type: integer
+                    version:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+          readOnly: true
+        location:
+          $ref: '#/components/schemas/LocationSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationAreaName'
+          readOnly: true
+        pokemon_encounters:
+          type: array
+          items:
+            type: object
+            properties:
+              pokemon:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              version_details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    version:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+                    max_chance:
+                      type: integer
+                    encounter_details:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          min_level:
+                            type: integer
+                          max_level:
+                            type: integer
+                          condition_values:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                url:
+                                  type: string
+                          chance:
+                            type: integer
+                          method:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              url:
+                                type: string
+          readOnly: true
+      required:
+      - encounter_method_rates
+      - game_index
+      - id
+      - location
+      - name
+      - names
+      - pokemon_encounters
+    LocationAreaName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    LocationAreaSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    LocationDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        region:
+          $ref: '#/components/schemas/RegionSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationName'
+          readOnly: true
+        game_indices:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationGameIndex'
+          readOnly: true
+        areas:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationAreaSummary'
+          readOnly: true
+      required:
+      - areas
+      - game_indices
+      - id
+      - name
+      - names
+      - region
+    LocationGameIndex:
+      type: object
+      properties:
+        game_index:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+      required:
+      - game_index
+      - generation
+    LocationName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    LocationSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MachineDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        item:
+          $ref: '#/components/schemas/ItemSummary'
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+        move:
+          $ref: '#/components/schemas/MoveSummary'
+      required:
+      - id
+      - item
+      - move
+      - version_group
+    MachineSummary:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - url
+    MoveBattleStyleDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveBattleStyleName'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+    MoveBattleStyleName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    MoveBattleStyleSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MoveChange:
+      type: object
+      properties:
+        accuracy:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        power:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        pp:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        effect_chance:
+          type: integer
+        effect_entries:
+          type: string
+          readOnly: true
+        type:
+          $ref: '#/components/schemas/TypeSummary'
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+      required:
+      - effect_chance
+      - effect_entries
+      - type
+      - version_group
+    MoveDamageClassDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    MoveDamageClassDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveDamageClassDescription'
+          readOnly: true
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveDamageClassName'
+          readOnly: true
+      required:
+      - descriptions
+      - id
+      - moves
+      - name
+      - names
+    MoveDamageClassName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    MoveDamageClassSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MoveDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        accuracy:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        effect_chance:
+          type: integer
+        pp:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        power:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        contest_combos:
+          type: object
+          properties:
+            normal:
+              type: object
+              properties:
+                use_before:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                use_after:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+            super:
+              type: object
+              properties:
+                use_before:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                use_after:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+          readOnly: true
+        contest_type:
+          $ref: '#/components/schemas/ContestTypeSummary'
+        contest_effect:
+          $ref: '#/components/schemas/ContestEffectSummary'
+        damage_class:
+          $ref: '#/components/schemas/MoveDamageClassSummary'
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveEffectEffectText'
+          readOnly: true
+        effect_changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveEffectChange'
+          readOnly: true
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+        meta:
+          allOf:
+          - $ref: '#/components/schemas/MoveMeta'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveName'
+          readOnly: true
+        past_values:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveChange'
+          readOnly: true
+        stat_changes:
+          type: array
+          items:
+            type: object
+            properties:
+              change:
+                type: integer
+              stat:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        super_contest_effect:
+          $ref: '#/components/schemas/SuperContestEffectSummary'
+        target:
+          $ref: '#/components/schemas/MoveTargetSummary'
+        type:
+          $ref: '#/components/schemas/TypeSummary'
+        machines:
+          type: array
+          items:
+            type: object
+            properties:
+              machine:
+                type: object
+                properties:
+                  url:
+                    type: string
+              version_group:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveFlavorText'
+          readOnly: true
+        learned_by_pokemon:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSummary'
+          readOnly: true
+      required:
+      - contest_combos
+      - contest_effect
+      - contest_type
+      - damage_class
+      - effect_chance
+      - effect_changes
+      - effect_entries
+      - flavor_text_entries
+      - generation
+      - id
+      - learned_by_pokemon
+      - machines
+      - meta
+      - name
+      - names
+      - past_values
+      - stat_changes
+      - super_contest_effect
+      - target
+      - type
+    MoveEffectChange:
+      type: object
+      properties:
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+        effect_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveEffectChangeEffectText'
+          readOnly: true
+      required:
+      - effect_entries
+      - version_group
+    MoveEffectChangeEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+    MoveEffectEffectText:
+      type: object
+      properties:
+        effect:
+          type: string
+          maxLength: 6000
+        short_effect:
+          type: string
+          maxLength: 300
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - effect
+      - language
+      - short_effect
+    MoveFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+      required:
+      - flavor_text
+      - language
+      - version_group
+    MoveLearnMethodDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    MoveLearnMethodDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveLearnMethodName'
+          readOnly: true
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveLearnMethodDescription'
+          readOnly: true
+        version_groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionGroupSummary'
+          readOnly: true
+      required:
+      - descriptions
+      - id
+      - name
+      - names
+      - version_groups
+    MoveLearnMethodName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    MoveLearnMethodSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MoveMeta:
+      type: object
+      properties:
+        ailment:
+          $ref: '#/components/schemas/MoveMetaAilmentSummary'
+        category:
+          $ref: '#/components/schemas/MoveMetaCategorySummary'
+        min_hits:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        max_hits:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        min_turns:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        max_turns:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        drain:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        healing:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        crit_rate:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        ailment_chance:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        flinch_chance:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        stat_chance:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+      required:
+      - ailment
+      - category
+    MoveMetaAilmentDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveMetaAilmentName'
+          readOnly: true
+      required:
+      - id
+      - moves
+      - name
+      - names
+    MoveMetaAilmentName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    MoveMetaAilmentSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MoveMetaCategoryDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    MoveMetaCategoryDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveMetaCategoryDescription'
+          readOnly: true
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+      required:
+      - descriptions
+      - id
+      - moves
+      - name
+    MoveMetaCategorySummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MoveName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    MoveSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    MoveTargetDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    MoveTargetDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveTargetDescription'
+          readOnly: true
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveTargetName'
+          readOnly: true
+      required:
+      - descriptions
+      - id
+      - moves
+      - name
+      - names
+    MoveTargetName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    MoveTargetSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    NatureBattleStylePreference:
+      type: object
+      properties:
+        low_hp_preference:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        high_hp_preference:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        move_battle_style:
+          $ref: '#/components/schemas/MoveBattleStyleSummary'
+      required:
+      - high_hp_preference
+      - low_hp_preference
+      - move_battle_style
+    NatureDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        decreased_stat:
+          $ref: '#/components/schemas/StatSummary'
+        increased_stat:
+          $ref: '#/components/schemas/StatSummary'
+        likes_flavor:
+          $ref: '#/components/schemas/BerryFlavorSummary'
+        hates_flavor:
+          $ref: '#/components/schemas/BerryFlavorSummary'
+        berries:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerrySummary'
+          readOnly: true
+        pokeathlon_stat_changes:
+          type: array
+          items:
+            type: object
+            properties:
+              max_change:
+                type: integer
+              pokeathlon_stat:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        move_battle_style_preferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/NatureBattleStylePreference'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/NatureName'
+          readOnly: true
+      required:
+      - berries
+      - decreased_stat
+      - hates_flavor
+      - id
+      - increased_stat
+      - likes_flavor
+      - move_battle_style_preferences
+      - name
+      - names
+      - pokeathlon_stat_changes
+    NatureName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    NatureSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PaginatedAbilitySummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilitySummary'
+    PaginatedBerryFirmnessSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerryFirmnessSummary'
+    PaginatedBerryFlavorSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerryFlavorSummary'
+    PaginatedBerrySummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BerrySummary'
+    PaginatedCharacteristicSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicSummary'
+    PaginatedContestEffectSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContestEffectSummary'
+    PaginatedContestTypeSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContestTypeSummary'
+    PaginatedEggGroupSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EggGroupSummary'
+    PaginatedEncounterConditionSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterConditionSummary'
+    PaginatedEncounterConditionValueSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterConditionValueSummary'
+    PaginatedEncounterMethodSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EncounterMethodSummary'
+    PaginatedEvolutionChainSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvolutionChainSummary'
+    PaginatedEvolutionTriggerSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvolutionTriggerSummary'
+    PaginatedGenderSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenderSummary'
+    PaginatedGenerationSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenerationSummary'
+    PaginatedGrowthRateSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrowthRateSummary'
+    PaginatedItemAttributeSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemAttributeSummary'
+    PaginatedItemCategorySummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemCategorySummary'
+    PaginatedItemFlingEffectSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemFlingEffectSummary'
+    PaginatedItemPocketSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemPocketSummary'
+    PaginatedItemSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemSummary'
+    PaginatedLanguageSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/LanguageSummary'
+    PaginatedLocationAreaSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationAreaSummary'
+    PaginatedLocationSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationSummary'
+    PaginatedMachineSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MachineSummary'
+    PaginatedMoveBattleStyleSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveBattleStyleSummary'
+    PaginatedMoveDamageClassSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveDamageClassSummary'
+    PaginatedMoveLearnMethodSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveLearnMethodSummary'
+    PaginatedMoveMetaAilmentSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveMetaAilmentSummary'
+    PaginatedMoveMetaCategorySummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveMetaCategorySummary'
+    PaginatedMoveSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+    PaginatedMoveTargetSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveTargetSummary'
+    PaginatedNatureSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/NatureSummary'
+    PaginatedPalParkAreaSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PalParkAreaSummary'
+    PaginatedPokeathlonStatSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokeathlonStatSummary'
+    PaginatedPokedexSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokedexSummary'
+    PaginatedPokemonColorSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonColorSummary'
+    PaginatedPokemonFormSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonFormSummary'
+    PaginatedPokemonHabitatSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonHabitatSummary'
+    PaginatedPokemonShapeSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonShapeSummary'
+    PaginatedPokemonSpeciesSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+    PaginatedPokemonSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSummary'
+    PaginatedRegionSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegionSummary'
+    PaginatedStatSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/StatSummary'
+    PaginatedSuperContestEffectSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SuperContestEffectSummary'
+    PaginatedTypeSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/TypeSummary'
+    PaginatedVersionGroupSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionGroupSummary'
+    PaginatedVersionSummaryList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionSummary'
+    PalParkAreaDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/PalParkAreaName'
+          readOnly: true
+        pokemon_encounters:
+          type: array
+          items:
+            type: object
+            properties:
+              base_score:
+                type: integer
+              rate:
+                type: integer
+              pokemon_species:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+      - pokemon_encounters
+    PalParkAreaName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    PalParkAreaSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokeathlonStatDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        affecting_natures:
+          type: array
+          items:
+            type: object
+            properties:
+              increase:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    max_change:
+                      type: integer
+                    nature:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+              decrease:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    max_change:
+                      type: integer
+                    nature:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokeathlonStatName'
+          readOnly: true
+      required:
+      - affecting_natures
+      - id
+      - name
+      - names
+    PokeathlonStatName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    PokeathlonStatSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokedexDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    PokedexDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        is_main_series:
+          type: boolean
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokedexDescription'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokedexName'
+          readOnly: true
+        pokemon_entries:
+          type: array
+          items:
+            type: object
+            properties:
+              entry_number:
+                type: integer
+              pokemon_species:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        region:
+          $ref: '#/components/schemas/RegionSummary'
+        version_groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionGroupSummary'
+          readOnly: true
+      required:
+      - descriptions
+      - id
+      - name
+      - names
+      - pokemon_entries
+      - region
+      - version_groups
+    PokedexName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    PokedexSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokemonColorDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonColorName'
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+      - pokemon_species
+    PokemonColorName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    PokemonColorSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokemonDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        base_experience:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        height:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        is_default:
+          type: boolean
+        order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        weight:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        abilities:
+          type: array
+          items:
+            type: object
+            properties:
+              is_hidden:
+                type: boolean
+              slot:
+                type: integer
+              ability:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        past_abilities:
+          type: array
+          items:
+            type: object
+            properties:
+              generation:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              abilities:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+          readOnly: true
+        forms:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonFormSummary'
+          readOnly: true
+        game_indices:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonGameIndex'
+          readOnly: true
+        held_items:
+          type: array
+          items:
+            type: object
+            properties:
+              item:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              version_details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    rarity:
+                      type: integer
+                    version:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+          readOnly: true
+        location_area_encounters:
+          type: string
+          readOnly: true
+        moves:
+          type: array
+          items:
+            type: object
+            properties:
+              move:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              version_group_details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    level_learned_at:
+                      type: integer
+                    version_group:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+                    move_learn_method:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+          readOnly: true
+        species:
+          $ref: '#/components/schemas/PokemonSpeciesSummary'
+        sprites:
+          type: string
+          readOnly: true
+        cries:
+          type: string
+          readOnly: true
+        stats:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonStat'
+          readOnly: true
+        types:
+          type: array
+          items:
+            type: object
+            properties:
+              slot:
+                type: integer
+              type:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        past_types:
+          type: array
+          items:
+            type: object
+            properties:
+              generation:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              types:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    slot:
+                      type: integer
+                    type:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+          readOnly: true
+      required:
+      - abilities
+      - cries
+      - forms
+      - game_indices
+      - held_items
+      - id
+      - location_area_encounters
+      - moves
+      - name
+      - past_abilities
+      - past_types
+      - species
+      - sprites
+      - stats
+      - types
+    PokemonDexEntry:
+      type: object
+      properties:
+        entry_number:
+          type: integer
+        pokedex:
+          $ref: '#/components/schemas/PokedexSummary'
+      required:
+      - entry_number
+      - pokedex
+    PokemonFormDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        form_order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        is_default:
+          type: boolean
+        is_battle_only:
+          type: boolean
+        is_mega:
+          type: boolean
+        form_name:
+          type: string
+          maxLength: 30
+        pokemon:
+          $ref: '#/components/schemas/PokemonSummary'
+        sprites:
+          type: string
+          readOnly: true
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+        form_names:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              language:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        names:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              language:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        types:
+          type: array
+          items:
+            type: object
+            properties:
+              slot:
+                type: string
+              type:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+      required:
+      - form_name
+      - form_names
+      - id
+      - name
+      - names
+      - pokemon
+      - sprites
+      - types
+      - version_group
+    PokemonFormSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokemonGameIndex:
+      type: object
+      properties:
+        game_index:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        version:
+          $ref: '#/components/schemas/VersionSummary'
+      required:
+      - game_index
+      - version
+    PokemonHabitatDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonHabitatName'
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - id
+      - name
+      - names
+      - pokemon_species
+    PokemonHabitatName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    PokemonHabitatSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokemonShapeDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        awesome_names:
+          type: array
+          items:
+            type: object
+            properties:
+              awesome_name:
+                type: string
+              language:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        names:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              language:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        pokemon_species:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesSummary'
+          readOnly: true
+      required:
+      - awesome_names
+      - id
+      - name
+      - names
+      - pokemon_species
+    PokemonShapeSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokemonSpeciesDescription:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 1000
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+    PokemonSpeciesDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        gender_rate:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        capture_rate:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        base_happiness:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        is_baby:
+          type: boolean
+        is_legendary:
+          type: boolean
+        is_mythical:
+          type: boolean
+        hatch_counter:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        has_gender_differences:
+          type: boolean
+        forms_switchable:
+          type: boolean
+        growth_rate:
+          $ref: '#/components/schemas/GrowthRateSummary'
+        pokedex_numbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonDexEntry'
+          readOnly: true
+        egg_groups:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              url:
+                type: string
+          readOnly: true
+        color:
+          $ref: '#/components/schemas/PokemonColorSummary'
+        shape:
+          $ref: '#/components/schemas/PokemonShapeSummary'
+        evolves_from_species:
+          $ref: '#/components/schemas/PokemonSpeciesSummary'
+        evolution_chain:
+          $ref: '#/components/schemas/EvolutionChainSummary'
+        habitat:
+          $ref: '#/components/schemas/PokemonHabitatSummary'
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+        names:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              language:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        pal_park_encounters:
+          type: array
+          items:
+            type: object
+            properties:
+              base_score:
+                type: integer
+              rate:
+                type: integer
+              area:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        form_descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesDescription'
+          readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonSpeciesFlavorText'
+          readOnly: true
+        genera:
+          type: array
+          items:
+            type: object
+            properties:
+              genus:
+                type: string
+              language:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        varieties:
+          type: array
+          items:
+            type: object
+            properties:
+              is_default:
+                type: boolean
+              pokemon:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+      required:
+      - color
+      - egg_groups
+      - evolution_chain
+      - evolves_from_species
+      - flavor_text_entries
+      - form_descriptions
+      - genera
+      - generation
+      - growth_rate
+      - habitat
+      - id
+      - name
+      - names
+      - pal_park_encounters
+      - pokedex_numbers
+      - shape
+      - varieties
+    PokemonSpeciesFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+        version:
+          $ref: '#/components/schemas/VersionSummary'
+      required:
+      - flavor_text
+      - language
+      - version
+    PokemonSpeciesSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    PokemonStat:
+      type: object
+      properties:
+        base_stat:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        effort:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        stat:
+          $ref: '#/components/schemas/StatSummary'
+      required:
+      - base_stat
+      - effort
+      - stat
+    PokemonSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    RegionDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationSummary'
+          readOnly: true
+        main_generation:
+          allOf:
+          - $ref: '#/components/schemas/GenerationSummary'
+          readOnly: true
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegionName'
+          readOnly: true
+        pokedexes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokedexSummary'
+          readOnly: true
+        version_groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionGroupSummary'
+          readOnly: true
+      required:
+      - id
+      - locations
+      - main_generation
+      - name
+      - names
+      - pokedexes
+      - version_groups
+    RegionName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    RegionSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    StatDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        game_index:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        is_battle_only:
+          type: boolean
+        affecting_moves:
+          type: object
+          properties:
+            increase:
+              type: object
+              properties:
+                change:
+                  type: integer
+                move:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+            decrease:
+              type: object
+              properties:
+                change:
+                  type: integer
+                move:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+          readOnly: true
+        affecting_natures:
+          type: object
+          properties:
+            increase:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+            decrease:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicSummary'
+          readOnly: true
+        move_damage_class:
+          $ref: '#/components/schemas/MoveDamageClassSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/StatName'
+          readOnly: true
+      required:
+      - affecting_moves
+      - affecting_natures
+      - characteristics
+      - game_index
+      - id
+      - move_damage_class
+      - name
+      - names
+    StatName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    StatSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    SuperContestEffectDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        appeal:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SuperContestEffectFlavorText'
+          readOnly: true
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+      required:
+      - appeal
+      - flavor_text_entries
+      - id
+      - moves
+    SuperContestEffectFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+          maxLength: 500
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - flavor_text
+      - language
+    SuperContestEffectSummary:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - url
+    TypeDetail:
+      type: object
+      description: Serializer for the Type resource
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        damage_relations:
+          type: object
+          properties:
+            no_damage_to:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+            half_damage_to:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+            double_damage_to:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+            no_damage_from:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+            half_damage_from:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+            double_damage_from:
+              type: object
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+          readOnly: true
+        past_damage_relations:
+          type: array
+          items:
+            type: object
+            properties:
+              generation:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+              damage_relations:
+                type: object
+                properties:
+                  no_damage_to:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  half_damage_to:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  double_damage_to:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  no_damage_from:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  half_damage_from:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  double_damage_from:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+          readOnly: true
+        game_indices:
+          type: array
+          items:
+            $ref: '#/components/schemas/TypeGameIndex'
+          readOnly: true
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+        move_damage_class:
+          $ref: '#/components/schemas/MoveDamageClassSummary'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityName'
+          readOnly: true
+        pokemon:
+          type: array
+          items:
+            type: object
+            properties:
+              slot:
+                type: integer
+              pokemon:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+          readOnly: true
+        moves:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveSummary'
+          readOnly: true
+      required:
+      - damage_relations
+      - game_indices
+      - generation
+      - id
+      - move_damage_class
+      - moves
+      - name
+      - names
+      - past_damage_relations
+      - pokemon
+    TypeGameIndex:
+      type: object
+      properties:
+        game_index:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+      required:
+      - game_index
+      - generation
+    TypeSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    VersionDetail:
+      type: object
+      description: |-
+        Should have a link to Version Group info but the Circular
+        dependency and compilation order fight eachother and I'm
+        not sure how to add anything other than a hyperlink
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionName'
+          readOnly: true
+        version_group:
+          $ref: '#/components/schemas/VersionGroupSummary'
+      required:
+      - id
+      - name
+      - names
+      - version_group
+    VersionGroupDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        generation:
+          $ref: '#/components/schemas/GenerationSummary'
+        move_learn_methods:
+          type: array
+          items:
+            $ref: '#/components/schemas/MoveLearnMethodSummary'
+          readOnly: true
+        pokedexes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokedexSummary'
+          readOnly: true
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegionSummary'
+          readOnly: true
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionSummary'
+          readOnly: true
+      required:
+      - generation
+      - id
+      - move_learn_methods
+      - name
+      - pokedexes
+      - regions
+      - versions
+    VersionGroupSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+    VersionName:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - language
+      - name
+    VersionSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - name
+      - url
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -72,22 +72,21 @@ class PokeapiCommonViewset(
 #  APIS  #
 ##########
 
+retrieve_path_parameter = OpenApiParameter(
+    name="id",
+    description="This parameter can be a string or an integer.",
+    location=OpenApiParameter.PATH,
+    type=OpenApiTypes.STR,
+    required=True,
+)
+
 
 class AbilityResource(PokeapiCommonViewset):
     queryset = Ability.objects.all()
     serializer_class = AbilityDetailSerializer
     list_serializer_class = AbilitySummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -97,16 +96,7 @@ class BerryResource(PokeapiCommonViewset):
     serializer_class = BerryDetailSerializer
     list_serializer_class = BerrySummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -116,16 +106,7 @@ class BerryFirmnessResource(PokeapiCommonViewset):
     serializer_class = BerryFirmnessDetailSerializer
     list_serializer_class = BerryFirmnessSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -135,16 +116,7 @@ class BerryFlavorResource(PokeapiCommonViewset):
     serializer_class = BerryFlavorDetailSerializer
     list_serializer_class = BerryFlavorSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -172,16 +144,7 @@ class EggGroupResource(PokeapiCommonViewset):
     serializer_class = EggGroupDetailSerializer
     list_serializer_class = EggGroupSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -191,16 +154,7 @@ class EncounterConditionResource(PokeapiCommonViewset):
     serializer_class = EncounterConditionDetailSerializer
     list_serializer_class = EncounterConditionSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -210,16 +164,7 @@ class EncounterConditionValueResource(PokeapiCommonViewset):
     serializer_class = EncounterConditionValueDetailSerializer
     list_serializer_class = EncounterConditionValueSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -229,16 +174,7 @@ class EncounterMethodResource(PokeapiCommonViewset):
     serializer_class = EncounterMethodDetailSerializer
     list_serializer_class = EncounterMethodSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -254,16 +190,7 @@ class EvolutionTriggerResource(PokeapiCommonViewset):
     serializer_class = EvolutionTriggerDetailSerializer
     list_serializer_class = EvolutionTriggerSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -273,16 +200,7 @@ class GenerationResource(PokeapiCommonViewset):
     serializer_class = GenerationDetailSerializer
     list_serializer_class = GenerationSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -292,16 +210,7 @@ class GenderResource(PokeapiCommonViewset):
     serializer_class = GenderDetailSerializer
     list_serializer_class = GenderSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -311,16 +220,7 @@ class GrowthRateResource(PokeapiCommonViewset):
     serializer_class = GrowthRateDetailSerializer
     list_serializer_class = GrowthRateSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -330,16 +230,7 @@ class ItemResource(PokeapiCommonViewset):
     serializer_class = ItemDetailSerializer
     list_serializer_class = ItemSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -349,16 +240,7 @@ class ItemCategoryResource(PokeapiCommonViewset):
     serializer_class = ItemCategoryDetailSerializer
     list_serializer_class = ItemCategorySummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -368,16 +250,7 @@ class ItemAttributeResource(PokeapiCommonViewset):
     serializer_class = ItemAttributeDetailSerializer
     list_serializer_class = ItemAttributeSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -387,16 +260,7 @@ class ItemFlingEffectResource(PokeapiCommonViewset):
     serializer_class = ItemFlingEffectDetailSerializer
     list_serializer_class = ItemFlingEffectSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -406,16 +270,7 @@ class ItemPocketResource(PokeapiCommonViewset):
     serializer_class = ItemPocketDetailSerializer
     list_serializer_class = ItemPocketSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -425,16 +280,7 @@ class LanguageResource(PokeapiCommonViewset):
     serializer_class = LanguageDetailSerializer
     list_serializer_class = LanguageSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -462,16 +308,7 @@ class MoveResource(PokeapiCommonViewset):
     serializer_class = MoveDetailSerializer
     list_serializer_class = MoveSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -481,16 +318,7 @@ class MoveDamageClassResource(PokeapiCommonViewset):
     serializer_class = MoveDamageClassDetailSerializer
     list_serializer_class = MoveDamageClassSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -500,16 +328,7 @@ class MoveMetaAilmentResource(PokeapiCommonViewset):
     serializer_class = MoveMetaAilmentDetailSerializer
     list_serializer_class = MoveMetaAilmentSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -519,16 +338,7 @@ class MoveBattleStyleResource(PokeapiCommonViewset):
     serializer_class = MoveBattleStyleDetailSerializer
     list_serializer_class = MoveBattleStyleSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -538,16 +348,7 @@ class MoveMetaCategoryResource(PokeapiCommonViewset):
     serializer_class = MoveMetaCategoryDetailSerializer
     list_serializer_class = MoveMetaCategorySummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -557,16 +358,7 @@ class MoveLearnMethodResource(PokeapiCommonViewset):
     serializer_class = MoveLearnMethodDetailSerializer
     list_serializer_class = MoveLearnMethodSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -576,16 +368,7 @@ class MoveTargetResource(PokeapiCommonViewset):
     serializer_class = MoveTargetDetailSerializer
     list_serializer_class = MoveTargetSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -595,16 +378,7 @@ class NatureResource(PokeapiCommonViewset):
     serializer_class = NatureDetailSerializer
     list_serializer_class = NatureSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -614,16 +388,7 @@ class PalParkAreaResource(PokeapiCommonViewset):
     serializer_class = PalParkAreaDetailSerializer
     list_serializer_class = PalParkAreaSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -633,16 +398,7 @@ class PokeathlonStatResource(PokeapiCommonViewset):
     serializer_class = PokeathlonStatDetailSerializer
     list_serializer_class = PokeathlonStatSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -652,16 +408,7 @@ class PokedexResource(PokeapiCommonViewset):
     serializer_class = PokedexDetailSerializer
     list_serializer_class = PokedexSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -671,16 +418,7 @@ class PokemonColorResource(PokeapiCommonViewset):
     serializer_class = PokemonColorDetailSerializer
     list_serializer_class = PokemonColorSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -690,16 +428,7 @@ class PokemonFormResource(PokeapiCommonViewset):
     serializer_class = PokemonFormDetailSerializer
     list_serializer_class = PokemonFormSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -709,16 +438,7 @@ class PokemonHabitatResource(PokeapiCommonViewset):
     serializer_class = PokemonHabitatDetailSerializer
     list_serializer_class = PokemonHabitatSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -728,16 +448,7 @@ class PokemonShapeResource(PokeapiCommonViewset):
     serializer_class = PokemonShapeDetailSerializer
     list_serializer_class = PokemonShapeSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -747,16 +458,7 @@ class PokemonResource(PokeapiCommonViewset):
     serializer_class = PokemonDetailSerializer
     list_serializer_class = PokemonSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -766,16 +468,7 @@ class PokemonSpeciesResource(PokeapiCommonViewset):
     serializer_class = PokemonSpeciesDetailSerializer
     list_serializer_class = PokemonSpeciesSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -785,16 +478,7 @@ class RegionResource(PokeapiCommonViewset):
     serializer_class = RegionDetailSerializer
     list_serializer_class = RegionSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -804,16 +488,7 @@ class StatResource(PokeapiCommonViewset):
     serializer_class = StatDetailSerializer
     list_serializer_class = StatSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -829,16 +504,7 @@ class TypeResource(PokeapiCommonViewset):
     serializer_class = TypeDetailSerializer
     list_serializer_class = TypeSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -848,16 +514,7 @@ class VersionResource(PokeapiCommonViewset):
     serializer_class = VersionDetailSerializer
     list_serializer_class = VersionSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 
@@ -867,16 +524,7 @@ class VersionGroupResource(PokeapiCommonViewset):
     serializer_class = VersionGroupDetailSerializer
     list_serializer_class = VersionGroupSummarySerializer
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
+    @extend_schema(parameters=[retrieve_path_parameter])
     def retrieve(self, request, pk=None):
         return super().retrieve(request, pk)
 

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -4,6 +4,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.shortcuts import get_object_or_404
 from django.http import Http404
+from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.types import OpenApiTypes
 
 from .models import *
 from .serializers import *
@@ -75,11 +77,37 @@ class AbilityResource(PokeapiCommonViewset):
     serializer_class = AbilityDetailSerializer
     list_serializer_class = AbilitySummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class BerryResource(PokeapiCommonViewset):
     queryset = Berry.objects.all()
     serializer_class = BerryDetailSerializer
     list_serializer_class = BerrySummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class BerryFirmnessResource(PokeapiCommonViewset):
@@ -87,11 +115,37 @@ class BerryFirmnessResource(PokeapiCommonViewset):
     serializer_class = BerryFirmnessDetailSerializer
     list_serializer_class = BerryFirmnessSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class BerryFlavorResource(PokeapiCommonViewset):
     queryset = BerryFlavor.objects.all()
     serializer_class = BerryFlavorDetailSerializer
     list_serializer_class = BerryFlavorSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class CharacteristicResource(PokeapiCommonViewset):
@@ -117,11 +171,37 @@ class EggGroupResource(PokeapiCommonViewset):
     serializer_class = EggGroupDetailSerializer
     list_serializer_class = EggGroupSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class EncounterConditionResource(PokeapiCommonViewset):
     queryset = EncounterCondition.objects.all()
     serializer_class = EncounterConditionDetailSerializer
     list_serializer_class = EncounterConditionSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class EncounterConditionValueResource(PokeapiCommonViewset):
@@ -129,11 +209,37 @@ class EncounterConditionValueResource(PokeapiCommonViewset):
     serializer_class = EncounterConditionValueDetailSerializer
     list_serializer_class = EncounterConditionValueSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class EncounterMethodResource(PokeapiCommonViewset):
     queryset = EncounterMethod.objects.all()
     serializer_class = EncounterMethodDetailSerializer
     list_serializer_class = EncounterMethodSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class EvolutionChainResource(PokeapiCommonViewset):
@@ -147,11 +253,37 @@ class EvolutionTriggerResource(PokeapiCommonViewset):
     serializer_class = EvolutionTriggerDetailSerializer
     list_serializer_class = EvolutionTriggerSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class GenerationResource(PokeapiCommonViewset):
     queryset = Generation.objects.all()
     serializer_class = GenerationDetailSerializer
     list_serializer_class = GenerationSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class GenderResource(PokeapiCommonViewset):
@@ -159,17 +291,56 @@ class GenderResource(PokeapiCommonViewset):
     serializer_class = GenderDetailSerializer
     list_serializer_class = GenderSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class GrowthRateResource(PokeapiCommonViewset):
     queryset = GrowthRate.objects.all()
     serializer_class = GrowthRateDetailSerializer
     list_serializer_class = GrowthRateSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class ItemResource(PokeapiCommonViewset):
     queryset = Item.objects.all()
     serializer_class = ItemDetailSerializer
     list_serializer_class = ItemSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class ItemCategoryResource(PokeapiCommonViewset):

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -885,6 +885,83 @@ class PokemonEncounterView(APIView):
     Handles Pokemon Encounters as a sub-resource.
     """
 
+    @extend_schema(
+        responses={
+            200: {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "location_area": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "version_details": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "version": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "url": {"type": "string"},
+                                        },
+                                    },
+                                    "max_chance": {"type": "integer"},
+                                    "encounter_details": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "min_level": {
+                                                    "type": "integer"
+                                                },
+                                                "max_level": {
+                                                    "type": "integer"
+                                                },
+                                                "condition_values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type":
+                                                                    "string"
+                                                            },
+                                                            "url": {
+                                                                "type":
+                                                                    "string"
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                                "chance": {"type": "integer"},
+                                                "method": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    )
     def get(self, request, pokemon_id):
         self.context = dict(request=request)
 

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -348,11 +348,37 @@ class ItemCategoryResource(PokeapiCommonViewset):
     serializer_class = ItemCategoryDetailSerializer
     list_serializer_class = ItemCategorySummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class ItemAttributeResource(PokeapiCommonViewset):
     queryset = ItemAttribute.objects.all()
     serializer_class = ItemAttributeDetailSerializer
     list_serializer_class = ItemAttributeSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class ItemFlingEffectResource(PokeapiCommonViewset):
@@ -360,17 +386,56 @@ class ItemFlingEffectResource(PokeapiCommonViewset):
     serializer_class = ItemFlingEffectDetailSerializer
     list_serializer_class = ItemFlingEffectSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class ItemPocketResource(PokeapiCommonViewset):
     queryset = ItemPocket.objects.all()
     serializer_class = ItemPocketDetailSerializer
     list_serializer_class = ItemPocketSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class LanguageResource(PokeapiCommonViewset):
     queryset = Language.objects.all()
     serializer_class = LanguageDetailSerializer
     list_serializer_class = LanguageSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class LocationResource(PokeapiCommonViewset):
@@ -396,11 +461,37 @@ class MoveResource(PokeapiCommonViewset):
     serializer_class = MoveDetailSerializer
     list_serializer_class = MoveSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class MoveDamageClassResource(PokeapiCommonViewset):
     queryset = MoveDamageClass.objects.all()
     serializer_class = MoveDamageClassDetailSerializer
     list_serializer_class = MoveDamageClassSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class MoveMetaAilmentResource(PokeapiCommonViewset):
@@ -408,11 +499,37 @@ class MoveMetaAilmentResource(PokeapiCommonViewset):
     serializer_class = MoveMetaAilmentDetailSerializer
     list_serializer_class = MoveMetaAilmentSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class MoveBattleStyleResource(PokeapiCommonViewset):
     queryset = MoveBattleStyle.objects.all()
     serializer_class = MoveBattleStyleDetailSerializer
     list_serializer_class = MoveBattleStyleSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class MoveMetaCategoryResource(PokeapiCommonViewset):
@@ -420,11 +537,37 @@ class MoveMetaCategoryResource(PokeapiCommonViewset):
     serializer_class = MoveMetaCategoryDetailSerializer
     list_serializer_class = MoveMetaCategorySummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class MoveLearnMethodResource(PokeapiCommonViewset):
     queryset = MoveLearnMethod.objects.all()
     serializer_class = MoveLearnMethodDetailSerializer
     list_serializer_class = MoveLearnMethodSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class MoveTargetResource(PokeapiCommonViewset):
@@ -432,11 +575,37 @@ class MoveTargetResource(PokeapiCommonViewset):
     serializer_class = MoveTargetDetailSerializer
     list_serializer_class = MoveTargetSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class NatureResource(PokeapiCommonViewset):
     queryset = Nature.objects.all()
     serializer_class = NatureDetailSerializer
     list_serializer_class = NatureSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class PalParkAreaResource(PokeapiCommonViewset):
@@ -444,11 +613,37 @@ class PalParkAreaResource(PokeapiCommonViewset):
     serializer_class = PalParkAreaDetailSerializer
     list_serializer_class = PalParkAreaSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class PokeathlonStatResource(PokeapiCommonViewset):
     queryset = PokeathlonStat.objects.all()
     serializer_class = PokeathlonStatDetailSerializer
     list_serializer_class = PokeathlonStatSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class PokedexResource(PokeapiCommonViewset):
@@ -456,11 +651,37 @@ class PokedexResource(PokeapiCommonViewset):
     serializer_class = PokedexDetailSerializer
     list_serializer_class = PokedexSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class PokemonColorResource(PokeapiCommonViewset):
     queryset = PokemonColor.objects.all()
     serializer_class = PokemonColorDetailSerializer
     list_serializer_class = PokemonColorSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class PokemonFormResource(PokeapiCommonViewset):
@@ -468,11 +689,37 @@ class PokemonFormResource(PokeapiCommonViewset):
     serializer_class = PokemonFormDetailSerializer
     list_serializer_class = PokemonFormSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class PokemonHabitatResource(PokeapiCommonViewset):
     queryset = PokemonHabitat.objects.all()
     serializer_class = PokemonHabitatDetailSerializer
     list_serializer_class = PokemonHabitatSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class PokemonShapeResource(PokeapiCommonViewset):
@@ -480,11 +727,37 @@ class PokemonShapeResource(PokeapiCommonViewset):
     serializer_class = PokemonShapeDetailSerializer
     list_serializer_class = PokemonShapeSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class PokemonResource(PokeapiCommonViewset):
     queryset = Pokemon.objects.all()
     serializer_class = PokemonDetailSerializer
     list_serializer_class = PokemonSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class PokemonSpeciesResource(PokeapiCommonViewset):
@@ -492,17 +765,56 @@ class PokemonSpeciesResource(PokeapiCommonViewset):
     serializer_class = PokemonSpeciesDetailSerializer
     list_serializer_class = PokemonSpeciesSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class RegionResource(PokeapiCommonViewset):
     queryset = Region.objects.all()
     serializer_class = RegionDetailSerializer
     list_serializer_class = RegionSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class StatResource(PokeapiCommonViewset):
     queryset = Stat.objects.all()
     serializer_class = StatDetailSerializer
     list_serializer_class = StatSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class SuperContestEffectResource(PokeapiCommonViewset):
@@ -516,17 +828,56 @@ class TypeResource(PokeapiCommonViewset):
     serializer_class = TypeDetailSerializer
     list_serializer_class = TypeSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class VersionResource(PokeapiCommonViewset):
     queryset = Version.objects.all()
     serializer_class = VersionDetailSerializer
     list_serializer_class = VersionSummarySerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 class VersionGroupResource(PokeapiCommonViewset):
     queryset = VersionGroup.objects.all()
     serializer_class = VersionGroupDetailSerializer
     list_serializer_class = VersionGroupSummarySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="id",
+                description="This parameter can be a string or an integer.",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+            ),
+        ]
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 class PokemonEncounterView(APIView):

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -1,11 +1,12 @@
 import re
+
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from django.shortcuts import get_object_or_404
-from django.http import Http404
-from drf_spectacular.utils import extend_schema, OpenApiParameter
-from drf_spectacular.types import OpenApiTypes
 
 from .models import *
 from .serializers import *
@@ -917,25 +918,15 @@ class PokemonEncounterView(APIView):
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "min_level": {
-                                                    "type": "integer"
-                                                },
-                                                "max_level": {
-                                                    "type": "integer"
-                                                },
+                                                "min_level": {"type": "integer"},
+                                                "max_level": {"type": "integer"},
                                                 "condition_values": {
                                                     "type": "array",
                                                     "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                            "name": {
-                                                                "type":
-                                                                    "string"
-                                                            },
-                                                            "url": {
-                                                                "type":
-                                                                    "string"
-                                                            },
+                                                            "name": {"type": "string"},
+                                                            "url": {"type": "string"},
                                                         },
                                                     },
                                                 },
@@ -943,12 +934,8 @@ class PokemonEncounterView(APIView):
                                                 "method": {
                                                     "type": "object",
                                                     "properties": {
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "type": "string"
-                                                        },
+                                                        "name": {"type": "string"},
+                                                        "url": {"type": "string"},
                                                     },
                                                 },
                                             },

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -612,6 +612,7 @@ class RegionDetailSerializer(serializers.ModelSerializer):
             "version_groups",
         )
 
+    @extend_schema_field(VersionGroupSummarySerializer(many=True))
     def get_region_version_groups(self, obj):
         vg_regions = VersionGroupRegion.objects.filter(region=obj)
         data = VersionGroupRegionSerializer(
@@ -641,7 +642,6 @@ class GenerationNameSerializer(serializers.ModelSerializer):
 class GenerationDetailSerializer(serializers.ModelSerializer):
     main_region = RegionSummarySerializer(source="region")
     names = GenerationNameSerializer(many=True, read_only=True, source="generationname")
-    # TODO: 空配列か確認必要
     abilities = AbilitySummarySerializer(many=True, read_only=True, source="ability")
     moves = MoveSummarySerializer(many=True, read_only=True, source="move")
     pokemon_species = PokemonSpeciesSummarySerializer(
@@ -928,6 +928,37 @@ class LocationAreaDetailSerializer(serializers.ModelSerializer):
             "pokemon_encounters",
         )
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "encounter_method": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "version_details": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "rate": {"type": "integer"},
+                            "version": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_method_rates(self, obj):
         # Get encounters related to this area and pull out unique encounter methods
         encounter_rates = LocationAreaEncounterRate.objects.filter(
@@ -969,6 +1000,65 @@ class LocationAreaDetailSerializer(serializers.ModelSerializer):
 
         return encounter_rate_list
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "pokemon": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "version_details": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "version": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "max_chance": {"type": "integet"},
+                            "encounter_details": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "min_level": {"type": "integer"},
+                                        "max_level": {"type": "integer"},
+                                        "condition_values": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {"type": "string"},
+                                                    "url": {"type": "string"},
+                                                },
+                                            },
+                                        },
+                                        "chance": {"type": "integer"},
+                                        "method": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "url": {"type": "string"},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_encounters(self, obj):
         # get versions for later use
         version_objects = Version.objects.all()
@@ -1140,8 +1230,23 @@ class AbilityDetailSerializer(serializers.ModelSerializer):
             "pokemon",
         )
 
-    # TODO: "ability"が不要のため、レスポンス用のシリアライザを定義するかは検討
-    @extend_schema_field(PokemonAbilitySerializer(many=True))
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "is_hidden": {"type": "boolean"},
+                "slot": {"type": "integer"},
+                "pokemon": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_ability_pokemon(self, obj):
         pokemon_ability_objects = PokemonAbility.objects.filter(ability=obj)
         data = PokemonAbilitySerializer(
@@ -1192,6 +1297,37 @@ class StatDetailSerializer(serializers.ModelSerializer):
             "names",
         )
 
+    @extend_schema_field({
+        "type": "object",
+        "properties": {
+            "increase": {
+                "type": "object",
+                "properties": {
+                    "change": {"type": "integer"},
+                    "move": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                },
+            },
+            "decrease": {
+                "type": "object",
+                "properties": {
+                    "change": {"type": "integer"},
+                    "move": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_moves_that_affect(self, obj):
         stat_change_objects = MoveMetaStatChange.objects.filter(stat=obj)
         stat_changes = MoveMetaStatChangeSerializer(
@@ -1208,6 +1344,31 @@ class StatDetailSerializer(serializers.ModelSerializer):
 
         return changes
 
+    @extend_schema_field({
+        "type": "object",
+        "properties": {
+            "increase": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+            "decrease": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_natures_that_affect(self, obj):
         increase_objects = Nature.objects.filter(increased_stat=obj)
         increases = NatureSummarySerializer(
@@ -1302,6 +1463,7 @@ class ItemAttributeDetailSerializer(serializers.ModelSerializer):
         model = ItemAttribute
         fields = ("id", "name", "descriptions", "items", "names")
 
+    @extend_schema_field(ItemSummarySerializer(many=True))
     def get_attribute_items(self, obj):
         item_map_objects = ItemAttributeMap.objects.filter(item_attribute=obj)
         items = []
@@ -1610,6 +1772,22 @@ class NatureDetailSerializer(serializers.ModelSerializer):
             "names",
         )
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "max_change": {"type": "integer"},
+                "pokeathlon_stat": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokeathlon_stats(self, obj):
         pokeathlon_stat_objects = NaturePokeathlonStat.objects.filter(nature=obj)
         pokeathlon_stats = NaturePokeathlonStatSerializer(
@@ -1665,8 +1843,22 @@ class BerryFlavorDetailSerializer(serializers.ModelSerializer):
         model = BerryFlavor
         fields = ("id", "name", "berries", "contest_type", "names")
 
-    # TODO: "flavor"が不要のため、レスポンス用のシリアライザを定義するかは検討
-    @extend_schema_field(BerryFlavorMapSerializer(many=True))
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "potency": {"type": "integer"},
+                "berry": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_berries_with_flavor(self, obj):
         flavor_map_objects = BerryFlavorMap.objects.filter(
             berry_flavor=obj, potency__gt=0
@@ -1704,8 +1896,22 @@ class BerryDetailSerializer(serializers.ModelSerializer):
             "natural_gift_type",
         )
 
-    # TODO: "berry"が不要のため、レスポンス用のシリアらいざを定義するかは検討
-    @extend_schema_field(BerryFlavorMapSerializer(many=True))
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "potency": {"type": "integer"},
+                "flavor": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_berry_flavors(self, obj):
         flavor_map_objects = BerryFlavorMap.objects.filter(berry=obj)
         flavor_maps = BerryFlavorMapSerializer(
@@ -1842,6 +2048,53 @@ class TypeDetailSerializer(serializers.ModelSerializer):
                 TypeSummarySerializer(type, context=self.context).data
             )
 
+    @extend_schema_field({
+        "type": "object",
+        "properties": {
+            "no_damage_to": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+            "half_damage_to": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+            "double_damage_to": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+            "no_damage_from": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+            "half_damage_from": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+            "double_damage_from": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+        },
+    })
     def get_type_relationships(self, obj):
         relations = OrderedDict()
         relations["no_damage_to"] = []
@@ -1905,8 +2158,70 @@ class TypeDetailSerializer(serializers.ModelSerializer):
                     del rel_list[i]
                     return
 
-    # returns past type relationships for the given type object
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "generation": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "damage_relations": {
+                    "type": "object",
+                    "properties": {
+                        "no_damage_to": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "half_damage_to": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "double_damage_to": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "no_damage_from": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "half_damage_from": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "double_damage_from": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_type_past_relationships(self, obj):
+        """returns past type relationships for the given type object"""
         # collect data from DB
         damage_type_results = list(TypeEfficacyPast.objects.filter(damage_type=obj))
         target_type_results = list(TypeEfficacyPast.objects.filter(target_type=obj))
@@ -2000,6 +2315,22 @@ class TypeDetailSerializer(serializers.ModelSerializer):
         gen_introduced = Generation.objects.get(pk=type_obj.generation.id)
         return gen_introduced.id <= current_gen.id
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "slot": {"type": "integer"},
+                "pokemon": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                }
+            },
+        },
+    })
     def get_type_pokemon(self, obj):
         poke_type_objects = PokemonType.objects.filter(type=obj)
         poke_types = PokemonTypeSerializer(
@@ -2106,6 +2437,7 @@ class MoveMetaAilmentDetailSerializer(serializers.ModelSerializer):
         model = MoveMetaAilment
         fields = ("id", "name", "moves", "names")
 
+    @extend_schema_field(MoveSummarySerializer(many=True))
     def get_ailment_moves(self, obj):
         move_meta_objects = MoveMeta.objects.filter(move_meta_ailment=obj)
         moves = []
@@ -2136,6 +2468,7 @@ class MoveMetaCategoryDetailSerializer(serializers.ModelSerializer):
         model = MoveMetaCategory
         fields = ("id", "name", "descriptions", "moves")
 
+    @extend_schema_field(MoveSummarySerializer(many=True))
     def get_category_moves(self, obj):
         move_meta_objects = MoveMeta.objects.filter(move_meta_category=obj)
         moves = []
@@ -2327,6 +2660,7 @@ class MoveDetailSerializer(serializers.ModelSerializer):
             "learned_by_pokemon",
         )
 
+    @extend_schema_field(PokemonSummarySerializer(many=True))
     def get_learned_by_pokemon(self, obj):
         pokemon_moves = PokemonMove.objects.filter(move_id=obj).order_by("pokemon_id")
 
@@ -2344,6 +2678,27 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return pokemon_list
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "machine": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                    },
+                },
+                "version_group": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_move_machines(self, obj):
         machine_objects = Machine.objects.filter(move=obj)
 
@@ -2364,6 +2719,61 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return machines
 
+    @extend_schema_field({
+        "type": "object",
+        "properties": {
+            "normal": {
+                "type": "object",
+                "properties": {
+                    "use_before": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
+                    "use_after": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+            "super": {
+                "type": "object",
+                "properties": {
+                    "use_before": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
+                    "use_after": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_combos(self, obj):
         normal_before_objects = ContestCombo.objects.filter(first_move=obj)
         normal_before_data = ContestComboSerializer(
@@ -2421,6 +2831,7 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return details
 
+    @extend_schema_field(MoveEffectEffectTextSerializer(many=True))
     def get_effect_text(self, obj):
         effect_texts = MoveEffectEffectText.objects.filter(move_effect=obj.move_effect)
         data = MoveEffectEffectTextSerializer(
@@ -2435,6 +2846,7 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return data
 
+    @extend_schema_field(MoveEffectChangeSerializer(many=True))
     def get_effect_change_text(self, obj):
         effect_changes = MoveEffectChange.objects.filter(move_effect=obj.move_effect)
         data = MoveEffectChangeSerializer(
@@ -2443,6 +2855,22 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return data
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "change": {"type": "integer"},
+                "stat": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_move_stat_change(self, obj):
         stat_change_objects = MoveMetaStatChange.objects.filter(move=obj)
         stat_changes = MoveMetaStatChangeSerializer(
@@ -2487,6 +2915,23 @@ class PalParkAreaDetailSerializer(serializers.ModelSerializer):
         model = PalParkArea
         fields = ("id", "name", "names", "pokemon_encounters")
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "base_score": {"type": "integer"},
+                "rate": {"type": "integer"},
+                "pokemon_species": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_encounters(self, obj):
         pal_park_objects = PalPark.objects.filter(pal_park_area=obj)
         parks = PalParkSerializer(
@@ -2571,6 +3016,22 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
             "types",
         )
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "language": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_form_names(self, obj):
         form_results = PokemonFormName.objects.filter(
             pokemon_form=obj, name__regex=".+"
@@ -2586,6 +3047,22 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
 
         return data
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "language": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_form_pokemon_names(self, obj):
         form_results = PokemonFormName.objects.filter(
             pokemon_form=obj, pokemon_name__regex=".+"
@@ -2606,6 +3083,22 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
         sprites_object = PokemonFormSprites.objects.get(pokemon_form_id=obj)
         return sprites_object.sprites
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "slot": {"type": "string"},
+                "type": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_form_types(self, obj):
         form_type_objects = PokemonFormType.objects.filter(pokemon_form=obj)
         form_types = PokemonFormTypeSerializer(
@@ -2689,6 +3182,7 @@ class MoveLearnMethodDetailSerializer(serializers.ModelSerializer):
         model = MoveLearnMethod
         fields = ("id", "name", "names", "descriptions", "version_groups")
 
+    @extend_schema_field(VersionGroupSummarySerializer(many=True))
     def get_method_version_groups(self, obj):
         version_group_objects = VersionGroupMoveLearnMethod.objects.filter(
             move_learn_method=obj
@@ -2733,6 +3227,22 @@ class PokemonShapeDetailSerializer(serializers.ModelSerializer):
         model = PokemonShape
         fields = ("id", "name", "awesome_names", "names", "pokemon_species")
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "language": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_shape_names(self, obj):
         results = PokemonShapeName.objects.filter(pokemon_shape_id=obj)
         serializer = PokemonShapeNameSerializer(
@@ -2745,6 +3255,22 @@ class PokemonShapeDetailSerializer(serializers.ModelSerializer):
 
         return data
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "awesome_name": {"type": "string"},
+                "language": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_shape_awesome_names(self, obj):
         results = PokemonShapeName.objects.filter(pokemon_shape_id=obj)
         serializer = PokemonShapeNameSerializer(
@@ -2846,6 +3372,44 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
         cries_object = PokemonCries.objects.get(pokemon_id=obj)
         return cries_object.cries
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "move": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "version_group_details": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "level_learned_at": {"type": "integer"},
+                            "version_group": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "move_learn_method": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_moves(self, obj):
         version_objects = VersionGroup.objects.all()
         version_data = VersionGroupSummarySerializer(
@@ -2897,6 +3461,37 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return move_list
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "version_details": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "rarity": {"type": "integer"},
+                            "version": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_held_items(self, obj):
         # Get items related to this pokemon and pull out unique Item IDs
         pokemon_items = PokemonItem.objects.filter(pokemon_id=obj).order_by("item_id")
@@ -2930,6 +3525,23 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return item_list
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "is_hidden": {"type": "boolean"},
+                "slot": {"type": "integer"},
+                "ability": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_abilities(self, obj):
         pokemon_ability_objects = PokemonAbility.objects.filter(pokemon=obj)
         data = PokemonAbilitySerializer(
@@ -2943,6 +3555,31 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return abilities
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "generation": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "abilities": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_past_pokemon_abilities(self, obj):
         pokemon_past_ability_objects = PokemonAbilityPast.objects.filter(pokemon=obj)
         pokemon_past_abilities = PokemonAbilityPastSerializer(
@@ -2978,6 +3615,22 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return final_data
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "slot": {"type": "integer"},
+                "type": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_types(self, obj):
         poke_type_objects = PokemonType.objects.filter(pokemon=obj)
         poke_types = PokemonTypeSerializer(
@@ -2989,6 +3642,37 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return poke_types
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "generation": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "types": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "slot": {"type": "integer"},
+                            "type": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_past_pokemon_types(self, obj):
         poke_past_type_objects = PokemonTypePast.objects.filter(pokemon=obj)
         poke_past_types = PokemonTypePastSerializer(
@@ -3157,6 +3841,19 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
             "varieties",
         )
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "language": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+        },
+    })
     def get_pokemon_names(self, obj):
         species_results = PokemonSpeciesName.objects.filter(pokemon_species=obj)
         species_serializer = PokemonSpeciesNameSerializer(
@@ -3170,6 +3867,22 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return data
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "genus": {"type": "string"},
+                "language": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_genera(self, obj):
         results = PokemonSpeciesName.objects.filter(pokemon_species=obj)
         serializer = PokemonSpeciesNameSerializer(
@@ -3185,6 +3898,16 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return genera
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "url": {"type": "string"},
+            },
+        },
+    })
     def get_pokemon_egg_groups(self, obj):
         results = PokemonEggGroup.objects.filter(pokemon_species=obj)
         data = PokemonEggGroupSerializer(results, many=True, context=self.context).data
@@ -3194,6 +3917,22 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return groups
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "is_default": {"type": "boolean"},
+                "pokemon": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokemon_varieties(self, obj):
         results = Pokemon.objects.filter(pokemon_species=obj)
         summary_data = PokemonSummarySerializer(
@@ -3213,6 +3952,20 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return varieties
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "base_score": {"type": "integer"},
+                "rate": {"type": "integer"},
+                "area": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+        },
+    })
     def get_encounters(self, obj):
         pal_park_objects = PalPark.objects.filter(pokemon_species=obj)
         parks = PalParkSerializer(
@@ -3263,7 +4016,6 @@ class PokemonEvolutionSerializer(serializers.ModelSerializer):
 
 
 class EvolutionChainDetailSerializer(serializers.ModelSerializer):
-    # TODO: baby_trigger_itemが常にnullなのかは確認
     baby_trigger_item = ItemSummarySerializer()
     chain = serializers.SerializerMethodField("build_chain")
 
@@ -3271,7 +4023,109 @@ class EvolutionChainDetailSerializer(serializers.ModelSerializer):
         model = EvolutionChain
         fields = ("id", "baby_trigger_item", "chain")
 
-    # TODO: 定義追加。シリアライザを定義するか、オブジェクトを一から定義するかは検討
+    @extend_schema_field({
+        "type": "object",
+        "properties": {
+            "is_baby": {"type": "boolean"},
+            "species": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+            "evolution_details": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "item": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "trigger": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "gender": {},
+                        "held_item": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "known_move": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "known_move_type": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "location": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "min_level": {"type": "integer"},
+                        "min_happiness": {"type": "integer"},
+                        "min_beauty": {"type": "integer"},
+                        "min_affection": {"type": "integer"},
+                        "needs_overworld_rain": {"type": "boolean"},
+                        "party_species": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "party_type": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "relative_physical_stats": {"type": "integer"},
+                        "time_of_day": {"type": "string"},
+                        "trade_species": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                        "turn_upside_down": {"type": "boolean"},
+                    },
+                },
+            },
+            "evolves_to": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def build_chain(self, obj):
         chain_id = obj.id
 
@@ -3384,6 +4238,46 @@ class PokeathlonStatDetailSerializer(serializers.HyperlinkedModelSerializer):
         model = PokeathlonStat
         fields = ("id", "name", "affecting_natures", "names")
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "increase": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "max_change": {"type": "integer"},
+                            "nature": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+                "decrease": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "max_change": {"type": "integer"},
+                            "nature": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
     def get_natures_that_affect(self, obj):
         stat_change_objects = NaturePokeathlonStat.objects.filter(pokeathlon_stat=obj)
         stat_changes = NaturePokeathlonStatSerializer(
@@ -3442,6 +4336,22 @@ class PokedexDetailSerializer(serializers.ModelSerializer):
             "version_groups",
         )
 
+    @extend_schema_field({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "entry_number": {"type": "integer"},
+                "pokemon_species": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })
     def get_pokedex_entries(self, obj):
         results = PokemonDexNumber.objects.filter(pokedex=obj).order_by(
             "pokedex_number"
@@ -3456,6 +4366,7 @@ class PokedexDetailSerializer(serializers.ModelSerializer):
 
         return data
 
+    @extend_schema_field(VersionGroupSummarySerializer(many=True))
     def get_pokedex_version_groups(self, obj):
         dex_group_objects = PokedexVersionGroup.objects.filter(pokedex=obj)
         dex_groups = PokedexVersionGroupSerializer(
@@ -3515,6 +4426,7 @@ class VersionGroupDetailSerializer(serializers.ModelSerializer):
             "versions",
         )
 
+    @extend_schema_field(RegionSummarySerializer(many=True))
     def get_version_group_regions(self, obj):
         vg_regions = VersionGroupRegion.objects.filter(version_group=obj)
         data = VersionGroupRegionSerializer(
@@ -3527,6 +4439,7 @@ class VersionGroupDetailSerializer(serializers.ModelSerializer):
 
         return regions
 
+    @extend_schema_field(MoveLearnMethodSummarySerializer(many=True))
     def get_learn_methods(self, obj):
         learn_method_objects = VersionGroupMoveLearnMethod.objects.filter(
             version_group=obj
@@ -3541,6 +4454,7 @@ class VersionGroupDetailSerializer(serializers.ModelSerializer):
 
         return methods
 
+    @extend_schema_field(PokedexSummarySerializer(many=True))
     def get_version_groups_pokedexes(self, obj):
         dex_group_objects = PokedexVersionGroup.objects.filter(version_group=obj)
         dex_groups = PokedexVersionGroupSerializer(

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -364,6 +364,15 @@ class PokemonAbilitySerializer(serializers.ModelSerializer):
         fields = ("is_hidden", "slot", "ability", "pokemon")
 
 
+# TODO: sample code
+class GetAbilityPokemonSerializer(serializers.ModelSerializer):
+    pokemon = PokemonSummarySerializer()
+
+    class Meta:
+        model = PokemonAbility
+        fields = ("is_hidden", "slot", "pokemon")
+
+
 class PokemonAbilityPastSerializer(serializers.ModelSerializer):
     generation = GenerationSummarySerializer()
     ability = AbilitySummarySerializer()
@@ -1237,37 +1246,20 @@ class AbilityDetailSerializer(serializers.ModelSerializer):
             "pokemon",
         )
 
-    @extend_schema_field(
-        {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "is_hidden": {"type": "boolean"},
-                    "slot": {"type": "integer"},
-                    "pokemon": {
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string"},
-                            "url": {"type": "string"},
-                        },
-                    },
-                },
-            },
-        }
-    )
+    @extend_schema_field(GetAbilityPokemonSerializer(many=True))
     def get_ability_pokemon(self, obj):
         pokemon_ability_objects = PokemonAbility.objects.filter(ability=obj)
-        data = PokemonAbilitySerializer(
+        # TODO: sample code
+        return GetAbilityPokemonSerializer(
             pokemon_ability_objects, many=True, context=self.context
         ).data
-        pokemon = []
+        # pokemon = []
 
-        for poke in data:
-            del poke["ability"]
-            pokemon.append(poke)
+        # for poke in data:
+        #     del poke["ability"]
+        #     pokemon.append(poke)
 
-        return pokemon
+        # return pokemon
 
 
 ######################

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -1030,7 +1030,7 @@ class LocationAreaDetailSerializer(serializers.ModelSerializer):
                                         "url": {"type": "string"},
                                     },
                                 },
-                                "max_chance": {"type": "integet"},
+                                "max_chance": {"type": "integer"},
                                 "encounter_details": {
                                     "type": "array",
                                     "items": {
@@ -3910,8 +3910,11 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
                 "properties": {
                     "name": {"type": "string"},
                     "language": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
@@ -4030,8 +4033,11 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
                     "base_score": {"type": "integer"},
                     "rate": {"type": "integer"},
                     "area": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -1,15 +1,16 @@
-from collections import OrderedDict
 import json
+from collections import OrderedDict
+
 from django.urls import reverse
-from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from .models import *
 
 # pylint: disable=redefined-builtin
 
 # PokeAPI v2 serializers in order of dependency
-
-from .models import *
 
 
 #########################
@@ -680,22 +681,24 @@ class GenderDetailSerializer(serializers.ModelSerializer):
         model = Gender
         fields = ("id", "name", "pokemon_species_details", "required_for_evolution")
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "rate": {"type": "integer"},
-                "pokemon_species": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rate": {"type": "integer"},
+                    "pokemon_species": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_species(self, obj):
         species_objects = []
 
@@ -928,37 +931,39 @@ class LocationAreaDetailSerializer(serializers.ModelSerializer):
             "pokemon_encounters",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "encounter_method": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "version_details": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "encounter_method": {
                         "type": "object",
                         "properties": {
-                            "rate": {"type": "integer"},
-                            "version": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                    "version_details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "rate": {"type": "integer"},
+                                "version": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_method_rates(self, obj):
         # Get encounters related to this area and pull out unique encounter methods
         encounter_rates = LocationAreaEncounterRate.objects.filter(
@@ -1000,54 +1005,56 @@ class LocationAreaDetailSerializer(serializers.ModelSerializer):
 
         return encounter_rate_list
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "pokemon": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "version_details": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "pokemon": {
                         "type": "object",
                         "properties": {
-                            "version": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
-                                },
-                            },
-                            "max_chance": {"type": "integet"},
-                            "encounter_details": {
-                                "type": "array",
-                                "items": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                    "version_details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "version": {
                                     "type": "object",
                                     "properties": {
-                                        "min_level": {"type": "integer"},
-                                        "max_level": {"type": "integer"},
-                                        "condition_values": {
-                                            "type": "array",
-                                            "items": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
+                                },
+                                "max_chance": {"type": "integet"},
+                                "encounter_details": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "min_level": {"type": "integer"},
+                                            "max_level": {"type": "integer"},
+                                            "condition_values": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {"type": "string"},
+                                                        "url": {"type": "string"},
+                                                    },
+                                                },
+                                            },
+                                            "chance": {"type": "integer"},
+                                            "method": {
                                                 "type": "object",
                                                 "properties": {
                                                     "name": {"type": "string"},
                                                     "url": {"type": "string"},
                                                 },
-                                            },
-                                        },
-                                        "chance": {"type": "integer"},
-                                        "method": {
-                                            "type": "object",
-                                            "properties": {
-                                                "name": {"type": "string"},
-                                                "url": {"type": "string"},
                                             },
                                         },
                                     },
@@ -1057,8 +1064,8 @@ class LocationAreaDetailSerializer(serializers.ModelSerializer):
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_encounters(self, obj):
         # get versions for later use
         version_objects = Version.objects.all()
@@ -1230,23 +1237,25 @@ class AbilityDetailSerializer(serializers.ModelSerializer):
             "pokemon",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "is_hidden": {"type": "boolean"},
-                "slot": {"type": "integer"},
-                "pokemon": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "is_hidden": {"type": "boolean"},
+                    "slot": {"type": "integer"},
+                    "pokemon": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_ability_pokemon(self, obj):
         pokemon_ability_objects = PokemonAbility.objects.filter(ability=obj)
         data = PokemonAbilitySerializer(
@@ -1297,37 +1306,39 @@ class StatDetailSerializer(serializers.ModelSerializer):
             "names",
         )
 
-    @extend_schema_field({
-        "type": "object",
-        "properties": {
-            "increase": {
-                "type": "object",
-                "properties": {
-                    "change": {"type": "integer"},
-                    "move": {
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string"},
-                            "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "object",
+            "properties": {
+                "increase": {
+                    "type": "object",
+                    "properties": {
+                        "change": {"type": "integer"},
+                        "move": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+                "decrease": {
+                    "type": "object",
+                    "properties": {
+                        "change": {"type": "integer"},
+                        "move": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
                         },
                     },
                 },
             },
-            "decrease": {
-                "type": "object",
-                "properties": {
-                    "change": {"type": "integer"},
-                    "move": {
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string"},
-                            "url": {"type": "string"},
-                        },
-                    },
-                },
-            },
-        },
-    })
+        }
+    )
     def get_moves_that_affect(self, obj):
         stat_change_objects = MoveMetaStatChange.objects.filter(stat=obj)
         stat_changes = MoveMetaStatChangeSerializer(
@@ -1344,31 +1355,33 @@ class StatDetailSerializer(serializers.ModelSerializer):
 
         return changes
 
-    @extend_schema_field({
-        "type": "object",
-        "properties": {
-            "increase": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "object",
+            "properties": {
+                "increase": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                },
+                "decrease": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-            "decrease": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-            },
-        },
-    })
+        }
+    )
     def get_natures_that_affect(self, obj):
         increase_objects = Nature.objects.filter(increased_stat=obj)
         increases = NatureSummarySerializer(
@@ -1580,22 +1593,24 @@ class ItemDetailSerializer(serializers.ModelSerializer):
             "machines",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "machine": {"type": "string"},
-                "version_group": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "machine": {"type": "string"},
+                    "version_group": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
         }
-    })
+    )
     def get_item_machines(self, obj):
         machine_objects = Machine.objects.filter(item=obj)
 
@@ -1616,12 +1631,14 @@ class ItemDetailSerializer(serializers.ModelSerializer):
 
         return machines
 
-    @extend_schema_field({
-        "type": "object",
-        "properties": {
-            "default": {"type": "string"},
-        },
-    })
+    @extend_schema_field(
+        {
+            "type": "object",
+            "properties": {
+                "default": {"type": "string"},
+            },
+        }
+    )
     def get_item_sprites(self, obj):
         sprites_object = ItemSprites.objects.get(item_id=obj)
         return sprites_object.sprites
@@ -1644,37 +1661,39 @@ class ItemDetailSerializer(serializers.ModelSerializer):
 
         return attributes
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "pokemon": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "version_details": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "pokemon": {
                         "type": "object",
                         "properties": {
-                            "rarity": {"type": "integer"},
-                            "version": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                    "version_details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "rarity": {"type": "integer"},
+                                "version": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_held_by_pokemon(self, obj):
         pokemon_items = PokemonItem.objects.filter(item=obj).order_by("pokemon_id")
         pokemon_ids = pokemon_items.values("pokemon_id").distinct()
@@ -1772,22 +1791,24 @@ class NatureDetailSerializer(serializers.ModelSerializer):
             "names",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "max_change": {"type": "integer"},
-                "pokeathlon_stat": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "max_change": {"type": "integer"},
+                    "pokeathlon_stat": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokeathlon_stats(self, obj):
         pokeathlon_stat_objects = NaturePokeathlonStat.objects.filter(nature=obj)
         pokeathlon_stats = NaturePokeathlonStatSerializer(
@@ -1843,22 +1864,24 @@ class BerryFlavorDetailSerializer(serializers.ModelSerializer):
         model = BerryFlavor
         fields = ("id", "name", "berries", "contest_type", "names")
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "potency": {"type": "integer"},
-                "berry": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "potency": {"type": "integer"},
+                    "berry": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_berries_with_flavor(self, obj):
         flavor_map_objects = BerryFlavorMap.objects.filter(
             berry_flavor=obj, potency__gt=0
@@ -1896,22 +1919,24 @@ class BerryDetailSerializer(serializers.ModelSerializer):
             "natural_gift_type",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "potency": {"type": "integer"},
-                "flavor": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "potency": {"type": "integer"},
+                    "flavor": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_berry_flavors(self, obj):
         flavor_map_objects = BerryFlavorMap.objects.filter(berry=obj)
         flavor_maps = BerryFlavorMapSerializer(
@@ -2048,53 +2073,55 @@ class TypeDetailSerializer(serializers.ModelSerializer):
                 TypeSummarySerializer(type, context=self.context).data
             )
 
-    @extend_schema_field({
-        "type": "object",
-        "properties": {
-            "no_damage_to": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "object",
+            "properties": {
+                "no_damage_to": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "half_damage_to": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "double_damage_to": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "no_damage_from": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "half_damage_from": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                },
+                "double_damage_from": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
                 },
             },
-            "half_damage_to": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
-                },
-            },
-            "double_damage_to": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
-                },
-            },
-            "no_damage_from": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
-                },
-            },
-            "half_damage_from": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
-                },
-            },
-            "double_damage_from": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
-                },
-            },
-        },
-    })
+        }
+    )
     def get_type_relationships(self, obj):
         relations = OrderedDict()
         relations["no_damage_to"] = []
@@ -2158,68 +2185,70 @@ class TypeDetailSerializer(serializers.ModelSerializer):
                     del rel_list[i]
                     return
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "generation": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "generation": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
-                },
-                "damage_relations": {
-                    "type": "object",
-                    "properties": {
-                        "no_damage_to": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                    "damage_relations": {
+                        "type": "object",
+                        "properties": {
+                            "no_damage_to": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
-                        },
-                        "half_damage_to": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                            "half_damage_to": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
-                        },
-                        "double_damage_to": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                            "double_damage_to": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
-                        },
-                        "no_damage_from": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                            "no_damage_from": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
-                        },
-                        "half_damage_from": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                            "half_damage_from": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
-                        },
-                        "double_damage_from": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                            "double_damage_from": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_type_past_relationships(self, obj):
         """returns past type relationships for the given type object"""
         # collect data from DB
@@ -2315,22 +2344,24 @@ class TypeDetailSerializer(serializers.ModelSerializer):
         gen_introduced = Generation.objects.get(pk=type_obj.generation.id)
         return gen_introduced.id <= current_gen.id
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "slot": {"type": "integer"},
-                "pokemon": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "slot": {"type": "integer"},
+                    "pokemon": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
-                }
+                },
             },
-        },
-    })
+        }
+    )
     def get_type_pokemon(self, obj):
         poke_type_objects = PokemonType.objects.filter(type=obj)
         poke_types = PokemonTypeSerializer(
@@ -2678,27 +2709,29 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return pokemon_list
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "machine": {
-                    "type": "object",
-                    "properties": {
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "machine": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                        },
                     },
-                },
-                "version_group": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+                    "version_group": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_move_machines(self, obj):
         machine_objects = Machine.objects.filter(move=obj)
 
@@ -2719,61 +2752,63 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return machines
 
-    @extend_schema_field({
-        "type": "object",
-        "properties": {
-            "normal": {
-                "type": "object",
-                "properties": {
-                    "use_before": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "object",
+            "properties": {
+                "normal": {
+                    "type": "object",
+                    "properties": {
+                        "use_before": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                        "use_after": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
                         },
                     },
-                    "use_after": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
+                },
+                "super": {
+                    "type": "object",
+                    "properties": {
+                        "use_before": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                        },
+                        "use_after": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
                             },
                         },
                     },
                 },
             },
-            "super": {
-                "type": "object",
-                "properties": {
-                    "use_before": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                    },
-                    "use_after": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    })
+        }
+    )
     def get_combos(self, obj):
         normal_before_objects = ContestCombo.objects.filter(first_move=obj)
         normal_before_data = ContestComboSerializer(
@@ -2855,22 +2890,24 @@ class MoveDetailSerializer(serializers.ModelSerializer):
 
         return data
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "change": {"type": "integer"},
-                "stat": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "change": {"type": "integer"},
+                    "stat": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_move_stat_change(self, obj):
         stat_change_objects = MoveMetaStatChange.objects.filter(move=obj)
         stat_changes = MoveMetaStatChangeSerializer(
@@ -2915,23 +2952,25 @@ class PalParkAreaDetailSerializer(serializers.ModelSerializer):
         model = PalParkArea
         fields = ("id", "name", "names", "pokemon_encounters")
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "base_score": {"type": "integer"},
-                "rate": {"type": "integer"},
-                "pokemon_species": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "base_score": {"type": "integer"},
+                    "rate": {"type": "integer"},
+                    "pokemon_species": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_encounters(self, obj):
         pal_park_objects = PalPark.objects.filter(pal_park_area=obj)
         parks = PalParkSerializer(
@@ -3016,22 +3055,24 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
             "types",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "language": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "language": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_form_names(self, obj):
         form_results = PokemonFormName.objects.filter(
             pokemon_form=obj, name__regex=".+"
@@ -3047,22 +3088,24 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
 
         return data
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "language": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "language": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_form_pokemon_names(self, obj):
         form_results = PokemonFormName.objects.filter(
             pokemon_form=obj, pokemon_name__regex=".+"
@@ -3083,22 +3126,24 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
         sprites_object = PokemonFormSprites.objects.get(pokemon_form_id=obj)
         return sprites_object.sprites
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "slot": {"type": "string"},
-                "type": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "slot": {"type": "string"},
+                    "type": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_form_types(self, obj):
         form_type_objects = PokemonFormType.objects.filter(pokemon_form=obj)
         form_types = PokemonFormTypeSerializer(
@@ -3227,22 +3272,24 @@ class PokemonShapeDetailSerializer(serializers.ModelSerializer):
         model = PokemonShape
         fields = ("id", "name", "awesome_names", "names", "pokemon_species")
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "language": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "language": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_shape_names(self, obj):
         results = PokemonShapeName.objects.filter(pokemon_shape_id=obj)
         serializer = PokemonShapeNameSerializer(
@@ -3255,22 +3302,24 @@ class PokemonShapeDetailSerializer(serializers.ModelSerializer):
 
         return data
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "awesome_name": {"type": "string"},
-                "language": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "awesome_name": {"type": "string"},
+                    "language": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_shape_awesome_names(self, obj):
         results = PokemonShapeName.objects.filter(pokemon_shape_id=obj)
         serializer = PokemonShapeNameSerializer(
@@ -3372,44 +3421,46 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
         cries_object = PokemonCries.objects.get(pokemon_id=obj)
         return cries_object.cries
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "move": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "version_group_details": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "move": {
                         "type": "object",
                         "properties": {
-                            "level_learned_at": {"type": "integer"},
-                            "version_group": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                    "version_group_details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "level_learned_at": {"type": "integer"},
+                                "version_group": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
-                            },
-                            "move_learn_method": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                                "move_learn_method": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_moves(self, obj):
         version_objects = VersionGroup.objects.all()
         version_data = VersionGroupSummarySerializer(
@@ -3461,37 +3512,39 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return move_list
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "item": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "version_details": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "item": {
                         "type": "object",
                         "properties": {
-                            "rarity": {"type": "integer"},
-                            "version": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                    "version_details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "rarity": {"type": "integer"},
+                                "version": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_held_items(self, obj):
         # Get items related to this pokemon and pull out unique Item IDs
         pokemon_items = PokemonItem.objects.filter(pokemon_id=obj).order_by("item_id")
@@ -3525,23 +3578,25 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return item_list
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "is_hidden": {"type": "boolean"},
-                "slot": {"type": "integer"},
-                "ability": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "is_hidden": {"type": "boolean"},
+                    "slot": {"type": "integer"},
+                    "ability": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_abilities(self, obj):
         pokemon_ability_objects = PokemonAbility.objects.filter(pokemon=obj)
         data = PokemonAbilitySerializer(
@@ -3555,31 +3610,33 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return abilities
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "generation": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "abilities": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "generation": {
                         "type": "object",
                         "properties": {
                             "name": {"type": "string"},
                             "url": {"type": "string"},
                         },
                     },
+                    "abilities": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                        },
+                    },
                 },
             },
-        },
-    })
+        }
+    )
     def get_past_pokemon_abilities(self, obj):
         pokemon_past_ability_objects = PokemonAbilityPast.objects.filter(pokemon=obj)
         pokemon_past_abilities = PokemonAbilityPastSerializer(
@@ -3615,22 +3672,24 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return final_data
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "slot": {"type": "integer"},
-                "type": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "slot": {"type": "integer"},
+                    "type": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_types(self, obj):
         poke_type_objects = PokemonType.objects.filter(pokemon=obj)
         poke_types = PokemonTypeSerializer(
@@ -3642,37 +3701,39 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return poke_types
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "generation": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
-                    },
-                },
-                "types": {
-                    "type": "array",
-                    "items": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "generation": {
                         "type": "object",
                         "properties": {
-                            "slot": {"type": "integer"},
-                            "type": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                    "types": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "slot": {"type": "integer"},
+                                "type": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_past_pokemon_types(self, obj):
         poke_past_type_objects = PokemonTypePast.objects.filter(pokemon=obj)
         poke_past_types = PokemonTypePastSerializer(
@@ -3841,19 +3902,21 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
             "varieties",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "language": {
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
                     "name": {"type": "string"},
-                    "url": {"type": "string"},
+                    "language": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_names(self, obj):
         species_results = PokemonSpeciesName.objects.filter(pokemon_species=obj)
         species_serializer = PokemonSpeciesNameSerializer(
@@ -3867,22 +3930,24 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return data
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "genus": {"type": "string"},
-                "language": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "genus": {"type": "string"},
+                    "language": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_genera(self, obj):
         results = PokemonSpeciesName.objects.filter(pokemon_species=obj)
         serializer = PokemonSpeciesNameSerializer(
@@ -3898,16 +3963,18 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return genera
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"},
+                },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_egg_groups(self, obj):
         results = PokemonEggGroup.objects.filter(pokemon_species=obj)
         data = PokemonEggGroupSerializer(results, many=True, context=self.context).data
@@ -3917,22 +3984,24 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return groups
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "is_default": {"type": "boolean"},
-                "pokemon": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "is_default": {"type": "boolean"},
+                    "pokemon": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokemon_varieties(self, obj):
         results = Pokemon.objects.filter(pokemon_species=obj)
         summary_data = PokemonSummarySerializer(
@@ -3952,20 +4021,22 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
         return varieties
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "base_score": {"type": "integer"},
-                "rate": {"type": "integer"},
-                "area": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "base_score": {"type": "integer"},
+                    "rate": {"type": "integer"},
+                    "area": {
+                        "name": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
                 },
             },
-        },
-    })
+        }
+    )
     def get_encounters(self, obj):
         pal_park_objects = PalPark.objects.filter(pokemon_species=obj)
         parks = PalParkSerializer(
@@ -4023,109 +4094,111 @@ class EvolutionChainDetailSerializer(serializers.ModelSerializer):
         model = EvolutionChain
         fields = ("id", "baby_trigger_item", "chain")
 
-    @extend_schema_field({
-        "type": "object",
-        "properties": {
-            "is_baby": {"type": "boolean"},
-            "species": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "url": {"type": "string"},
-                },
-            },
-            "evolution_details": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "item": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "trigger": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "gender": {},
-                        "held_item": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "known_move": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "known_move_type": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "location": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "min_level": {"type": "integer"},
-                        "min_happiness": {"type": "integer"},
-                        "min_beauty": {"type": "integer"},
-                        "min_affection": {"type": "integer"},
-                        "needs_overworld_rain": {"type": "boolean"},
-                        "party_species": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "party_type": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "relative_physical_stats": {"type": "integer"},
-                        "time_of_day": {"type": "string"},
-                        "trade_species": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "url": {"type": "string"},
-                            },
-                        },
-                        "turn_upside_down": {"type": "boolean"},
-                    },
-                },
-            },
-            "evolves_to": {
-                "type": "array",
-                "items": {
+    @extend_schema_field(
+        {
+            "type": "object",
+            "properties": {
+                "is_baby": {"type": "boolean"},
+                "species": {
                     "type": "object",
                     "properties": {
                         "name": {"type": "string"},
                         "url": {"type": "string"},
                     },
                 },
+                "evolution_details": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "item": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "trigger": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "gender": {},
+                            "held_item": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "known_move": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "known_move_type": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "location": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "min_level": {"type": "integer"},
+                            "min_happiness": {"type": "integer"},
+                            "min_beauty": {"type": "integer"},
+                            "min_affection": {"type": "integer"},
+                            "needs_overworld_rain": {"type": "boolean"},
+                            "party_species": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "party_type": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "relative_physical_stats": {"type": "integer"},
+                            "time_of_day": {"type": "string"},
+                            "trade_species": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "url": {"type": "string"},
+                                },
+                            },
+                            "turn_upside_down": {"type": "boolean"},
+                        },
+                    },
+                },
+                "evolves_to": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                    },
+                },
             },
-        },
-    })
+        }
+    )
     def build_chain(self, obj):
         chain_id = obj.id
 
@@ -4238,46 +4311,48 @@ class PokeathlonStatDetailSerializer(serializers.HyperlinkedModelSerializer):
         model = PokeathlonStat
         fields = ("id", "name", "affecting_natures", "names")
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "increase": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "max_change": {"type": "integer"},
-                            "nature": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "increase": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "max_change": {"type": "integer"},
+                                "nature": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
-                },
-                "decrease": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "max_change": {"type": "integer"},
-                            "nature": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "url": {"type": "string"},
+                    "decrease": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "max_change": {"type": "integer"},
+                                "nature": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "url": {"type": "string"},
+                                    },
                                 },
                             },
                         },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_natures_that_affect(self, obj):
         stat_change_objects = NaturePokeathlonStat.objects.filter(pokeathlon_stat=obj)
         stat_changes = NaturePokeathlonStatSerializer(
@@ -4336,22 +4411,24 @@ class PokedexDetailSerializer(serializers.ModelSerializer):
             "version_groups",
         )
 
-    @extend_schema_field({
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "entry_number": {"type": "integer"},
-                "pokemon_species": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "url": {"type": "string"},
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "entry_number": {"type": "integer"},
+                    "pokemon_species": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
                     },
                 },
             },
-        },
-    })
+        }
+    )
     def get_pokedex_entries(self, obj):
         results = PokemonDexNumber.objects.filter(pokedex=obj).order_by(
             "pokedex_number"

--- a/pokemon_v2/urls.py
+++ b/pokemon_v2/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.urls import path
 
 #####################################
 #
@@ -7,6 +8,12 @@ from django.conf.urls import include, url
 #####################################
 
 from rest_framework import routers
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
+
 from pokemon_v2.api import *
 
 # pylint: disable=invalid-name
@@ -75,5 +82,20 @@ urlpatterns = [
         r"^api/v2/pokemon/(?P<pokemon_id>\d+)/encounters",
         PokemonEncounterView.as_view(),
         name="pokemon_encounters",
+    ),
+    path(
+        "api/v2/schema/",
+        SpectacularAPIView.as_view(),
+        name="schema",
+    ),
+    path(
+        "api/v2/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "api/v2/schema/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
     ),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django-discover-runner==1.0
 django-redis==4.12.1
 django-cachalot==2.4.2
 djangorestframework==3.14.0
+drf-spectacular==0.27.1
 gunicorn==21.2.0
 mimeparse==0.1.3
 psycopg2-binary==2.9.9


### PR DESCRIPTION
Hello.
I am not good at English, so sorry if I am rude.

We have added OpenAPI support and UI for Swagger and ReDoc.
You will be able to try the API on the web.
You can also visualize response and request types.

Swagger: [http://localhost/api/v2/schema/swagger-ui/](http://localhost/api/v2/schema/swagger-ui/)
ReDoc: [http://localhost/api/v2/schema/redoc/](http://localhost/api/v2/schema/redoc/)

Some changes are convered by #1046 pull request.

Relevant issue: #528 