### PR TITLE
feat: add type hints to pokemon_v2/api.py

### DIFF
--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -1,11 +1,15 @@
 import re
 import subprocess
+from typing import Optional
+
 from rest_framework import viewsets
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.serializers import BaseSerializer
 from rest_framework.views import APIView
-from django.shortcuts import get_object_or_404
+from django.db.models import Model, Q, QuerySet
 from django.http import Http404
-from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
 
@@ -25,9 +29,9 @@ class ListOrDetailSerialRelation:
     for list or detail view.
     """
 
-    list_serializer_class = None
+    list_serializer_class: Optional[type[BaseSerializer]] = None
 
-    def get_serializer_class(self):
+    def get_serializer_class(self) -> type[BaseSerializer]:
         if self.action == "list" and self.list_serializer_class is not None:
             return self.list_serializer_class
         return self.serializer_class
@@ -39,11 +43,11 @@ class NameOrIdRetrieval:
     pk (in this case ID) or by name
     """
 
-    idPattern = re.compile(r"^-?[0-9]+$")
+    idPattern: re.Pattern[str] = re.compile(r"^-?[0-9]+$")
     # Allow alphanumeric, hyphen, plus, and space (Space added for test cases using name for lookup, ex: 'base pkm')
-    namePattern = re.compile(r"^[0-9A-Za-z\-\+ ]+$")
+    namePattern: re.Pattern[str] = re.compile(r"^[0-9A-Za-z\-\+ ]+$")
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()
         filter = self.request.GET.get("q", "")
 
@@ -52,7 +56,7 @@ class NameOrIdRetrieval:
 
         return queryset
 
-    def get_object(self):
+    def get_object(self) -> Model:
         queryset = self.get_queryset()
         queryset = self.filter_queryset(queryset)
         lookup = self.kwargs["pk"]

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -1,6 +1,5 @@
 import re
 import subprocess
-from typing import Optional
 
 from rest_framework import viewsets
 from rest_framework.request import Request
@@ -29,7 +28,7 @@ class ListOrDetailSerialRelation:
     for list or detail view.
     """
 
-    list_serializer_class: Optional[type[BaseSerializer]] = None
+    list_serializer_class: type[BaseSerializer] | None = None
 
     def get_serializer_class(self) -> type[BaseSerializer]:
         if self.action == "list" and self.list_serializer_class is not None:
@@ -98,7 +97,7 @@ class PokeapiCommonViewset(
     ListOrDetailSerialRelation, NameOrIdRetrieval, viewsets.ReadOnlyModelViewSet
 ):
     @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request: Request, pk: Optional[str] = None) -> Response:
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
         return super().retrieve(request, pk)
 
     pass

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -98,7 +98,7 @@ class PokeapiCommonViewset(
     ListOrDetailSerialRelation, NameOrIdRetrieval, viewsets.ReadOnlyModelViewSet
 ):
     @extend_schema(parameters=[retrieve_path_parameter])
-    def retrieve(self, request, pk=None):
+    def retrieve(self, request: Request, pk: Optional[str] = None) -> Response:
         return super().retrieve(request, pk)
 
     pass
@@ -988,7 +988,7 @@ class VersionGroupResource(PokeapiCommonViewset):
     },
 )
 class PokemonEncounterView(APIView):
-    def get(self, request, pokemon_id):
+    def get(self, request: Request, pokemon_id: str) -> Response:
         self.context = dict(request=request)
 
         try:
@@ -1087,7 +1087,7 @@ class PokemonEncounterView(APIView):
     },
 )
 class PokeapiMetaView(APIView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             git_hash = (
                 subprocess.check_output(


### PR DESCRIPTION
## Summary
Adds Python type annotations to `pokemon_v2/api.py`. Pure annotation change — no runtime behavior modified.

**What's annotated:**
- The 6 method signatures: `ListOrDetailSerialRelation.get_serializer_class`, `NameOrIdRetrieval.get_queryset` / `get_object`, `PokeapiCommonViewset.retrieve`, `PokemonEncounterView.get`, `PokeapiMetaView.get`
- Class attributes: `list_serializer_class`, `idPattern`, `namePattern`

**Types used:** canonical DRF / Django imports — `Request`, `Response`, `BaseSerializer`, `QuerySet`, `Model`, `re.Pattern[str]`, and PEP 604 unions (`X | None`).

## Motivation
The `pokemon_v2` module currently has no type annotations anywhere (api.py / models.py / serializers.py). This PR is the first step toward fixing that. Annotations give readers and IDEs a clear contract on method inputs/outputs without changing runtime behavior, and lay groundwork for adding `mypy` to CI down the road if maintainers want stricter checks.

## Scope and limitations
- **api.py only.** `pokemon_v2/models.py` has no method definitions (only Django field declarations), so there is nothing to annotate there without pulling in `django-stubs`, which is a much larger change.
- `serializers.py` is intentionally out of scope for this PR.
- No `mypy` enforcement added; these annotations are documentation-grade rather than type-checked. Happy to follow up with a CI hook if of interest.

## Test plan
- [x] `make format-check` passes locally (black 25.11.0)
- [x] `make test` (verified green on CircleCI)
- [x] `make openapi-generate` (verified green on CircleCI)
