### PR TITLE
feat: Make name lookups in api endpoints case insensitive

### DIFF
--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -39,7 +39,8 @@ class NameOrIdRetrieval:
     """
 
     idPattern = re.compile(r"^-?[0-9]+$")
-    namePattern = re.compile(r"^[0-9A-Za-z\-\+]+$")
+    # Allow alphanumeric, hyphen, plus, and space (Space added for test cases using name for lookup, ex: 'base pkm')
+    namePattern = re.compile(r"^[0-9A-Za-z\-\+ ]+$")
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -63,7 +64,7 @@ class NameOrIdRetrieval:
             resp = get_object_or_404(queryset, pk=lookup)
 
         elif self.namePattern.match(lookup):
-            resp = get_object_or_404(queryset, name=lookup)
+            resp = get_object_or_404(queryset, name__iexact=lookup)
 
         else:
             raise Http404


### PR DESCRIPTION
Solves issue #1179 makes lookup via name case-insensitive, for example 

```py
In [1]: import requests as r

In [2]: x = r.get('http://localhost:8000/api/v2/pokemon/Bulbasaur/')

In [3]: y = r.get('http://localhost:8000/api/v2/pokemon/bulbasaur/')

In [4]: x.status_code, y.status_code
Out[4]: (200, 200)

In [5]: x.json()["name"], y.json()["name"]
Out[5]: ('bulbasaur', 'bulbasaur')
```

Minor changes in lookup logic now uses `[__iexact]`(https://docs.djangoproject.com/en/dev/ref/models/querysets/#iexact) for querying.

Test cases are added for case-insensitive testing for the api:
https://github.com/PokeAPI/pokeapi/blob/63f0e2699b713dd1f832aba7f6c53eb66a6a30c6/pokemon_v2/tests.py#L5695-L5799

@Naramsim feel free to take a look when you have some time