### PR TITLE
docs(openapi): `q` query string param, fix `id` path parameter, nix refactor

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,10 @@
 with import <nixpkgs> { };
-
-let
-  pythonPackages = python3Packages;
-in pkgs.mkShell rec {
-  name = "impurePythonEnv";
+pkgs.mkShell {
+  name = "onix-shellder";
   venvDir = "./.venv";
   buildInputs = [
     python310Packages.python
     python310Packages.venvShellHook
-
-    # python310Packages.coverage
-    # python310Packages.python-mimeparse
-    # python310Packages.python-dateutil
-    # python310Packages.drf-spectacular
-    # python310Packages.djangorestframework
-    # python310Packages.django-redis
-    # python310Packages.django-cors-headers
 
     # Required dependancies 
     black
@@ -37,6 +26,7 @@ in pkgs.mkShell rec {
   postShellHook = ''
     # allow pip to install wheels
     unset SOURCE_DATE_EPOCH
+    zsh -l
   '';
 
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -34,6 +34,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -1501,12 +1507,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - in: query
-        name: q
-        schema:
-          type: string
-        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
-          Case-insensitive query applied on the `name` property. "
       tags:
       - location
       security:
@@ -1530,8 +1530,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
-        description: This parameter can be a string or an integer.
+          type: integer
+        description: A unique integer value identifying this location area.
         required: true
       tags:
       - location

--- a/openapi.yml
+++ b/openapi.yml
@@ -95,6 +95,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - berries
       security:
@@ -127,6 +133,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - berries
       security:
@@ -186,6 +198,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - berries
       security:
@@ -275,6 +293,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -334,6 +358,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - contests
       security:
@@ -392,6 +422,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - contests
       security:
@@ -453,6 +489,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -513,6 +555,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - encounters
       security:
@@ -545,6 +593,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - encounters
       security:
@@ -629,6 +683,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - encounters
       security:
@@ -688,6 +748,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - evolution
       security:
@@ -748,6 +814,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - evolution
       security:
@@ -809,6 +881,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -871,6 +949,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - games
       security:
@@ -932,6 +1016,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -992,6 +1082,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - items
       security:
@@ -1024,6 +1120,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - items
       security:
@@ -1082,6 +1184,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - items
       security:
@@ -1140,6 +1248,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - items
       security:
@@ -1197,6 +1311,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - items
       security:
@@ -1280,6 +1400,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - utility
       security:
@@ -1337,6 +1463,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - location
       security:
@@ -1369,6 +1501,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - location
       security:
@@ -1454,6 +1592,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - machines
       security:
@@ -1515,6 +1659,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - moves
       security:
@@ -1548,6 +1698,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - moves
       security:
@@ -1607,6 +1763,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - moves
       security:
@@ -1664,6 +1826,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - moves
       security:
@@ -1720,6 +1888,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -1776,6 +1950,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - moves
       security:
@@ -1833,6 +2013,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - moves
       security:
@@ -1919,6 +2105,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -1977,6 +2169,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - location
       security:
@@ -2037,6 +2235,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2100,6 +2304,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - games
       security:
@@ -2165,6 +2375,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2199,6 +2415,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2261,6 +2483,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2321,6 +2549,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2378,6 +2612,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2437,6 +2677,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2645,6 +2891,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - location
       security:
@@ -2705,6 +2957,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2764,6 +3022,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - contests
       security:
@@ -2824,6 +3088,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - pokemon
       security:
@@ -2883,6 +3153,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - games
       security:
@@ -2914,6 +3190,12 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: "> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\n\
+          Case-insensitive query applied on the `name` property. "
       tags:
       - games
       security:

--- a/openapi.yml
+++ b/openapi.yml
@@ -58,8 +58,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this ability.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -150,8 +150,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this berry firmness.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - berries
@@ -210,8 +210,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this berry flavor.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - berries
@@ -238,8 +238,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this berry.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - berries
@@ -300,8 +300,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this characteristic.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -356,8 +356,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this contest effect.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - contests
@@ -416,8 +416,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this contest type.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - contests
@@ -478,8 +478,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this egg group.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -568,8 +568,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this encounter condition value.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - encounters
@@ -594,8 +594,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this encounter condition.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - encounters
@@ -652,8 +652,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this encounter method.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - encounters
@@ -712,8 +712,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this evolution chain.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - evolution
@@ -772,8 +772,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this evolution trigger.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - evolution
@@ -834,8 +834,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this gender.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -896,8 +896,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this generation.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - games
@@ -956,8 +956,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this growth rate.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -1047,8 +1047,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this item attribute.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - items
@@ -1105,8 +1105,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this item category.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - items
@@ -1163,8 +1163,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this item fling effect.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - items
@@ -1219,8 +1219,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this item pocket.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - items
@@ -1246,8 +1246,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this item.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - items
@@ -1302,8 +1302,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this language.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - utility
@@ -1392,8 +1392,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this location area.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - location
@@ -1418,8 +1418,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this location.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - location
@@ -1478,8 +1478,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this machine.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - machines
@@ -1572,8 +1572,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move meta ailment.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - moves
@@ -1630,8 +1630,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move battle style.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - moves
@@ -1686,8 +1686,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move meta category.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - moves
@@ -1742,8 +1742,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move damage class.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -1798,8 +1798,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move learn method.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - moves
@@ -1856,8 +1856,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move target.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - moves
@@ -1884,8 +1884,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this move.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - moves
@@ -1942,8 +1942,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this nature.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2000,8 +2000,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pal park area.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - location
@@ -2062,8 +2062,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokeathlon stat.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2126,8 +2126,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokedex.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - games
@@ -2224,8 +2224,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokemon color.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2286,8 +2286,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokemon form.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2344,8 +2344,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokemon habitat.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2400,8 +2400,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokemon shape.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2462,8 +2462,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokemon species.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2492,8 +2492,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this pokemon.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2669,8 +2669,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this region.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - location
@@ -2729,8 +2729,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this stat.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2787,8 +2787,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this super contest effect.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - contests
@@ -2849,8 +2849,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this type.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - pokemon
@@ -2936,8 +2936,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this version group.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - games
@@ -2961,8 +2961,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this version.
+          type: string
+        description: This parameter can be a string or an integer.
         required: true
       tags:
       - games
@@ -3140,28 +3140,16 @@ components:
           maxLength: 100
         growth_time:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         max_harvest:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         natural_gift_power:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         size:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         smoothness:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         soil_dryness:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         firmness:
           $ref: '#/components/schemas/BerryFirmnessSummary'
         flavors:
@@ -3410,12 +3398,8 @@ components:
           readOnly: true
         appeal:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         jam:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         effect_entries:
           type: array
           items:
@@ -3683,8 +3667,6 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         names:
           type: array
           items:
@@ -3998,12 +3980,8 @@ components:
       properties:
         level:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         experience:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
       required:
       - experience
       - level
@@ -4354,14 +4332,10 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         fling_power:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         fling_effect:
           $ref: '#/components/schemas/ItemFlingEffectSummary'
         attributes:
@@ -4602,8 +4576,6 @@ components:
       properties:
         game_index:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         generation:
           $ref: '#/components/schemas/GenerationSummary'
       required:
@@ -4744,8 +4716,6 @@ components:
           maxLength: 100
         game_index:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         encounter_method_rates:
           type: array
           items:
@@ -4982,8 +4952,6 @@ components:
       properties:
         game_index:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         generation:
           $ref: '#/components/schemas/GenerationSummary'
       required:
@@ -5088,20 +5056,14 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         power:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         pp:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         effect_chance:
           type: integer
         effect_entries:
@@ -5223,28 +5185,20 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         effect_chance:
           type: integer
         pp:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         priority:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         power:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         contest_combos:
           type: object
           required:
@@ -5656,62 +5610,42 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         max_hits:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         min_turns:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         max_turns:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         drain:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         healing:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         crit_rate:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         ailment_chance:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         flinch_chance:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         stat_chance:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
       required:
       - ailment
       - category
@@ -5929,12 +5863,8 @@ components:
       properties:
         low_hp_preference:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         high_hp_preference:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         move_battle_style:
           $ref: '#/components/schemas/MoveBattleStyleSummary'
       required:
@@ -7356,28 +7286,20 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         height:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         is_default:
           type: boolean
         order:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         weight:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         abilities:
           type: array
           items:
@@ -7765,14 +7687,10 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         form_order:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         is_default:
           type: boolean
         is_battle_only:
@@ -7923,8 +7841,6 @@ components:
       properties:
         game_index:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         version:
           $ref: '#/components/schemas/VersionSummary'
       required:
@@ -8080,26 +7996,18 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         gender_rate:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         capture_rate:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         base_happiness:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         is_baby:
           type: boolean
         is_legendary:
@@ -8110,8 +8018,6 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         has_gender_differences:
           type: boolean
         forms_switchable:
@@ -8329,12 +8235,8 @@ components:
       properties:
         base_stat:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         effort:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         stat:
           $ref: '#/components/schemas/StatSummary'
       required:
@@ -8443,8 +8345,6 @@ components:
           maxLength: 100
         game_index:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         is_battle_only:
           type: boolean
         affecting_moves:
@@ -8604,8 +8504,6 @@ components:
           readOnly: true
         appeal:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         flavor_text_entries:
           type: array
           items:
@@ -8965,8 +8863,6 @@ components:
       properties:
         game_index:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
         generation:
           $ref: '#/components/schemas/GenerationSummary'
       required:
@@ -9023,8 +8919,6 @@ components:
           type:
           - integer
           - 'null'
-          maximum: 2147483647
-          minimum: -2147483648
         generation:
           $ref: '#/components/schemas/GenerationSummary'
         move_learn_methods:

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -50,16 +50,6 @@ class NameOrIdRetrieval:
 
         return queryset
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="id",
-                description="This parameter can be a string or an integer.",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-            ),
-        ]
-    )
     def get_object(self):
         queryset = self.get_queryset()
         queryset = self.filter_queryset(queryset)
@@ -91,6 +81,13 @@ class PokeapiCommonViewset(
 #  APIS  #
 ##########
 
+retrieve_path_parameter = OpenApiParameter(
+    name="id",
+    description="This parameter can be a string or an integer.",
+    location=OpenApiParameter.PATH,
+    type=OpenApiTypes.STR,
+    required=True,
+)
 
 @extend_schema(
     description="Abilities provide passive effects for Pokémon in battle or in the overworld. Pokémon have multiple possible abilities but can have only one ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability) for greater detail.",
@@ -100,6 +97,10 @@ class AbilityResource(PokeapiCommonViewset):
     queryset = Ability.objects.all()
     serializer_class = AbilityDetailSerializer
     list_serializer_class = AbilitySummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -117,6 +118,10 @@ class BerryResource(PokeapiCommonViewset):
     serializer_class = BerryDetailSerializer
     list_serializer_class = BerrySummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Berries can be soft or hard. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Category:Berries_by_firmness) for greater detail.",
@@ -132,6 +137,10 @@ class BerryFirmnessResource(PokeapiCommonViewset):
     queryset = BerryFirmness.objects.all()
     serializer_class = BerryFirmnessDetailSerializer
     list_serializer_class = BerryFirmnessSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -149,6 +158,10 @@ class BerryFlavorResource(PokeapiCommonViewset):
     serializer_class = BerryFlavorDetailSerializer
     list_serializer_class = BerryFlavorSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Characteristics indicate which stat contains a Pokémon's highest IV. A Pokémon's Characteristic is determined by the remainder of its highest IV divided by 5 (gene_modulo). Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Characteristic) for greater detail.",
@@ -164,6 +177,10 @@ class CharacteristicResource(PokeapiCommonViewset):
     queryset = Characteristic.objects.all()
     serializer_class = CharacteristicDetailSerializer
     list_serializer_class = CharacteristicSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -181,6 +198,10 @@ class ContestEffectResource(PokeapiCommonViewset):
     serializer_class = ContestEffectDetailSerializer
     list_serializer_class = ContestEffectSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Contest types are categories judges used to weigh a Pokémon's condition in Pokémon contests. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Contest_condition) for greater detail.",
@@ -196,6 +217,10 @@ class ContestTypeResource(PokeapiCommonViewset):
     queryset = ContestType.objects.all()
     serializer_class = ContestTypeDetailSerializer
     list_serializer_class = ContestTypeSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -213,6 +238,10 @@ class EggGroupResource(PokeapiCommonViewset):
     serializer_class = EggGroupDetailSerializer
     list_serializer_class = EggGroupSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Conditions which affect what pokemon might appear in the wild, e.g., day or night.",
@@ -228,6 +257,10 @@ class EncounterConditionResource(PokeapiCommonViewset):
     queryset = EncounterCondition.objects.all()
     serializer_class = EncounterConditionDetailSerializer
     list_serializer_class = EncounterConditionSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -245,6 +278,10 @@ class EncounterConditionValueResource(PokeapiCommonViewset):
     serializer_class = EncounterConditionValueDetailSerializer
     list_serializer_class = EncounterConditionValueSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Methods by which the player might can encounter Pokémon in the wild, e.g., walking in tall grass. Check out Bulbapedia for greater detail.",
@@ -260,6 +297,10 @@ class EncounterMethodResource(PokeapiCommonViewset):
     queryset = EncounterMethod.objects.all()
     serializer_class = EncounterMethodDetailSerializer
     list_serializer_class = EncounterMethodSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -277,6 +318,10 @@ class EvolutionChainResource(PokeapiCommonViewset):
     serializer_class = EvolutionChainDetailSerializer
     list_serializer_class = EvolutionChainSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Evolution triggers are the events and conditions that cause a Pokémon to evolve. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Methods_of_evolution) for greater detail.",
