### PR TITLE
Add English names for Kitakami and Blueberry pokedexes

### DIFF
--- a/data/v2/csv/pokedex_prose.csv
+++ b/data/v2/csv/pokedex_prose.csv
@@ -59,3 +59,5 @@ pokedex_id,local_language_id,name,description
 29,9,Crown Tundra,Crown Tundra dex
 30,9,Hisui,Hisui dex
 31,9,Paldea,Paldea dex
+32,9,Kitakami,Kitakami dex
+33,9,Blueberry,Blueberry Academy dex


### PR DESCRIPTION
Very small pull request to add lines in `pokedex_prose.csv` for the English names of the Kitakami and Blueberry pokedex resources. Used the names present on Serebii here: https://www.serebii.net/scarletviolet/paldeapokedex.shtml. 