### PR TITLE
fix #1067: Icy Snow Vivillon incorrect image

### DIFF
--- a/data/v2/csv/pokemon_forms.csv
+++ b/data/v2/csv/pokemon_forms.csv
@@ -664,7 +664,7 @@ id,identifier,form_identifier,pokemon_id,introduced_in_version_group_id,is_defau
 663,talonflame,,663,15,1,0,0,1,858
 664,scatterbug-icy-snow,icy-snow,664,15,1,0,0,1,859
 665,spewpa-icy-snow,icy-snow,665,15,1,0,0,1,879
-666,vivillon-meadow,meadow,666,15,0,0,0,7,905
+666,vivillon-meadow,meadow,666,15,1,0,0,7,905
 667,litleo,,667,15,1,0,0,1,919
 668,pyroar,,668,15,1,0,0,1,920
 669,flabebe-red,red,669,15,1,0,0,1,921
@@ -1109,7 +1109,7 @@ id,identifier,form_identifier,pokemon_id,introduced_in_version_group_id,is_defau
 10083,kyurem-white,white,10023,14,1,0,0,2,832
 10084,keldeo-resolute,resolute,10024,14,1,0,0,2,835
 10085,arceus-fairy,fairy,493,15,0,0,0,18,660
-10086,vivillon-icy-snow,icy-snow,666,15,1,0,0,1,899
+10086,vivillon-icy-snow,icy-snow,666,15,0,0,0,1,899
 10087,vivillon-polar,polar,666,15,0,0,0,2,900
 10088,vivillon-tundra,tundra,666,15,0,0,0,3,901
 10089,vivillon-continental,continental,666,15,0,0,0,4,902


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->
Relates to #1067.

I opted for the solution suggested by @Deleca7755. It seemed like the easiest one and the original intended objective.
The Meadow form is now the default one instead of the Icy Snow form. 
Consequently, _almost_ all existing sprites don't need to be changed. 
There is only the default shiny one that points to the Icy Snow form.
I initiated a PR to fix this aswell on the sprites project: https://github.com/PokeAPI/sprites/pull/157