### PR TITLE
fix: correct "charecterictics" typo in OpenAPI summary

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -297,7 +297,7 @@ paths:
         IV. A Pokémon's Characteristic is determined by the remainder of its highest
         IV divided by 5 (gene_modulo). Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Characteristic)
         for greater detail.
-      summary: List charecterictics
+      summary: List characteristics
       parameters:
       - name: limit
         required: false

--- a/pokemon_v2/api.py
+++ b/pokemon_v2/api.py
@@ -174,7 +174,7 @@ class BerryFlavorResource(PokeapiCommonViewset):
 )
 @extend_schema_view(
     list=extend_schema(
-        summary="List charecterictics",
+        summary="List characteristics",
     )
 )
 class CharacteristicResource(PokeapiCommonViewset):


### PR DESCRIPTION
# Change description

Fixes a typo in the characteristic endpoint's OpenAPI list summary: "List charecterictics" → "List characteristics".

Two-line change: the `extend_schema_view` summary in `pokemon_v2/api.py` and the corresponding line in the checked-in `openapi.yml`. I intentionally did not run a full `make openapi-generate`, because regeneration currently produces ~265 lines of unrelated integer-range churn (int32 → int64 bounds) — that drift is tracked separately in #1623 and shouldn't be mixed into a typo fix.

**How to test:** `grep -ri charecterictics .` returns nothing; `make format-check` passes.

## AI coding assistance disclosure

I used Claude Code to make sure there were no other typos of "charecterictics" in the project and to help with the PR description

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [ ] I have written tests for my code changes (if applicable). *(N/A — docs-text-only change.)*
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
