### PR TITLE
Fixed effect of "Scorching Sands" to indicate it causes a burn

### DIFF
--- a/data/v2/csv/moves.csv
+++ b/data/v2/csv/moves.csv
@@ -813,7 +813,7 @@ id,identifier,generation_id,type_id,power,pp,accuracy,priority,target_id,damage_
 812,flip-turn,8,11,60,20,100,0,10,2,1,,,,
 813,triple-axel,8,15,20,10,90,0,10,2,1,,,,
 814,dual-wingbeat,8,3,40,10,90,0,10,2,1,,,,
-815,scorching-sands,8,5,70,10,100,0,10,3,1,30,,,
+815,scorching-sands,8,5,70,10,100,0,10,3,5,30,,,
 816,jungle-healing,8,12,,10,,0,13,1,1,,,,
 817,wicked-blow,8,17,75,5,100,0,10,2,1,,,,
 818,surging-strikes,8,11,25,5,100,0,10,2,1,,,,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

Fixes the effect text of "Scorching Sands" to indicate that it has a 30% chance to cause a burn. Previously, the API indicated it did regular damage with no additional effect.

Sample of new response:

```json
{
  "id": 815,
  "name": "scorching-sands",
  "accuracy": 100,
  "effect_chance": 30,
  <snip>
  "effect_entries": [
    {
      "effect": "Inflicts regular damage.  Has a 30% chance to burn the target.",
      "short_effect": "Has a 30% chance to burn the target.",
      "language": {
        "name": "en",
        "url": "http://localhost/api/v2/language/9/"
      }
    }
  ],
  <snip>
}
```