@@ -292,6 +337,10 @@ class EvolutionTriggerResource(PokeapiCommonViewset):
     queryset = EvolutionTrigger.objects.all()
     serializer_class = EvolutionTriggerDetailSerializer
     list_serializer_class = EvolutionTriggerSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -309,6 +358,10 @@ class GenerationResource(PokeapiCommonViewset):
     serializer_class = GenerationDetailSerializer
     list_serializer_class = GenerationSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Genders were introduced in Generation II for the purposes of breeding Pokémon but can also result in visual differences or even different evolutionary lines. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Gender) for greater detail.",
@@ -324,6 +377,10 @@ class GenderResource(PokeapiCommonViewset):
     queryset = Gender.objects.all()
     serializer_class = GenderDetailSerializer
     list_serializer_class = GenderSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -341,6 +398,10 @@ class GrowthRateResource(PokeapiCommonViewset):
     serializer_class = GrowthRateDetailSerializer
     list_serializer_class = GrowthRateSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="An item is an object in the games which the player can pick up, keep in their bag, and use in some manner. They have various uses, including healing, powering up, helping catch Pokémon, or to access a new area.",
@@ -356,6 +417,10 @@ class ItemResource(PokeapiCommonViewset):
     queryset = Item.objects.all()
     serializer_class = ItemDetailSerializer
     list_serializer_class = ItemSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -373,6 +438,10 @@ class ItemCategoryResource(PokeapiCommonViewset):
     serializer_class = ItemCategoryDetailSerializer
     list_serializer_class = ItemCategorySummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description='Item attributes define particular aspects of items, e.g."usable in battle" or "consumable".',
