### PR TITLE
feat: Migrate nix setup to uv, and add a github action for testing env

### DIFF
--- a/.github/workflows/nix-environment.yml
+++ b/.github/workflows/nix-environment.yml
@@ -1,0 +1,48 @@
+name: Nix Environment
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  nix-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Evaluate default.nix
+        run: nix-instantiate default.nix
+      
+      - name: Test Nix shellHook runs automatically
+        run: |
+          nix-shell --run "
+            echo 'ShellHook completed successfully' &&
+            uv --version &&
+            test -d .venv && echo 'Virtual environment exists' || (echo 'Virtual environment not found' && exit 1)
+          "
+      
+      - name: Start pokeapi in Nix environment
+        run: |
+          nix-shell --run "
+            make install-base &&
+            make setup &&
+            make build-db
+          "
+      
+      - name: Test pokeapi serves correctly
+        run: |
+          nix-shell --run "
+            nohup make serve &
+            sleep 3 &&
+            curl -Ss http://localhost:8000/api/v2/pokemon/1/ | grep -q 'bulbasaur'
+          "

--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,10 @@
 with import <nixpkgs> { };
-pkgs.mkShell {
-  name = "onix-shellder";
-  venvDir = "./.venv";
-  buildInputs = [
-    python313Packages.python
-    python313Packages.venvShellHook
 
-    # Required dependencies
+mkShell {
+  packages = [
+    uv
 
-    # Python
-    python313Packages.black
-
-    # misc
+    # non-Python system libraries your project needs
     taglib
     openssl
     git
@@ -21,16 +14,8 @@ pkgs.mkShell {
     zlib
   ];
 
-  # Runs after creating the virtual environment
-  postVenvCreation = ''
+  shellHook = ''
     unset SOURCE_DATE_EPOCH
-    pip install -r requirements.txt
+    uv sync --locked --all-extras --dev
   '';
-
-  postShellHook = ''
-    unset SOURCE_DATE_EPOCH
-    # use z shell, run exit to get back to default bash
-    zsh -l
-  '';
-
 }


### PR DESCRIPTION
# Change description

Updated the nix env to use uv to install deps, also added a github action to test working inside nix env

<img width="3378" height="890" alt="image" src="https://github.com/user-attachments/assets/5c661c9e-55b3-43f9-adfa-b78c70455efb" />

resolves #1583 

## AI coding assistance disclosure

None

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
