### PR TITLE
Add missing English effect_entries for as-one-glastrier and as-one-spectrier

### DIFF
--- a/data/v2/csv/ability_prose.csv
+++ b/data/v2/csv/ability_prose.csv
@@ -1958,6 +1958,16 @@ This Ability is not bypassed by Mold Breaker, Teravolt, or Turboblaze."
 264,9,"Boosts Attack after knocking out a Pokémon.","When the Pokémon knocks out a target, it utters a chilling neigh, which boosts its Attack stat."
 265,5,Booste l’Attaque Spéciale après avoir mis un Pokémon KO.,"Quand le Pokémon met une cible KO, il pousse un hennissement terrifiant, qui augmente sa stat d'Attaque Spéciale."
 265,9,"Boosts Special Attack after knocking out a Pokémon.","When the Pokémon knocks out a target, it utters a terrifying neigh, which boosts its Sp. Atk stat."
+266,9,Combines the effects of Unnerve and Chilling Neigh.,"This Pokémon has the combined effects of Unnerve and Chilling Neigh.
+
+Opposing Pokémon cannot eat held Berries while this Pokémon is in battle. Affected Pokémon can still use Bug Bite or Pluck to eat a target's Berry.
+
+When this Pokémon knocks out a target, it utters a chilling neigh, which boosts its Attack stat."
+267,9,Combines the effects of Unnerve and Grim Neigh.,"This Pokémon has the combined effects of Unnerve and Grim Neigh.
+
+Opposing Pokémon cannot eat held Berries while this Pokémon is in battle. Affected Pokémon can still use Bug Bite or Pluck to eat a target's Berry.
+
+When this Pokémon knocks out a target, it utters a terrifying neigh, which boosts its Sp. Atk stat."
 268,5,Un contact change le Talent de l’attaquant en Odeur Tenace.,Un contact avec le Pokémon change le Talent de l'attaquant en Odeur Tenace.
 268,9,"Contact changes the attacker's Ability to Lingering Aroma.","Contact with the Pokémon changes the attacker’s Ability to Lingering Aroma."
 269,5,Change le sol en Champ Herbu quand le Pokémon est frappé par une attaque.,Change le sol en Champ Herbu quand le Pokémon est frappé par une attaque.

--- a/data/v2/csv/ability_prose.csv
+++ b/data/v2/csv/ability_prose.csv
@@ -1958,16 +1958,8 @@ This Ability is not bypassed by Mold Breaker, Teravolt, or Turboblaze."
 264,9,"Boosts Attack after knocking out a Pokémon.","When the Pokémon knocks out a target, it utters a chilling neigh, which boosts its Attack stat."
 265,5,Booste l’Attaque Spéciale après avoir mis un Pokémon KO.,"Quand le Pokémon met une cible KO, il pousse un hennissement terrifiant, qui augmente sa stat d'Attaque Spéciale."
 265,9,"Boosts Special Attack after knocking out a Pokémon.","When the Pokémon knocks out a target, it utters a terrifying neigh, which boosts its Sp. Atk stat."
-266,9,Combines the effects of Unnerve and Chilling Neigh.,"This Pokémon has the combined effects of Unnerve and Chilling Neigh.
-
-Opposing Pokémon cannot eat held Berries while this Pokémon is in battle. Affected Pokémon can still use Bug Bite or Pluck to eat a target's Berry.
-
-When this Pokémon knocks out a target, it utters a chilling neigh, which boosts its Attack stat."
-267,9,Combines the effects of Unnerve and Grim Neigh.,"This Pokémon has the combined effects of Unnerve and Grim Neigh.
-
-Opposing Pokémon cannot eat held Berries while this Pokémon is in battle. Affected Pokémon can still use Bug Bite or Pluck to eat a target's Berry.
-
-When this Pokémon knocks out a target, it utters a terrifying neigh, which boosts its Sp. Atk stat."
+266,9,Combines the effects of Unnerve and Chilling Neigh.,This Ability combines the effects of both Calyrex's Unnerve Ability and Glastrier's Chilling Neigh Ability.
+267,9,Combines the effects of Unnerve and Grim Neigh.,This Ability combines the effects of both Calyrex's Unnerve Ability and Spectrier's Grim Neigh Ability.
 268,5,Un contact change le Talent de l’attaquant en Odeur Tenace.,Un contact avec le Pokémon change le Talent de l'attaquant en Odeur Tenace.
 268,9,"Contact changes the attacker's Ability to Lingering Aroma.","Contact with the Pokémon changes the attacker’s Ability to Lingering Aroma."
 269,5,Change le sol en Champ Herbu quand le Pokémon est frappé par une attaque.,Change le sol en Champ Herbu quand le Pokémon est frappé par une attaque.

