### PR TITLE
fix: typo for crystal-cluster item name (cyrstal-cluster)

### DIFF
--- a/data/v2/csv/items.csv
+++ b/data/v2/csv/items.csv
@@ -2051,7 +2051,7 @@ id,identifier,category_id,cost,fling_power,fling_effect_id
 2101,teal-style-card,21,0,,
 2102,teal-mask,20,0,,
 2103,glimmering-charm,21,0,,
-2104,cyrstal-cluster,20,0,,
+2104,crystal-cluster,20,0,,
 2105,fairy-feather,12,750,,
 2106,wellspring-mask,12,0,,
 2107,hearthflame-mask,12,0,,


### PR DESCRIPTION
There is a pretty significant typo in the item's name. It should be `crystal-cluster` instead of `cyrstal-cluster`. The actual English name of the item is "Crystal Cluster"