@@ -388,6 +457,10 @@ class ItemAttributeResource(PokeapiCommonViewset):
     queryset = ItemAttribute.objects.all()
     serializer_class = ItemAttributeDetailSerializer
     list_serializer_class = ItemAttributeSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -405,6 +478,10 @@ class ItemFlingEffectResource(PokeapiCommonViewset):
     serializer_class = ItemFlingEffectDetailSerializer
     list_serializer_class = ItemFlingEffectSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Pockets within the players bag used for storing items by category.",
@@ -420,6 +497,10 @@ class ItemPocketResource(PokeapiCommonViewset):
     queryset = ItemPocket.objects.all()
     serializer_class = ItemPocketDetailSerializer
     list_serializer_class = ItemPocketSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -437,6 +518,10 @@ class LanguageResource(PokeapiCommonViewset):
     serializer_class = LanguageDetailSerializer
     list_serializer_class = LanguageSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Locations that can be visited within the games. Locations make up sizable portions of regions, like cities or routes.",
@@ -452,6 +537,10 @@ class LocationResource(PokeapiCommonViewset):
     queryset = Location.objects.all()
     serializer_class = LocationDetailSerializer
     list_serializer_class = LocationSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -469,6 +558,10 @@ class LocationAreaResource(ListOrDetailSerialRelation, viewsets.ReadOnlyModelVie
     serializer_class = LocationAreaDetailSerializer
     list_serializer_class = LocationAreaSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Machines are the representation of items that teach moves to Pokémon. They vary from version to version, so it is not certain that one specific TM or HM corresponds to a single Machine.",
@@ -484,6 +577,10 @@ class MachineResource(PokeapiCommonViewset):
     queryset = Machine.objects.all()
     serializer_class = MachineDetailSerializer
     list_serializer_class = MachineSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -501,6 +598,10 @@ class MoveResource(PokeapiCommonViewset):
     serializer_class = MoveDetailSerializer
     list_serializer_class = MoveSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Damage classes moves can have, e.g. physical, special, or non-damaging.",
@@ -516,6 +617,10 @@ class MoveDamageClassResource(PokeapiCommonViewset):
     queryset = MoveDamageClass.objects.all()
     serializer_class = MoveDamageClassDetailSerializer
     list_serializer_class = MoveDamageClassSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -533,6 +638,10 @@ class MoveMetaAilmentResource(PokeapiCommonViewset):
     serializer_class = MoveMetaAilmentDetailSerializer
     list_serializer_class = MoveMetaAilmentSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Styles of moves when used in the Battle Palace. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Battle_Frontier_(Generation_III)) for greater detail.",
@@ -548,6 +657,10 @@ class MoveBattleStyleResource(PokeapiCommonViewset):
     queryset = MoveBattleStyle.objects.all()
     serializer_class = MoveBattleStyleDetailSerializer
     list_serializer_class = MoveBattleStyleSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -565,6 +678,10 @@ class MoveMetaCategoryResource(PokeapiCommonViewset):
     serializer_class = MoveMetaCategoryDetailSerializer
     list_serializer_class = MoveMetaCategorySummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Methods by which Pokémon can learn moves.",
@@ -580,6 +697,10 @@ class MoveLearnMethodResource(PokeapiCommonViewset):
     queryset = MoveLearnMethod.objects.all()
     serializer_class = MoveLearnMethodDetailSerializer
     list_serializer_class = MoveLearnMethodSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -597,6 +718,10 @@ class MoveTargetResource(PokeapiCommonViewset):
     serializer_class = MoveTargetDetailSerializer
     list_serializer_class = MoveTargetSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Natures influence how a Pokémon's stats grow. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Nature) for greater detail.",
@@ -612,6 +737,10 @@ class NatureResource(PokeapiCommonViewset):
     queryset = Nature.objects.all()
     serializer_class = NatureDetailSerializer
     list_serializer_class = NatureSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -629,6 +758,10 @@ class PalParkAreaResource(PokeapiCommonViewset):
     serializer_class = PalParkAreaDetailSerializer
     list_serializer_class = PalParkAreaSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Pokeathlon Stats are different attributes of a Pokémon's performance in Pokéathlons. In Pokéathlons, competitions happen on different courses; one for each of the different Pokéathlon stats. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9athlon) for greater detail.",
@@ -644,6 +777,10 @@ class PokeathlonStatResource(PokeapiCommonViewset):
     queryset = PokeathlonStat.objects.all()
     serializer_class = PokeathlonStatDetailSerializer
     list_serializer_class = PokeathlonStatSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -661,6 +798,10 @@ class PokedexResource(PokeapiCommonViewset):
     serializer_class = PokedexDetailSerializer
     list_serializer_class = PokedexSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Colors used for sorting Pokémon in a Pokédex. The color listed in the Pokédex is usually the color most apparent or covering each Pokémon's body. No orange category exists; Pokémon that are primarily orange are listed as red or brown.",
@@ -676,6 +817,10 @@ class PokemonColorResource(PokeapiCommonViewset):
     queryset = PokemonColor.objects.all()
     serializer_class = PokemonColorDetailSerializer
     list_serializer_class = PokemonColorSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -693,6 +838,10 @@ class PokemonFormResource(PokeapiCommonViewset):
     serializer_class = PokemonFormDetailSerializer
     list_serializer_class = PokemonFormSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Habitats are generally different terrain Pokémon can be found in but can also be areas designated for rare or legendary Pokémon.",
