### PR TITLE
fix: Update router root view to include meta api

### DIFF
--- a/pokemon_v2/urls.py
+++ b/pokemon_v2/urls.py
@@ -1,17 +1,38 @@
-from django.urls import include, path, re_path
-
 #####################################
 #
 #   V2 API setup using Django Rest
 #
 #####################################
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django.urls import include, path, re_path
 from rest_framework import routers
+from rest_framework.reverse import reverse as drf_reverse
+
 from pokemon_v2.api import *
 
-# pylint: disable=invalid-name
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+    from rest_framework.response import Response
 
-router = routers.DefaultRouter()
+
+class PokeAPIRootView(routers.APIRootView):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().get(request, *args, **kwargs)
+        response.data["meta"] = drf_reverse("meta", request=request)
+        response.data = dict(sorted(response.data.items()))
+        return response
+
+
+class PokeAPIRouter(routers.DefaultRouter):
+    APIRootView = PokeAPIRootView
+
+
+router = PokeAPIRouter()
+
 
 router.register(r"ability", AbilityResource)
 router.register(r"berry", BerryResource)
@@ -38,7 +59,6 @@ router.register(r"language", LanguageResource)
 router.register(r"location", LocationResource)
 router.register(r"location-area", LocationAreaResource)
 router.register(r"machine", MachineResource)
-
 router.register(r"move", MoveResource)
 router.register(r"move-ailment", MoveMetaAilmentResource)
 router.register(r"move-battle-style", MoveBattleStyleResource)


### PR DESCRIPTION
# Change description

Subclasses the router to include the `meta` api into the `api/v2` router since an `APIView` cannot be registered to a router it is being reversed via drf and added to the router

I looked into viewsets and a `retrieve` only viewset wouldnt work since the router root view lists the `list` endpoints which causes openapi to pick this endpoint up wrong creating this conundrum

<img width="1831" height="1225" alt="image" src="https://github.com/user-attachments/assets/a633c03c-2ced-489d-906c-7025d0c8154e" />
<img width="1296" height="182" alt="image" src="https://github.com/user-attachments/assets/545f3fe6-6c4d-410c-a15d-7be29c86104b" />

## AI coding assistance disclosure

None

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
