### PR TITLE
Fixed typo in Teal Mask item identifier

### DIFF
--- a/data/v2/csv/items.csv
+++ b/data/v2/csv/items.csv
@@ -2049,7 +2049,7 @@ id,identifier,category_id,cost,fling_power,fling_effect_id
 2099,yellow-dish,55,0,,
 2100,roto-stick,21,0,,
 2101,teal-style-card,21,0,,
-2102,teak-mask,20,0,,
+2102,teal-mask,20,0,,
 2103,glimmering-charm,21,0,,
 2104,cyrstal-cluster,20,0,,
 2105,fairy-feather,12,750,,


### PR DESCRIPTION
This PR fixes a minor typo in `data/v2/csv/items.csv` where `teal-mask` is written as `teak-mask`