@@ -708,6 +857,10 @@ class PokemonHabitatResource(PokeapiCommonViewset):
     queryset = PokemonHabitat.objects.all()
     serializer_class = PokemonHabitatDetailSerializer
     list_serializer_class = PokemonHabitatSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -725,6 +878,10 @@ class PokemonShapeResource(PokeapiCommonViewset):
     serializer_class = PokemonShapeDetailSerializer
     list_serializer_class = PokemonShapeSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Pokémon are the creatures that inhabit the world of the Pokémon games. They can be caught using Pokéballs and trained by battling with other Pokémon. Each Pokémon belongs to a specific species but may take on a variant which makes it differ from other Pokémon of the same species, such as base stats, available abilities and typings. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_(species)) for greater detail.",
@@ -740,6 +897,10 @@ class PokemonResource(PokeapiCommonViewset):
     queryset = Pokemon.objects.all()
     serializer_class = PokemonDetailSerializer
     list_serializer_class = PokemonSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -757,6 +918,10 @@ class PokemonSpeciesResource(PokeapiCommonViewset):
     serializer_class = PokemonSpeciesDetailSerializer
     list_serializer_class = PokemonSpeciesSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="A region is an organized area of the Pokémon world. Most often, the main difference between regions is the species of Pokémon that can be encountered within them.",
@@ -772,6 +937,10 @@ class RegionResource(PokeapiCommonViewset):
     queryset = Region.objects.all()
     serializer_class = RegionDetailSerializer
     list_serializer_class = RegionSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -789,6 +958,10 @@ class StatResource(PokeapiCommonViewset):
     serializer_class = StatDetailSerializer
     list_serializer_class = StatSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Super contest effects refer to the effects of moves when used in super contests.",
@@ -804,6 +977,10 @@ class SuperContestEffectResource(PokeapiCommonViewset):
     queryset = SuperContestEffect.objects.all()
     serializer_class = SuperContestEffectDetailSerializer
     list_serializer_class = SuperContestEffectSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -821,6 +998,10 @@ class TypeResource(PokeapiCommonViewset):
     serializer_class = TypeDetailSerializer
     list_serializer_class = TypeSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Versions of the games, e.g., Red, Blue or Yellow.",
@@ -837,6 +1018,10 @@ class VersionResource(PokeapiCommonViewset):
     serializer_class = VersionDetailSerializer
     list_serializer_class = VersionSummarySerializer
 
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
 
 @extend_schema(
     description="Version groups categorize highly similar versions of the games.",
@@ -852,6 +1037,10 @@ class VersionGroupResource(PokeapiCommonViewset):
     queryset = VersionGroup.objects.all()
     serializer_class = VersionGroupDetailSerializer
     list_serializer_class = VersionGroupSummarySerializer
+
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
 
 
 @extend_schema(

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -89,6 +89,14 @@ retrieve_path_parameter = OpenApiParameter(
     required=True,
 )
 
+q_query_string_parameter = OpenApiParameter(
+    name="q",
+    description="> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\nCase-insensitive query applied on the `name` property. ",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.STR,
+)
+
+
 @extend_schema(
     description="Abilities provide passive effects for Pokémon in battle or in the overworld. Pokémon have multiple possible abilities but can have only one ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability) for greater detail.",
     tags=["pokemon"],
@@ -109,9 +117,7 @@ class AbilityResource(PokeapiCommonViewset):
     summary="Get a berry",
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List berries",
-    )
+    list=extend_schema(summary="List berries", parameters=[q_query_string_parameter])
 )
 class BerryResource(PokeapiCommonViewset):
     queryset = Berry.objects.all()
@@ -130,7 +136,7 @@ class BerryResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List berry firmness",
+        summary="List berry firmness", parameters=[q_query_string_parameter]
     )
 )
 class BerryFirmnessResource(PokeapiCommonViewset):
@@ -150,7 +156,7 @@ class BerryFirmnessResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List berry flavors",
+        summary="List berry flavors", parameters=[q_query_string_parameter]
     )
 )
 class BerryFlavorResource(PokeapiCommonViewset):
@@ -170,7 +176,7 @@ class BerryFlavorResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List charecterictics",
+        summary="List charecterictics", parameters=[q_query_string_parameter]
     )
 )
 class CharacteristicResource(PokeapiCommonViewset):
@@ -190,7 +196,7 @@ class CharacteristicResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List contest effects",
+        summary="List contest effects", parameters=[q_query_string_parameter]
     )
 )
 class ContestEffectResource(PokeapiCommonViewset):
@@ -210,7 +216,7 @@ class ContestEffectResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List contest types",
+        summary="List contest types", parameters=[q_query_string_parameter]
     )
 )
 class ContestTypeResource(PokeapiCommonViewset):
@@ -229,9 +235,7 @@ class ContestTypeResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List egg groups",
-    )
+    list=extend_schema(summary="List egg groups", parameters=[q_query_string_parameter])
 )
 class EggGroupResource(PokeapiCommonViewset):
     queryset = EggGroup.objects.all()
@@ -250,7 +254,7 @@ class EggGroupResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List encounter conditions",
+        summary="List encounter conditions", parameters=[q_query_string_parameter]
     )
 )
 class EncounterConditionResource(PokeapiCommonViewset):
@@ -270,7 +274,7 @@ class EncounterConditionResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List encounter condition values",
+        summary="List encounter condition values", parameters=[q_query_string_parameter]
     )
 )
 class EncounterConditionValueResource(PokeapiCommonViewset):
@@ -290,7 +294,7 @@ class EncounterConditionValueResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List encounter methods",
+        summary="List encounter methods", parameters=[q_query_string_parameter]
     )
 )
 class EncounterMethodResource(PokeapiCommonViewset):
@@ -310,7 +314,7 @@ class EncounterMethodResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List evolution chains",
+        summary="List evolution chains", parameters=[q_query_string_parameter]
     )
 )
 class EvolutionChainResource(PokeapiCommonViewset):
@@ -330,7 +334,7 @@ class EvolutionChainResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List evolution triggers",
+        summary="List evolution triggers", parameters=[q_query_string_parameter]
     )
 )
 class EvolutionTriggerResource(PokeapiCommonViewset):
@@ -349,9 +353,7 @@ class EvolutionTriggerResource(PokeapiCommonViewset):
     tags=["games"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List genrations",
-    )
+    list=extend_schema(summary="List genrations", parameters=[q_query_string_parameter])
 )
 class GenerationResource(PokeapiCommonViewset):
     queryset = Generation.objects.all()
@@ -369,9 +371,7 @@ class GenerationResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List genders",
-    )
+    list=extend_schema(summary="List genders", parameters=[q_query_string_parameter])
 )
 class GenderResource(PokeapiCommonViewset):
     queryset = Gender.objects.all()
