### PR TITLE
Fix duplicated names of Supersweet Syrup and French translations

### DIFF
--- a/data/v2/csv/ability_names.csv
+++ b/data/v2/csv/ability_names.csv
@@ -2899,10 +2899,6 @@ ability_id,local_language_id,name
 300,3,감미로운꿀
 300,4,甘露之蜜
 300,5,Nectar Mielleux
-300,1,かんろなミツ
-300,3,감미로운꿀
-300,4,甘露之蜜
-300,5,Nectar Mielleux
 300,6,Süßer Nektar
 300,7,Néctar Dulce
 300,8,Sciroppo Sublime

--- a/data/v2/csv/item_pocket_names.csv
+++ b/data/v2/csv/item_pocket_names.csv
@@ -35,7 +35,7 @@ item_pocket_id,local_language_id,name
 7,9,Battle Items
 7,12,战斗道具
 8,4,重要物品
-8,5,Object rares
+8,5,Objets rares
 8,7,Objetos clave
 8,9,Key Items
 8,12,重要物品

--- a/data/v2/csv/pokemon_form_names.csv
+++ b/data/v2/csv/pokemon_form_names.csv
@@ -169,7 +169,7 @@ pokemon_form_id,local_language_id,form_name,pokemon_name
 592,1,オスのすがた,
 592,3,수컷의 모습,
 592,4,雄性的樣子,
-592,5,Mâle,
+592,5,Mâle,Viskuse Mâle
 592,6,Männlich,
 592,7,Macho,
 592,8,Maschio,
@@ -179,7 +179,7 @@ pokemon_form_id,local_language_id,form_name,pokemon_name
 593,1,オスのすがた,
 593,3,수컷의 모습,
 593,4,雄性的樣子,
-593,5,Mâle,
+593,5,Mâle,Moyade Mâle
 593,6,Männlich,
 593,7,Macho,
 593,8,Maschio,
@@ -257,7 +257,7 @@ pokemon_form_id,local_language_id,form_name,pokemon_name
 668,1,オスのすがた,
 668,3,수컷의 모습,
 668,4,雄性的樣子,
-668,5,Mâle,
+668,5,Mâle,Némélios Mâle
 668,6,Männlich,
 668,7,Macho,
 668,8,Maschio,


### PR DESCRIPTION
# Change description

This is a really small PR that : 
- removes duplicated translations of Supersweet Syrup
- adds French translations of Frillish Jellicen and Pyror males forms (#1424) 
- fixes a wrong French translation in `data/v2/csv/item_pocket_names.csv`

## AI coding assistance disclosure

None

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
