### PR TITLE
Add `legacy-cgi` for newer Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ psycopg2-binary==2.9.10
 python-dateutil==2.8.2
 python-mimeparse==1.6.0
 drf-spectacular==0.28.0
+legacy-cgi; python_version >= '3.13'


### PR DESCRIPTION
As mentioned in https://github.com/PokeAPI/pokeapi/issues/1300, this project is not currently usable by the latest versions of Python due to the Django version being a year and 2 major versions out of date. The version of Django currently used relies on the `cgi` module that was removed from Python in version 3.13

I still believe that updating to the latest version of Django is the better long term fix, but for now adding [`legacy-cgi`](https://github.com/jackrosenthal/legacy-cgi) as dependency at least gets things rolling with no code change

I will leave the mentioned issue open as I still believe it is relevant and this to not be a "proper" fix for the mentioned issue(s), this is just meant to be a temporary work-around