@@ -390,7 +390,7 @@ class GenderResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List growth rates",
+        summary="List growth rates", parameters=[q_query_string_parameter]
     )
 )
 class GrowthRateResource(PokeapiCommonViewset):
@@ -409,9 +409,7 @@ class GrowthRateResource(PokeapiCommonViewset):
     tags=["items"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List items",
-    )
+    list=extend_schema(summary="List items", parameters=[q_query_string_parameter])
 )
 class ItemResource(PokeapiCommonViewset):
     queryset = Item.objects.all()
@@ -430,7 +428,7 @@ class ItemResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item categories",
+        summary="List item categories", parameters=[q_query_string_parameter]
     )
 )
 class ItemCategoryResource(PokeapiCommonViewset):
@@ -450,7 +448,7 @@ class ItemCategoryResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item attributes",
+        summary="List item attributes", parameters=[q_query_string_parameter]
     )
 )
 class ItemAttributeResource(PokeapiCommonViewset):
@@ -470,7 +468,7 @@ class ItemAttributeResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item fling effects",
+        summary="List item fling effects", parameters=[q_query_string_parameter]
     )
 )
 class ItemFlingEffectResource(PokeapiCommonViewset):
@@ -490,7 +488,7 @@ class ItemFlingEffectResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item pockets",
+        summary="List item pockets", parameters=[q_query_string_parameter]
     )
 )
 class ItemPocketResource(PokeapiCommonViewset):
@@ -509,9 +507,7 @@ class ItemPocketResource(PokeapiCommonViewset):
     tags=["utility"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List languages",
-    )
+    list=extend_schema(summary="List languages", parameters=[q_query_string_parameter])
 )
 class LanguageResource(PokeapiCommonViewset):
     queryset = Language.objects.all()
@@ -529,9 +525,7 @@ class LanguageResource(PokeapiCommonViewset):
     tags=["location"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List locations",
-    )
+    list=extend_schema(summary="List locations", parameters=[q_query_string_parameter])
 )
 class LocationResource(PokeapiCommonViewset):
     queryset = Location.objects.all()
@@ -550,7 +544,7 @@ class LocationResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List location areas",
+        summary="List location areas", parameters=[q_query_string_parameter]
     )
 )
 class LocationAreaResource(ListOrDetailSerialRelation, viewsets.ReadOnlyModelViewSet):
@@ -569,9 +563,7 @@ class LocationAreaResource(ListOrDetailSerialRelation, viewsets.ReadOnlyModelVie
     tags=["machines"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List machines",
-    )
+    list=extend_schema(summary="List machines", parameters=[q_query_string_parameter])
 )
 class MachineResource(PokeapiCommonViewset):
     queryset = Machine.objects.all()
@@ -589,9 +581,7 @@ class MachineResource(PokeapiCommonViewset):
     tags=["moves"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List moves",
-    )
+    list=extend_schema(summary="List moves", parameters=[q_query_string_parameter])
 )
 class MoveResource(PokeapiCommonViewset):
     queryset = Move.objects.all()
@@ -610,7 +600,7 @@ class MoveResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move damage classes",
+        summary="List move damage classes", parameters=[q_query_string_parameter]
     )
 )
 class MoveDamageClassResource(PokeapiCommonViewset):
@@ -630,7 +620,7 @@ class MoveDamageClassResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move meta ailments",
+        summary="List move meta ailments", parameters=[q_query_string_parameter]
     )
 )
 class MoveMetaAilmentResource(PokeapiCommonViewset):
@@ -650,7 +640,7 @@ class MoveMetaAilmentResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move battle styles",
+        summary="List move battle styles", parameters=[q_query_string_parameter]
     )
 )
 class MoveBattleStyleResource(PokeapiCommonViewset):
@@ -670,7 +660,7 @@ class MoveBattleStyleResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move meta categories",
+        summary="List move meta categories", parameters=[q_query_string_parameter]
     )
 )
 class MoveMetaCategoryResource(PokeapiCommonViewset):
@@ -690,7 +680,7 @@ class MoveMetaCategoryResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move learn methods",
+        summary="List move learn methods", parameters=[q_query_string_parameter]
     )
 )
 class MoveLearnMethodResource(PokeapiCommonViewset):
@@ -710,7 +700,7 @@ class MoveLearnMethodResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move targets",
+        summary="List move targets", parameters=[q_query_string_parameter]
     )
 )
 class MoveTargetResource(PokeapiCommonViewset):
@@ -729,9 +719,7 @@ class MoveTargetResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List natures",
-    )
+    list=extend_schema(summary="List natures", parameters=[q_query_string_parameter])
 )
 class NatureResource(PokeapiCommonViewset):
     queryset = Nature.objects.all()
@@ -750,7 +738,7 @@ class NatureResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pal park areas",
+        summary="List pal park areas", parameters=[q_query_string_parameter]
     )
 )
 class PalParkAreaResource(PokeapiCommonViewset):
@@ -770,7 +758,7 @@ class PalParkAreaResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokeathlon stats",
+        summary="List pokeathlon stats", parameters=[q_query_string_parameter]
     )
 )
 class PokeathlonStatResource(PokeapiCommonViewset):
@@ -789,9 +777,7 @@ class PokeathlonStatResource(PokeapiCommonViewset):
     tags=["games"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List pokedex",
-    )
+    list=extend_schema(summary="List pokedex", parameters=[q_query_string_parameter])
 )
 class PokedexResource(PokeapiCommonViewset):
     queryset = Pokedex.objects.all()
@@ -810,7 +796,7 @@ class PokedexResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon colors",
+        summary="List pokemon colors", parameters=[q_query_string_parameter]
     )
 )
 class PokemonColorResource(PokeapiCommonViewset):
@@ -830,7 +816,7 @@ class PokemonColorResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon forms",
+        summary="List pokemon forms", parameters=[q_query_string_parameter]
     )
 )
 class PokemonFormResource(PokeapiCommonViewset):
@@ -850,7 +836,7 @@ class PokemonFormResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemom habitas",
+        summary="List pokemom habitas", parameters=[q_query_string_parameter]
     )
 )
 class PokemonHabitatResource(PokeapiCommonViewset):
@@ -870,7 +856,7 @@ class PokemonHabitatResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon shapes",
+        summary="List pokemon shapes", parameters=[q_query_string_parameter]
     )
 )
 class PokemonShapeResource(PokeapiCommonViewset):
@@ -889,9 +875,7 @@ class PokemonShapeResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List pokemon",
-    )
+    list=extend_schema(summary="List pokemon", parameters=[q_query_string_parameter]),
 )
 class PokemonResource(PokeapiCommonViewset):
     queryset = Pokemon.objects.all()
@@ -910,7 +894,7 @@ class PokemonResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon species",
+        summary="List pokemon species", parameters=[q_query_string_parameter]
     )
 )
 class PokemonSpeciesResource(PokeapiCommonViewset):
