### PR TITLE
Fix Hasura README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ make docker-make-migrations
 make docker-migrate
 ```
 
-## GraphQL <a id="graphql"></a> &nbsp; <a href="ttps://github.com/hasura/graphql-engine"><img height="29px" src="https://graphql-engine-cdn.hasura.io/img/powered_by_hasura_blue.svg"/></a>
+## GraphQL <a id="graphql"></a> &nbsp; <a href="https://github.com/hasura/graphql-engine"><img height="29px" src="https://graphql-engine-cdn.hasura.io/img/powered_by_hasura_blue.svg"/></a>
 
 When you start PokéAPI with the above Docker Compose setup, an [Hasura Engine](https://github.com/hasura/graphql-engine) server is started as well. It's possible to track all the PokeAPI tables and foreign keys by simply
 


### PR DESCRIPTION
# Change description

Fixes a broken link in the README GraphQL section. The Hasura link was missing the leading `h` in `https://`, so the badge/link target did not resolve correctly.

This is a documentation-only change and does not alter API behaviour or served data.

## AI coding assistance disclosure

I used AI coding assistance to review the repository documentation, identify the broken README link, and prepare the one-line fix. I reviewed the generated change before submitting it.

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.