--- a/data/v2/csv/ability_prose.csv
+++ b/data/v2/csv/ability_prose.csv
@@ -1958,8 +1958,16 @@ This Ability is not bypassed by Mold Breaker, Teravolt, or Turboblaze."
 264,9,"Boosts Attack after knocking out a Pokémon.","When the Pokémon knocks out a target, it utters a chilling neigh, which boosts its Attack stat."
 265,5,Booste l’Attaque Spéciale après avoir mis un Pokémon KO.,"Quand le Pokémon met une cible KO, il pousse un hennissement terrifiant, qui augmente sa stat d'Attaque Spéciale."
 265,9,"Boosts Special Attack after knocking out a Pokémon.","When the Pokémon knocks out a target, it utters a terrifying neigh, which boosts its Sp. Atk stat."
-266,9,Combines the effects of Unnerve and Chilling Neigh.,This Ability combines the effects of both Calyrex's Unnerve Ability and Glastrier's Chilling Neigh Ability.
-267,9,Combines the effects of Unnerve and Grim Neigh.,This Ability combines the effects of both Calyrex's Unnerve Ability and Spectrier's Grim Neigh Ability.
+266,9,Combines the effects of Unnerve and Chilling Neigh.,"This Pokémon has the combined effects of Unnerve and Chilling Neigh.
+
+Opposing Pokémon cannot eat held Berries while this Pokémon is in battle. Affected Pokémon can still use Bug Bite or Pluck to eat a target's Berry.
+
+When this Pokémon knocks out a target, it utters a chilling neigh, which boosts its Attack stat."
+267,9,Combines the effects of Unnerve and Grim Neigh.,"This Pokémon has the combined effects of Unnerve and Grim Neigh.
+
+Opposing Pokémon cannot eat held Berries while this Pokémon is in battle. Affected Pokémon can still use Bug Bite or Pluck to eat a target's Berry.
+
+When this Pokémon knocks out a target, it utters a terrifying neigh, which boosts its Sp. Atk stat."
 268,5,Un contact change le Talent de l’attaquant en Odeur Tenace.,Un contact avec le Pokémon change le Talent de l'attaquant en Odeur Tenace.
 268,9,"Contact changes the attacker's Ability to Lingering Aroma.","Contact with the Pokémon changes the attacker’s Ability to Lingering Aroma."
 269,5,Change le sol en Champ Herbu quand le Pokémon est frappé par une attaque.,Change le sol en Champ Herbu quand le Pokémon est frappé par une attaque.


### PR DESCRIPTION
## Problem

Fixes #1615.

`as-one-glastrier` (ability 266) and `as-one-spectrier` (ability 267) had zero rows in `data/v2/csv/ability_prose.csv`, so `effect_entries` was empty for both, unlike every other ability which has at least an English entry.

## Fix

Added English (`local_language_id` 9) rows for both abilities, describing them as the combination of Unnerve with Chilling Neigh / Grim Neigh respectively (matching the official in-game description, see [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/As_One_(Ability))), and reusing the existing English wording already in this CSV for Unnerve (127), Chilling Neigh (264), and Grim Neigh (265).

I only added English entries — I didn't have a reliable source for official French wording so I left that out rather than guess.

## Test plan

- `csv.DictReader` parses the file cleanly (809 rows, no errors).
- Rebuilt the local sqlite DB from the CSVs and hit the live endpoints:
  - `GET /api/v2/ability/as-one-glastrier/` → `effect_entries` now has an English entry.
  - `GET /api/v2/ability/as-one-spectrier/` → same.
- `manage.py test pokemon_v2` passes (56 tests).