@@ -929,9 +913,7 @@ class PokemonSpeciesResource(PokeapiCommonViewset):
     tags=["location"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List regions",
-    )
+    list=extend_schema(summary="List regions", parameters=[q_query_string_parameter])
 )
 class RegionResource(PokeapiCommonViewset):
     queryset = Region.objects.all()
@@ -949,9 +931,7 @@ class RegionResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List stats",
-    )
+    list=extend_schema(summary="List stats", parameters=[q_query_string_parameter])
 )
 class StatResource(PokeapiCommonViewset):
     queryset = Stat.objects.all()
@@ -970,7 +950,7 @@ class StatResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List super contest effects",
+        summary="List super contest effects", parameters=[q_query_string_parameter]
     )
 )
 class SuperContestEffectResource(PokeapiCommonViewset):
@@ -989,9 +969,7 @@ class SuperContestEffectResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List types",
-    )
+    list=extend_schema(summary="List types", parameters=[q_query_string_parameter])
 )
 class TypeResource(PokeapiCommonViewset):
     queryset = Type.objects.all()
@@ -1009,9 +987,7 @@ class TypeResource(PokeapiCommonViewset):
     tags=["games"],
 )
 @extend_schema_view(
-    list=extend_schema(
-        summary="List versions",
-    )
+    list=extend_schema(summary="List versions", parameters=[q_query_string_parameter])
 )
 class VersionResource(PokeapiCommonViewset):
     queryset = Version.objects.all()
@@ -1030,7 +1006,7 @@ class VersionResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List version groups",
+        summary="List version groups", parameters=[q_query_string_parameter]
     )
 )
 class VersionGroupResource(PokeapiCommonViewset):

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -71,15 +71,12 @@ class NameOrIdRetrieval:
         return resp
 
 
-class PokeapiCommonViewset(
-    ListOrDetailSerialRelation, NameOrIdRetrieval, viewsets.ReadOnlyModelViewSet
-):
-    pass
-
-
-##########
-#  APIS  #
-##########
+q_query_string_parameter = OpenApiParameter(
+    name="q",
+    description="> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\nCase-insensitive query applied on the `name` property. ",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.STR,
+)
 
 retrieve_path_parameter = OpenApiParameter(
     name="id",
@@ -89,12 +86,21 @@ retrieve_path_parameter = OpenApiParameter(
     required=True,
 )
 
-q_query_string_parameter = OpenApiParameter(
-    name="q",
-    description="> Only available locally and not at [pokeapi.co](https://pokeapi.co/docs/v2)\nCase-insensitive query applied on the `name` property. ",
-    location=OpenApiParameter.QUERY,
-    type=OpenApiTypes.STR,
-)
+
+@extend_schema_view(list=extend_schema(parameters=[q_query_string_parameter]))
+class PokeapiCommonViewset(
+    ListOrDetailSerialRelation, NameOrIdRetrieval, viewsets.ReadOnlyModelViewSet
+):
+    @extend_schema(parameters=[retrieve_path_parameter])
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
+    pass
+
+
+##########
+#  APIS  #
+##########
 
 
 @extend_schema(
@@ -106,10 +112,6 @@ class AbilityResource(PokeapiCommonViewset):
     serializer_class = AbilityDetailSerializer
     list_serializer_class = AbilitySummarySerializer
 
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
-
 
 @extend_schema(
     description="Berries are small fruits that can provide HP and status condition restoration, stat enhancement, and even damage negation when eaten by Pokémon. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Berry) for greater detail.",
@@ -117,16 +119,14 @@ class AbilityResource(PokeapiCommonViewset):
     summary="Get a berry",
 )
 @extend_schema_view(
-    list=extend_schema(summary="List berries", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List berries",
+    )
 )
 class BerryResource(PokeapiCommonViewset):
     queryset = Berry.objects.all()
     serializer_class = BerryDetailSerializer
     list_serializer_class = BerrySummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -136,17 +136,13 @@ class BerryResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List berry firmness", parameters=[q_query_string_parameter]
+        summary="List berry firmness",
     )
 )
 class BerryFirmnessResource(PokeapiCommonViewset):
     queryset = BerryFirmness.objects.all()
     serializer_class = BerryFirmnessDetailSerializer
     list_serializer_class = BerryFirmnessSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -156,17 +152,13 @@ class BerryFirmnessResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List berry flavors", parameters=[q_query_string_parameter]
+        summary="List berry flavors",
     )
 )
 class BerryFlavorResource(PokeapiCommonViewset):
     queryset = BerryFlavor.objects.all()
     serializer_class = BerryFlavorDetailSerializer
     list_serializer_class = BerryFlavorSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -176,17 +168,13 @@ class BerryFlavorResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List charecterictics", parameters=[q_query_string_parameter]
+        summary="List charecterictics",
     )
 )
 class CharacteristicResource(PokeapiCommonViewset):
     queryset = Characteristic.objects.all()
     serializer_class = CharacteristicDetailSerializer
     list_serializer_class = CharacteristicSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -196,17 +184,13 @@ class CharacteristicResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List contest effects", parameters=[q_query_string_parameter]
+        summary="List contest effects",
     )
 )
 class ContestEffectResource(PokeapiCommonViewset):
     queryset = ContestEffect.objects.all()
     serializer_class = ContestEffectDetailSerializer
     list_serializer_class = ContestEffectSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -216,17 +200,13 @@ class ContestEffectResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List contest types", parameters=[q_query_string_parameter]
+        summary="List contest types",
     )
 )
 class ContestTypeResource(PokeapiCommonViewset):
     queryset = ContestType.objects.all()
     serializer_class = ContestTypeDetailSerializer
     list_serializer_class = ContestTypeSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -235,16 +215,14 @@ class ContestTypeResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List egg groups", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List egg groups",
+    )
 )
 class EggGroupResource(PokeapiCommonViewset):
     queryset = EggGroup.objects.all()
     serializer_class = EggGroupDetailSerializer
     list_serializer_class = EggGroupSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -254,17 +232,13 @@ class EggGroupResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List encounter conditions", parameters=[q_query_string_parameter]
+        summary="List encounter conditions",
     )
 )
 class EncounterConditionResource(PokeapiCommonViewset):
     queryset = EncounterCondition.objects.all()
     serializer_class = EncounterConditionDetailSerializer
     list_serializer_class = EncounterConditionSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -274,17 +248,13 @@ class EncounterConditionResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List encounter condition values", parameters=[q_query_string_parameter]
+        summary="List encounter condition values",
     )
 )
 class EncounterConditionValueResource(PokeapiCommonViewset):
     queryset = EncounterConditionValue.objects.all()
     serializer_class = EncounterConditionValueDetailSerializer
     list_serializer_class = EncounterConditionValueSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -294,17 +264,13 @@ class EncounterConditionValueResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List encounter methods", parameters=[q_query_string_parameter]
