### PR TITLE
fix: french translation for polteageit phony form

### DIFF
--- a/data/v2/csv/pokemon_form_names.csv
+++ b/data/v2/csv/pokemon_form_names.csv
@@ -402,7 +402,7 @@ pokemon_form_id,local_language_id,form_name,pokemon_name
 854,9,Phony Form,Phony Sinistea
 854,11,がんさくフォルム,
 855,1,がんさくフォルム,
-854,5,Forme Contrefaçon,Polthégeist Contrefaçon
+855,5,Forme Contrefaçon,Polthégeist Contrefaçon
 855,6,Fälschungsform,Mortipot (Fälschung)
 855,9,Phony Form,Phony Polteageist
 855,11,がんさくフォルム,


### PR DESCRIPTION
French translation for Polteageist (Phony form) was wrongfully linked to Sinistea. Fix this.