### PR TITLE
Openapi security

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -151,6 +151,7 @@ Created by [**Paul Hallett**](https://github.com/phalt) and other [**PokéAPI co
     "EXTERNAL_DOCS": {"url": "https://pokeapi.co/docs/v2"},
     "VERSION": "2.10.0",
     "SERVE_INCLUDE_SCHEMA": False,
+    "AUTHENTICATION_WHITELIST": [],
     "OAS_VERSION": "3.1.0",
     "COMPONENT_SPLIT_REQUEST": True,
     "TAGS": [

--- a/openapi.yml
+++ b/openapi.yml
@@ -42,8 +42,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -69,8 +67,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -109,8 +105,6 @@ paths:
       tags:
       - berries
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -137,8 +131,6 @@ paths:
       tags:
       - berries
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -175,8 +167,6 @@ paths:
       tags:
       - berries
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -201,8 +191,6 @@ paths:
       tags:
       - berries
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -240,8 +228,6 @@ paths:
       tags:
       - berries
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -267,8 +253,6 @@ paths:
       tags:
       - berries
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -307,8 +291,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -335,8 +317,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -374,8 +354,6 @@ paths:
       tags:
       - contests
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -401,8 +379,6 @@ paths:
       tags:
       - contests
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -438,8 +414,6 @@ paths:
       tags:
       - contests
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -463,8 +437,6 @@ paths:
       tags:
       - contests
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -503,8 +475,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -531,8 +501,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -569,8 +537,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -595,8 +561,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -633,8 +597,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -659,8 +621,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -697,8 +657,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -723,8 +681,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -762,8 +718,6 @@ paths:
       tags:
       - evolution
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -789,8 +743,6 @@ paths:
       tags:
       - evolution
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -828,8 +780,6 @@ paths:
       tags:
       - evolution
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -855,8 +805,6 @@ paths:
       tags:
       - evolution
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -895,8 +843,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -923,8 +869,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -963,8 +907,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -991,8 +933,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1030,8 +970,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1057,8 +995,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1096,8 +1032,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1123,8 +1057,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1161,8 +1093,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1187,8 +1117,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1225,8 +1153,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1251,8 +1177,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1289,8 +1213,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1315,8 +1237,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1352,8 +1272,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1377,8 +1295,6 @@ paths:
       tags:
       - items
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1414,8 +1330,6 @@ paths:
       tags:
       - utility
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1439,8 +1353,6 @@ paths:
       tags:
       - utility
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1477,8 +1389,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1503,8 +1413,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1535,8 +1443,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1561,8 +1467,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1600,8 +1504,6 @@ paths:
       tags:
       - machines
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1627,8 +1529,6 @@ paths:
       tags:
       - machines
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1645,8 +1545,6 @@ paths:
       tags:
       - utility
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1697,8 +1595,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1725,8 +1621,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1764,8 +1658,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1791,8 +1683,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1829,8 +1719,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1855,8 +1743,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1892,8 +1778,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1917,8 +1801,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1954,8 +1836,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -1979,8 +1859,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2016,8 +1894,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2041,8 +1917,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2079,8 +1953,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2105,8 +1977,6 @@ paths:
       tags:
       - moves
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2143,8 +2013,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2169,8 +2037,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2207,8 +2073,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2233,8 +2097,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2274,8 +2136,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2303,8 +2163,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2345,8 +2203,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2375,8 +2231,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2415,8 +2269,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2443,8 +2295,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2483,8 +2333,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2511,8 +2359,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2549,8 +2395,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2575,8 +2419,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2612,8 +2454,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2637,8 +2477,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2677,8 +2515,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2705,8 +2541,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2745,8 +2579,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2773,8 +2605,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2812,8 +2642,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2839,8 +2667,6 @@ paths:
       tags:
       - location
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2878,8 +2704,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2905,8 +2729,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2943,8 +2765,6 @@ paths:
       tags:
       - contests
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -2969,8 +2789,6 @@ paths:
       tags:
       - contests
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3009,8 +2827,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3037,8 +2853,6 @@ paths:
       tags:
       - pokemon
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3074,8 +2888,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3099,8 +2911,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3136,8 +2946,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3161,8 +2969,6 @@ paths:
       tags:
       - games
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -3186,8 +2992,6 @@ paths:
       tags:
       - encounters
       security:
-      - cookieAuth: []
-      - basicAuth: []
       - {}
       responses:
         '200':
@@ -9788,14 +9592,6 @@ components:
       required:
       - name
       - url
-  securitySchemes:
-    basicAuth:
-      type: http
-      scheme: basic
-    cookieAuth:
-      type: apiKey
-      in: cookie
-      name: sessionid
 servers:
 - url: https://pokeapi.co
 tags:

--- a/openapi.yml
+++ b/openapi.yml
@@ -20,7 +20,7 @@ paths:
         overworld. Pokémon have multiple possible abilities but can have only one
         ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability)
         for greater detail.
-      summary: Get ability
+      summary: List abilities
       parameters:
       - name: limit
         required: false
@@ -8304,6 +8304,29 @@ components:
                     examples:
                     - https://pokeapi.co/api/v2/type/7/
           readOnly: true
+        trigger_conditions:
+          type: array
+          items:
+            type: object
+            required:
+            - trigger
+            - name
+            - url
+            properties:
+              trigger:
+                type: string
+                examples:
+                - held-item
+              name:
+                type: string
+                examples:
+                - venusaurite
+              url:
+                type: string
+                format: uri
+                examples:
+                - https://pokeapi.co/api/v2/item/698/
+          readOnly: true
       required:
       - form_name
       - form_names
@@ -8312,6 +8335,7 @@ components:
       - names
       - pokemon
       - sprites
+      - trigger_conditions
       - types
       - version_group
     PokemonFormSummary:

--- a/openapi.yml
+++ b/openapi.yml
@@ -20,6 +20,7 @@ paths:
         overworld. Pokémon have multiple possible abilities but can have only one
         ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability)
         for greater detail.