+        summary="List encounter methods",
     )
 )
 class EncounterMethodResource(PokeapiCommonViewset):
     queryset = EncounterMethod.objects.all()
     serializer_class = EncounterMethodDetailSerializer
     list_serializer_class = EncounterMethodSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -314,17 +280,13 @@ class EncounterMethodResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List evolution chains", parameters=[q_query_string_parameter]
+        summary="List evolution chains",
     )
 )
 class EvolutionChainResource(PokeapiCommonViewset):
     queryset = EvolutionChain.objects.all()
     serializer_class = EvolutionChainDetailSerializer
     list_serializer_class = EvolutionChainSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -334,17 +296,13 @@ class EvolutionChainResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List evolution triggers", parameters=[q_query_string_parameter]
+        summary="List evolution triggers",
     )
 )
 class EvolutionTriggerResource(PokeapiCommonViewset):
     queryset = EvolutionTrigger.objects.all()
     serializer_class = EvolutionTriggerDetailSerializer
     list_serializer_class = EvolutionTriggerSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -353,16 +311,14 @@ class EvolutionTriggerResource(PokeapiCommonViewset):
     tags=["games"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List genrations", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List genrations",
+    )
 )
 class GenerationResource(PokeapiCommonViewset):
     queryset = Generation.objects.all()
     serializer_class = GenerationDetailSerializer
     list_serializer_class = GenerationSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -371,16 +327,14 @@ class GenerationResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List genders", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List genders",
+    )
 )
 class GenderResource(PokeapiCommonViewset):
     queryset = Gender.objects.all()
     serializer_class = GenderDetailSerializer
     list_serializer_class = GenderSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -390,17 +344,13 @@ class GenderResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List growth rates", parameters=[q_query_string_parameter]
+        summary="List growth rates",
     )
 )
 class GrowthRateResource(PokeapiCommonViewset):
     queryset = GrowthRate.objects.all()
     serializer_class = GrowthRateDetailSerializer
     list_serializer_class = GrowthRateSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -409,16 +359,14 @@ class GrowthRateResource(PokeapiCommonViewset):
     tags=["items"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List items", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List items",
+    )
 )
 class ItemResource(PokeapiCommonViewset):
     queryset = Item.objects.all()
     serializer_class = ItemDetailSerializer
     list_serializer_class = ItemSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -428,17 +376,13 @@ class ItemResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item categories", parameters=[q_query_string_parameter]
+        summary="List item categories",
     )
 )
 class ItemCategoryResource(PokeapiCommonViewset):
     queryset = ItemCategory.objects.all()
     serializer_class = ItemCategoryDetailSerializer
     list_serializer_class = ItemCategorySummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -448,17 +392,13 @@ class ItemCategoryResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item attributes", parameters=[q_query_string_parameter]
+        summary="List item attributes",
     )
 )
 class ItemAttributeResource(PokeapiCommonViewset):
     queryset = ItemAttribute.objects.all()
     serializer_class = ItemAttributeDetailSerializer
     list_serializer_class = ItemAttributeSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -468,17 +408,13 @@ class ItemAttributeResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item fling effects", parameters=[q_query_string_parameter]
+        summary="List item fling effects",
     )
 )
 class ItemFlingEffectResource(PokeapiCommonViewset):
     queryset = ItemFlingEffect.objects.all()
     serializer_class = ItemFlingEffectDetailSerializer
     list_serializer_class = ItemFlingEffectSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -488,17 +424,13 @@ class ItemFlingEffectResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List item pockets", parameters=[q_query_string_parameter]
+        summary="List item pockets",
     )
 )
 class ItemPocketResource(PokeapiCommonViewset):
     queryset = ItemPocket.objects.all()
     serializer_class = ItemPocketDetailSerializer
     list_serializer_class = ItemPocketSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -507,16 +439,14 @@ class ItemPocketResource(PokeapiCommonViewset):
     tags=["utility"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List languages", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List languages",
+    )
 )
 class LanguageResource(PokeapiCommonViewset):
     queryset = Language.objects.all()
     serializer_class = LanguageDetailSerializer
     list_serializer_class = LanguageSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -525,16 +455,14 @@ class LanguageResource(PokeapiCommonViewset):
     tags=["location"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List locations", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List locations",
+    )
 )
 class LocationResource(PokeapiCommonViewset):
     queryset = Location.objects.all()
     serializer_class = LocationDetailSerializer
     list_serializer_class = LocationSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -544,17 +472,13 @@ class LocationResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List location areas", parameters=[q_query_string_parameter]
+        summary="List location areas",
     )
 )
 class LocationAreaResource(ListOrDetailSerialRelation, viewsets.ReadOnlyModelViewSet):
     queryset = LocationArea.objects.all()
     serializer_class = LocationAreaDetailSerializer
     list_serializer_class = LocationAreaSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -563,16 +487,14 @@ class LocationAreaResource(ListOrDetailSerialRelation, viewsets.ReadOnlyModelVie
     tags=["machines"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List machines", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List machines",
+    )
 )
 class MachineResource(PokeapiCommonViewset):
     queryset = Machine.objects.all()
     serializer_class = MachineDetailSerializer
     list_serializer_class = MachineSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -581,16 +503,14 @@ class MachineResource(PokeapiCommonViewset):
     tags=["moves"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List moves", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List moves",
+    )
 )
 class MoveResource(PokeapiCommonViewset):
     queryset = Move.objects.all()
     serializer_class = MoveDetailSerializer
     list_serializer_class = MoveSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -600,17 +520,13 @@ class MoveResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move damage classes", parameters=[q_query_string_parameter]
+        summary="List move damage classes",
     )
 )
 class MoveDamageClassResource(PokeapiCommonViewset):
     queryset = MoveDamageClass.objects.all()
     serializer_class = MoveDamageClassDetailSerializer
     list_serializer_class = MoveDamageClassSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -620,17 +536,13 @@ class MoveDamageClassResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move meta ailments", parameters=[q_query_string_parameter]
+        summary="List move meta ailments",
     )
 )
 class MoveMetaAilmentResource(PokeapiCommonViewset):
     queryset = MoveMetaAilment.objects.all()
     serializer_class = MoveMetaAilmentDetailSerializer
     list_serializer_class = MoveMetaAilmentSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -640,17 +552,13 @@ class MoveMetaAilmentResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move battle styles", parameters=[q_query_string_parameter]
+        summary="List move battle styles",
     )
 )
 class MoveBattleStyleResource(PokeapiCommonViewset):
     queryset = MoveBattleStyle.objects.all()
     serializer_class = MoveBattleStyleDetailSerializer
     list_serializer_class = MoveBattleStyleSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -660,17 +568,13 @@ class MoveBattleStyleResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move meta categories", parameters=[q_query_string_parameter]
