### PR TITLE
fix: add missing Simplified Chinese name for Stellar type

### DIFF
--- a/data/v2/csv/type_names.csv
+++ b/data/v2/csv/type_names.csv
@@ -189,6 +189,7 @@ type_id,local_language_id,name
 19,8,Astrale
 19,9,Stellar
 19,11,ステラ
+19,12,星晶
 10001,1,？？？
 10001,3,???
 10001,4,???


### PR DESCRIPTION
This PR fixes a  missing translation for stellar type in Simplified Chinese.