+      summary: Get ability
       parameters:
       - name: limit
         required: false
@@ -57,6 +58,7 @@ paths:
         overworld. Pokémon have multiple possible abilities but can have only one
         ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability)
         for greater detail.
+      summary: Get ability
       parameters:
       - in: path
         name: id
@@ -1542,6 +1544,7 @@ paths:
       operationId: meta_list
       description: Returns metadata about the current deployed version of the API,
         including the git commit hash, deploy date, and tag (if any).
+      summary: Get API metadata
       tags:
       - utility
       security:

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -108,6 +108,7 @@ class PokeapiCommonViewset(
 @extend_schema(
     description="Abilities provide passive effects for Pokémon in battle or in the overworld. Pokémon have multiple possible abilities but can have only one ability at a time. Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Ability) for greater detail.",
     tags=["pokemon"],
+    summary="Get ability",
 )
 class AbilityResource(PokeapiCommonViewset):
     queryset = Ability.objects.all()
@@ -1063,6 +1064,7 @@ class PokemonEncounterView(APIView):
 
 @extend_schema(
     description="Returns metadata about the current deployed version of the API, including the git commit hash, deploy date, and tag (if any).",
+    summary="Get API metadata",
     tags=["utility"],
     responses={
         200: {

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -110,6 +110,11 @@ class PokeapiCommonViewset(
     tags=["pokemon"],
     summary="Get ability",
 )
+@extend_schema_view(
+    list=extend_schema(
+        summary="List abilities",
+    )
+)
 class AbilityResource(PokeapiCommonViewset):
     queryset = Ability.objects.all()
     serializer_class = AbilityDetailSerializer


### PR DESCRIPTION
# Change description

Remove the default security and security schema fields from the openapi schema generation, had auth whitelisted in settings since we dont perform any auth

ps: was thinking about picking up the astro site in development and noticed openapi docs had auth due the source being here

cc: @Naramsim 

## AI coding assistance disclosure

None

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