+        summary="List move meta categories",
     )
 )
 class MoveMetaCategoryResource(PokeapiCommonViewset):
     queryset = MoveMetaCategory.objects.all()
     serializer_class = MoveMetaCategoryDetailSerializer
     list_serializer_class = MoveMetaCategorySummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -680,17 +584,13 @@ class MoveMetaCategoryResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move learn methods", parameters=[q_query_string_parameter]
+        summary="List move learn methods",
     )
 )
 class MoveLearnMethodResource(PokeapiCommonViewset):
     queryset = MoveLearnMethod.objects.all()
     serializer_class = MoveLearnMethodDetailSerializer
     list_serializer_class = MoveLearnMethodSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -700,17 +600,13 @@ class MoveLearnMethodResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List move targets", parameters=[q_query_string_parameter]
+        summary="List move targets",
     )
 )
 class MoveTargetResource(PokeapiCommonViewset):
     queryset = MoveTarget.objects.all()
     serializer_class = MoveTargetDetailSerializer
     list_serializer_class = MoveTargetSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -719,16 +615,14 @@ class MoveTargetResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List natures", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List natures",
+    )
 )
 class NatureResource(PokeapiCommonViewset):
     queryset = Nature.objects.all()
     serializer_class = NatureDetailSerializer
     list_serializer_class = NatureSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -738,17 +632,13 @@ class NatureResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pal park areas", parameters=[q_query_string_parameter]
+        summary="List pal park areas",
     )
 )
 class PalParkAreaResource(PokeapiCommonViewset):
     queryset = PalParkArea.objects.all()
     serializer_class = PalParkAreaDetailSerializer
     list_serializer_class = PalParkAreaSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -758,17 +648,13 @@ class PalParkAreaResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokeathlon stats", parameters=[q_query_string_parameter]
+        summary="List pokeathlon stats",
     )
 )
 class PokeathlonStatResource(PokeapiCommonViewset):
     queryset = PokeathlonStat.objects.all()
     serializer_class = PokeathlonStatDetailSerializer
     list_serializer_class = PokeathlonStatSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -777,16 +663,14 @@ class PokeathlonStatResource(PokeapiCommonViewset):
     tags=["games"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List pokedex", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List pokedex",
+    )
 )
 class PokedexResource(PokeapiCommonViewset):
     queryset = Pokedex.objects.all()
     serializer_class = PokedexDetailSerializer
     list_serializer_class = PokedexSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -796,17 +680,13 @@ class PokedexResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon colors", parameters=[q_query_string_parameter]
+        summary="List pokemon colors",
     )
 )
 class PokemonColorResource(PokeapiCommonViewset):
     queryset = PokemonColor.objects.all()
     serializer_class = PokemonColorDetailSerializer
     list_serializer_class = PokemonColorSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -816,17 +696,13 @@ class PokemonColorResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon forms", parameters=[q_query_string_parameter]
+        summary="List pokemon forms",
     )
 )
 class PokemonFormResource(PokeapiCommonViewset):
     queryset = PokemonForm.objects.all()
     serializer_class = PokemonFormDetailSerializer
     list_serializer_class = PokemonFormSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -836,17 +712,13 @@ class PokemonFormResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemom habitas", parameters=[q_query_string_parameter]
+        summary="List pokemom habitas",
     )
 )
 class PokemonHabitatResource(PokeapiCommonViewset):
     queryset = PokemonHabitat.objects.all()
     serializer_class = PokemonHabitatDetailSerializer
     list_serializer_class = PokemonHabitatSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -856,17 +728,13 @@ class PokemonHabitatResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon shapes", parameters=[q_query_string_parameter]
+        summary="List pokemon shapes",
     )
 )
 class PokemonShapeResource(PokeapiCommonViewset):
     queryset = PokemonShape.objects.all()
     serializer_class = PokemonShapeDetailSerializer
     list_serializer_class = PokemonShapeSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -875,16 +743,14 @@ class PokemonShapeResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List pokemon", parameters=[q_query_string_parameter]),
+    list=extend_schema(
+        summary="List pokemon",
+    ),
 )
 class PokemonResource(PokeapiCommonViewset):
     queryset = Pokemon.objects.all()
     serializer_class = PokemonDetailSerializer
     list_serializer_class = PokemonSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -894,17 +760,13 @@ class PokemonResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List pokemon species", parameters=[q_query_string_parameter]
+        summary="List pokemon species",
     )
 )
 class PokemonSpeciesResource(PokeapiCommonViewset):
     queryset = PokemonSpecies.objects.all().order_by("id")
     serializer_class = PokemonSpeciesDetailSerializer
     list_serializer_class = PokemonSpeciesSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -913,16 +775,14 @@ class PokemonSpeciesResource(PokeapiCommonViewset):
     tags=["location"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List regions", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List regions",
+    )
 )
 class RegionResource(PokeapiCommonViewset):
     queryset = Region.objects.all()
     serializer_class = RegionDetailSerializer
     list_serializer_class = RegionSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -931,16 +791,14 @@ class RegionResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List stats", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List stats",
+    )
 )
 class StatResource(PokeapiCommonViewset):
     queryset = Stat.objects.all()
     serializer_class = StatDetailSerializer
     list_serializer_class = StatSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -950,17 +808,13 @@ class StatResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List super contest effects", parameters=[q_query_string_parameter]
+        summary="List super contest effects",
     )
 )
 class SuperContestEffectResource(PokeapiCommonViewset):
     queryset = SuperContestEffect.objects.all()
     serializer_class = SuperContestEffectDetailSerializer
     list_serializer_class = SuperContestEffectSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -969,16 +823,14 @@ class SuperContestEffectResource(PokeapiCommonViewset):
     tags=["pokemon"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List types", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List types",
+    )
 )
 class TypeResource(PokeapiCommonViewset):
     queryset = Type.objects.all()
     serializer_class = TypeDetailSerializer
     list_serializer_class = TypeSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -987,16 +839,14 @@ class TypeResource(PokeapiCommonViewset):
     tags=["games"],
 )
 @extend_schema_view(
-    list=extend_schema(summary="List versions", parameters=[q_query_string_parameter])
+    list=extend_schema(
+        summary="List versions",
+    )
 )
 class VersionResource(PokeapiCommonViewset):
     queryset = Version.objects.all()
     serializer_class = VersionDetailSerializer
     list_serializer_class = VersionSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(
@@ -1006,17 +856,13 @@ class VersionResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List version groups", parameters=[q_query_string_parameter]
+        summary="List version groups",
     )
 )
 class VersionGroupResource(PokeapiCommonViewset):
     queryset = VersionGroup.objects.all()
     serializer_class = VersionGroupDetailSerializer
     list_serializer_class = VersionGroupSummarySerializer
-
-    @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
-        return super().retrieve(request, pk)
 
 
 @extend_schema(


### PR DESCRIPTION
# OpenAPI Docs

- `q` query string param
- fix `id` path parameter
- nix refactor

Related #1078 #1065