### PR TITLE
docs: Regenerate openapi.yml spec

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -4077,6 +4077,7 @@ components:
                       - min_level
                       - min_move_count
                       - min_steps
+                      - near_special_rock
                       - needs_multiplayer
                       - needs_overworld_rain
                       - party_species
@@ -4183,6 +4184,9 @@ components:
                         min_steps:
                           type: integer
                           format: int32
+                          nullable: true
+                        near_special_rock:
+                          type: boolean
                           nullable: true
                         needs_multiplayer:
                           type: boolean
@@ -8152,7 +8156,62 @@ components:
             $ref: '#/components/schemas/PokemonStat'
           readOnly: true
         past_stats:
-          type: string
+          type: array
+          items:
+            type: object
+            required:
+            - generation
+            - stats
+            properties:
+              generation:
+                type: object
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    examples:
+                    - generation-vi
+                  url:
+                    type: string
+                    format: uri
+                    examples:
+                    - https://pokeapi.co/api/v2/generation/6/
+              stats:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - base_stat
+                  - effort
+                  - stat
+                  properties:
+                    base_stat:
+                      type: integer
+                      format: int32
+                      examples:
+                      - 45
+                    effort:
+                      type: integer
+                      format: int32
+                      examples:
+                      - 0
+                    stat:
+                      type: object
+                      required:
+                      - name
+                      - url
+                      properties:
+                        name:
+                          type: string
+                          examples:
+                          - speed
+                        url:
+                          type: string
+                          format: uri
+                          examples:
+                          - https://pokeapi.co/api/v2/stat/6/
           readOnly: true
         types:
           type: array

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -5092,6 +5092,65 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
 
         return final_data
 
+    @extend_schema_field(
+        field={
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["generation", "stats"],
+                "properties": {
+                    "generation": {
+                        "type": "object",
+                        "required": ["name", "url"],
+                        "properties": {
+                            "name": {"type": "string", "examples": ["generation-vi"]},
+                            "url": {
+                                "type": "string",
+                                "format": "uri",
+                                "examples": ["https://pokeapi.co/api/v2/generation/6/"],
+                            },
+                        },
+                    },
+                    "stats": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["base_stat", "effort", "stat"],
+                            "properties": {
+                                "base_stat": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "examples": [45],
+                                },
+                                "effort": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "examples": [0],
+                                },
+                                "stat": {
+                                    "type": "object",
+                                    "required": ["name", "url"],
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "examples": ["speed"],
+                                        },
+                                        "url": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "examples": [
+                                                "https://pokeapi.co/api/v2/stat/6/"
+                                            ],
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    )
     def get_past_pokemon_stats(self, obj):
         pokemon_past_stat_objects = PokemonStatPast.objects.filter(pokemon=obj)
         pokemon_past_stats = PokemonStatPastSerializer(


### PR DESCRIPTION
# Change description

Regenerates openapi.yml, also added schema definition for `get_past_pokemon_stats` to prevent a spec generation warning

resolves #1536 

## AI coding assistance disclosure

No AI used

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
