### PR TITLE
fix: make Ultra Necrozma battle-only

### DIFF
--- a/data/v2/csv/pokemon_forms.csv
+++ b/data/v2/csv/pokemon_forms.csv
@@ -1339,7 +1339,7 @@ id,identifier,form_identifier,pokemon_id,introduced_in_version_group_id,is_defau
 10313,togedemaru-totem,totem,10154,18,1,0,0,2,1147
 10314,necrozma-dusk,dusk,10155,18,1,0,0,2,1176
 10315,necrozma-dawn,dawn,10156,18,1,0,0,3,1177
-10316,necrozma-ultra,ultra,10157,18,1,0,0,4,1178
+10316,necrozma-ultra,ultra,10157,18,1,1,0,4,1178
 10317,pikachu-starter,starter,10158,19,1,0,0,15,50
 10318,eevee-starter,starter,10159,19,1,0,0,2,222
 10319,pikachu-world-cap,world-cap,10160,20,1,0,0,16,51


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

# Change description

Ultra Necrozma is a form only found in battle, when you make Ultra burst.

## AI coding assistance disclosure

Not used.

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
