### PR TITLE
fix: skip publish workflows on forks

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'PokeAPI/pokeapi'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docker:
-    if: github.repository == 'PokeAPI/pokeapi'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'PokeAPI/pokeapi'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    if: github.repository == 'PokeAPI/pokeapi'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Change description

Fixes #1624. Pushes to `master` on forks trigger the `Publish` and `Release` workflows, which fail without DockerHub/registry credentials and spam fork owners with failure emails on every upstream sync.

This adds `if: ${{ !github.event.repository.fork }}` to the single job in `docker-build-and-push.yml` and `release.yml`, so they only run in the upstream repo. Both workflows only trigger on `push` events, whose payload always includes the `repository.fork` flag, and using the flag (rather than a hardcoded repo name) keeps the guard working even if the repo is ever renamed or moved. `nix-environment.yml` is intentionally left unguarded: it needs no credentials and forks may want that build check.

**How to test:** push any commit to `master` on a fork — the Publish and Release workflows should show as skipped instead of failing.

## AI coding assistance disclosure

I used Claude Code to identify the affected workflows and prepare the change. I reviewed the diff myself.

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [ ] I have written tests for my code changes (if applicable). *(N/A — CI configuration change.)*
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
