### PR TITLE
feat: Mark get api metadata as get method

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -13,6 +13,33 @@ info:
     around the world. Pokémon and Pokémon character names are trademarks of Nintendo.\n
     \   "
 paths:
+  /api/v2/meta/:
+    get:
+      operationId: meta_retrieve
+      description: Returns metadata about the current deployed version of the API,
+        including the git commit hash, deploy date, and tag (if any).
+      summary: Get API metadata
+      tags:
+      - utility
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deploy_date:
+                    type: string
+                    nullable: true
+                  hash:
+                    type: string
+                    nullable: true
+                  tag:
+                    type: string
+                    nullable: true
+          description: ''
   /api/v2/ability/:
     get:
       operationId: ability_list
@@ -1538,35 +1565,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MachineDetail'
-          description: ''
-  /api/v2/meta/:
-    get:
-      operationId: meta_list
-      description: Returns metadata about the current deployed version of the API,
-        including the git commit hash, deploy date, and tag (if any).
-      summary: Get API metadata
-      tags:
-      - utility
-      security:
-      - {}
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    deploy_date:
-                      type: string
-                      nullable: true
-                    hash:
-                      type: string
-                      nullable: true
-                    tag:
-                      type: string
-                      nullable: true
           description: ''
   /api/v2/move/:
     get:

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -1082,8 +1082,8 @@ class PokemonEncounterView(APIView):
         }
     },
 )
-class PokeapiMetaViewset(viewsets.ViewSet):
-    def list(self, request):
+class PokeapiMetaView(APIView):
+    def get(self, request):
         try:
             git_hash = (
                 subprocess.check_output(

--- a/pokemon_v2/urls.py
+++ b/pokemon_v2/urls.py
@@ -38,7 +38,7 @@ router.register(r"language", LanguageResource)
 router.register(r"location", LocationResource)
 router.register(r"location-area", LocationAreaResource)
 router.register(r"machine", MachineResource)
-router.register(r"meta", PokeapiMetaViewset, basename="meta")
+
 router.register(r"move", MoveResource)
 router.register(r"move-ailment", MoveMetaAilmentResource)
 router.register(r"move-battle-style", MoveBattleStyleResource)
@@ -71,6 +71,7 @@ router.register(r"version-group", VersionGroupResource)
 ###########################
 
 urlpatterns = [
+    path("api/v2/meta/", PokeapiMetaView.as_view(), name="meta"),
     path("api/v2/", include(router.urls)),
     re_path(
         r"^api/v2/pokemon/(?P<pokemon_id>\d+)/encounters",


### PR DESCRIPTION
# Change description

Previously api metadata openapi schema defined it as a list which is misleading, redefined the schema to return an object since thats whats actually returned by the api (list -> get)

<img width="2412" height="962" alt="image" src="https://github.com/user-attachments/assets/3654770b-4d6e-4c0b-9839-022c425e9203" />

```diff
      responses:
        '200':
          content:
            application/json:
              schema:
-              type: array
+              type: object
```

## AI coding assistance disclosure

None

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
