### PR TITLE
Fix: Add missing summary serializer for version groups in evolutions

### DIFF
--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -5685,6 +5685,7 @@ class PokemonSpeciesDetailSerializer(serializers.ModelSerializer):
 
 
 class PokemonEvolutionSerializer(serializers.ModelSerializer):
+    version_group = VersionGroupSummarySerializer()
     item = ItemSummarySerializer(source="evolution_item")
     held_item = ItemSummarySerializer()
     known_move = MoveSummarySerializer()


### PR DESCRIPTION
# Change description

This is a small PR to add a summary serializer for version groups in `PokemonEvolutionSerializer` from PR #1558. My bad for missing that!

## AI coding assistance disclosure

No AI used.

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
