### PR TITLE
feat: add pokemon_form_flavor_text (per-form flavor text)

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1938,6 +1938,20 @@ def _build_pokemons():
     build_generic((PokemonFormCondition,), "pokemon_form_conditions.csv", csv_record_to_objects)
 
     def csv_record_to_objects(info):
+        yield PokemonFormFlavorText(
+            pokemon_form_id=int(info[0]),
+            version_id=int(info[1]),
+            language_id=int(info[2]),
+            flavor_text=info[3],
+        )
+
+    build_generic(
+        (PokemonFormFlavorText,),
+        "pokemon_form_flavor_text.csv",
+        csv_record_to_objects,
+    )
+
+    def csv_record_to_objects(info):
         yield PokemonGameIndex(pokemon_id=int(info[0]), version_id=int(info[1]), game_index=int(info[2]))
 
     build_generic((PokemonGameIndex,), "pokemon_game_indices.csv", csv_record_to_objects)

--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1239,6 +1239,20 @@ def _build_pokemons():
     )
 
     def csv_record_to_objects(info):
+        yield PokemonFormFlavorText(
+            pokemon_form_id=int(info[0]),
+            version_id=int(info[1]),
+            language_id=int(info[2]),
+            flavor_text=info[3],
+        )
+
+    build_generic(
+        (PokemonFormFlavorText,),
+        "pokemon_form_flavor_text.csv",
+        csv_record_to_objects,
+    )
+
+    def csv_record_to_objects(info):
         yield Pokemon(
             id=int(info[0]),
             name=info[1],

--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -1,0 +1,19 @@
+pokemon_form_id,version_id,language_id,flavor_text
+386,7,9,"The DNA of a space virus underwent a
+sudden mutation upon exposure to a
+laser beam and resulted in DEOXYS.The crystalline organ on this POKéMON’s
+chest appears to be its brain."
+386,8,9,"DEOXYS emerged from a virus that came
+from space. It is highly intelligent and
+wields psychokinetic powers.This POKéMON shoots lasers from the
+crystalline organ on its chest."
+10031,10,9,"This DEOXYS has transformed into its
+aggressive guise. It can fool enemies by
+altering its appearance."
+10032,11,9,"When it changes form, an aurora appears.
+It absorbs attacks by altering its
+cellular structure."
+10033,9,9,"A POKéMON that mutated from an
+extraterrestrial virus exposed to a laser
+beam. Its body is configured for superior
+agility and speed."

--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -1,0 +1,1 @@
+pokemon_form_id,version_id,language_id,flavor_text

--- a/graphql/v1beta2/metadata/databases/default/tables/public_pokemon_v2_pokemonformflavortext.yaml
+++ b/graphql/v1beta2/metadata/databases/default/tables/public_pokemon_v2_pokemonformflavortext.yaml
@@ -1,0 +1,29 @@
+table:
+  name: pokemon_v2_pokemonformflavortext
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: pokemonformflavortext
+  custom_root_fields: {}
+object_relationships:
+  - name: language
+    using:
+      foreign_key_constraint_on: language_id
+  - name: pokemonform
+    using:
+      foreign_key_constraint_on: pokemon_form_id
+  - name: version
+    using:
+      foreign_key_constraint_on: version_id
+select_permissions:
+  - role: anon
+    permission:
+      columns: '*'
+      filter: {}
+      limit: 100000
+      allow_aggregations: true
+      query_root_fields:
+        - select
+        - select_aggregate
+      subscription_root_fields: []

--- a/graphql/v1beta2/metadata/databases/default/tables/tables.yaml
+++ b/graphql/v1beta2/metadata/databases/default/tables/tables.yaml
@@ -119,6 +119,7 @@
 - "!include public_pokemon_v2_pokemonevolution.yaml"
 - "!include public_pokemon_v2_pokemonform.yaml"
 - "!include public_pokemon_v2_pokemonformcondition.yaml"
+- "!include public_pokemon_v2_pokemonformflavortext.yaml"
 - "!include public_pokemon_v2_pokemonformgeneration.yaml"
 - "!include public_pokemon_v2_pokemonformname.yaml"
 - "!include public_pokemon_v2_pokemonformsprites.yaml"

--- a/graphql/v1beta2/metadata/databases/default/tables/tables.yaml
+++ b/graphql/v1beta2/metadata/databases/default/tables/tables.yaml
@@ -116,6 +116,7 @@
 - "!include public_pokemon_v2_pokemonevolution.yaml"
 - "!include public_pokemon_v2_pokemonform.yaml"
 - "!include public_pokemon_v2_pokemonformcondition.yaml"
+- "!include public_pokemon_v2_pokemonformflavortext.yaml"
 - "!include public_pokemon_v2_pokemonformgeneration.yaml"
 - "!include public_pokemon_v2_pokemonformname.yaml"
 - "!include public_pokemon_v2_pokemonformsprites.yaml"

--- a/openapi.yml
+++ b/openapi.yml
@@ -7355,7 +7355,13 @@ components:
           items:
             $ref: '#/components/schemas/PokemonFormTriggerCondition'
           readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonFormFlavorText'
+          readOnly: true
       required:
+      - flavor_text_entries
       - form_name
       - form_names
       - id
@@ -7366,6 +7372,19 @@ components:
       - trigger_conditions
       - types
       - version_group
+    PokemonFormFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+        version:
+          $ref: '#/components/schemas/VersionSummary'
+      required:
+      - flavor_text
+      - language
+      - version
     PokemonFormName:
       type: object
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -8319,7 +8319,13 @@ components:
                 examples:
                 - https://pokeapi.co/api/v2/item/698/
           readOnly: true
+        flavor_text_entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/PokemonFormFlavorText'
+          readOnly: true
       required:
+      - flavor_text_entries
       - form_name
       - form_names
       - id
@@ -8330,6 +8336,19 @@ components:
       - trigger_conditions
       - types
       - version_group
+    PokemonFormFlavorText:
+      type: object
+      properties:
+        flavor_text:
+          type: string
+        language:
+          $ref: '#/components/schemas/LanguageSummary'
+        version:
+          $ref: '#/components/schemas/VersionSummary'
+      required:
+      - flavor_text
+      - language
+      - version
     PokemonFormSummary:
       type: object
       properties:

--- a/pokemon_v2/migrations/0032_pokemonformflavortext.py
+++ b/pokemon_v2/migrations/0032_pokemonformflavortext.py
@@ -1,0 +1,59 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pokemon_v2", "0031_encounterpokemondetail"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PokemonFormFlavorText",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("flavor_text", models.CharField(max_length=500)),
+                (
+                    "language",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(class)s_language",
+                        to="pokemon_v2.language",
+                    ),
+                ),
+                (
+                    "pokemon_form",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(class)s",
+                        to="pokemon_v2.pokemonform",
+                    ),
+                ),
+                (
+                    "version",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(class)s",
+                        to="pokemon_v2.version",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+    ]

--- a/pokemon_v2/migrations/0035_pokemonformflavortext.py
+++ b/pokemon_v2/migrations/0035_pokemonformflavortext.py
@@ -1,0 +1,59 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pokemon_v2", "0034_item_cost_and_time_of_day"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PokemonFormFlavorText",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("flavor_text", models.CharField(max_length=500)),
+                (
+                    "language",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(class)s_language",
+                        to="pokemon_v2.language",
+                    ),
+                ),
+                (
+                    "pokemon_form",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(class)s",
+                        to="pokemon_v2.pokemonform",
+                    ),
+                ),
+                (
+                    "version",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(class)s",
+                        to="pokemon_v2.version",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+    ]

--- a/pokemon_v2/models.py
+++ b/pokemon_v2/models.py
@@ -1566,6 +1566,10 @@ class PokemonSpeciesFlavorText(IsFlavorText, HasPokemonSpecies, HasVersion):
     pass
 
 
+class PokemonFormFlavorText(IsFlavorText, HasPokemonForm, HasVersion):
+    pass
+
+
 class Pokemon(HasName, HasPokemonSpecies, HasOrder):
     height = models.IntegerField(blank=True, null=True)
 

--- a/pokemon_v2/models.py
+++ b/pokemon_v2/models.py
@@ -183,6 +183,7 @@ __all__: tuple[str, ...] = (
     "PokemonEvolution",
     "PokemonForm",
     "PokemonFormCondition",
+    "PokemonFormFlavorText",
     "PokemonFormGeneration",
     "PokemonFormName",
     "PokemonFormSprites",
@@ -1826,6 +1827,10 @@ class PokemonSpeciesDescription(HasPokemonSpecies, IsDescription):
 
 
 class PokemonSpeciesFlavorText(IsFlavorText, HasPokemonSpecies, HasVersion):
+    pass
+
+
+class PokemonFormFlavorText(IsFlavorText, HasPokemonForm, HasVersion):
     pass
 
 

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -2571,6 +2571,16 @@ class PokemonShapeAwesomeNameSerializer(serializers.ModelSerializer[PokemonShape
         fields = ("awesome_name", "language")
 
 
+class PokemonFormFlavorTextSerializer(serializers.ModelSerializer[PokemonFormFlavorText]):
+    flavor_text = serializers.CharField()
+    language = LanguageSummarySerializer()
+    version = VersionSummarySerializer()
+
+    class Meta:
+        model = PokemonFormFlavorText
+        fields = ("flavor_text", "language", "version")
+
+
 class PokemonFormDetailSerializer(serializers.ModelSerializer[PokemonForm]):
     pokemon = PokemonSummarySerializer()
     version_group = VersionGroupSummarySerializer()
@@ -2579,6 +2589,7 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer[PokemonForm]):
     names = serializers.SerializerMethodField("get_pokemon_form_pokemon_names")
     types = serializers.SerializerMethodField("get_pokemon_form_types")
     trigger_conditions = serializers.SerializerMethodField("get_pokemon_form_triggers_conditions")
+    flavor_text_entries = PokemonFormFlavorTextSerializer(many=True, read_only=True, source="pokemonformflavortext")
 
     class Meta:
         model = PokemonForm
@@ -2598,6 +2609,7 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer[PokemonForm]):
             "names",
             "types",
             "trigger_conditions",
+            "flavor_text_entries",
         )
 
     @extend_schema_field(PokemonFormNameSerializer(many=True))

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -3668,6 +3668,16 @@ class PokemonFormConditionSerializer(serializers.ModelSerializer):
         fields = ("trigger", "item", "ability", "move")
 
 
+class PokemonFormFlavorTextSerializer(serializers.ModelSerializer):
+    flavor_text = serializers.CharField()
+    language = LanguageSummarySerializer()
+    version = VersionSummarySerializer()
+
+    class Meta:
+        model = PokemonFormFlavorText
+        fields = ("flavor_text", "language", "version")
+
+
 class PokemonFormDetailSerializer(serializers.ModelSerializer):
     pokemon = PokemonSummarySerializer()
     version_group = VersionGroupSummarySerializer()
@@ -3676,6 +3686,9 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
     names = serializers.SerializerMethodField("get_pokemon_form_pokemon_names")
     types = serializers.SerializerMethodField("get_pokemon_form_types")
     trigger_conditions = serializers.SerializerMethodField("get_pokemon_form_triggers_conditions")
+    flavor_text_entries = PokemonFormFlavorTextSerializer(
+        many=True, read_only=True, source="pokemonformflavortext"
+    )
 
     class Meta:
         model = PokemonForm
@@ -3695,6 +3708,7 @@ class PokemonFormDetailSerializer(serializers.ModelSerializer):
             "names",
             "types",
             "trigger_conditions",
+            "flavor_text_entries",
         )
 
     @extend_schema_field(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

## Summary

Adds a new `PokemonFormFlavorText` model/table, exposing `flavor_text_entries` on `/pokemon-form/{id}`. It mirrors the existing species-level `pokemon_species_flavor_text`, so forms that had their own Pokédex entries can carry them explicitly.

## Scope

Populated for **Generation III only**, the earliest generation with form-specific Pokédex entries:

- **Gen I–II**: no form-specific entries.
- **Gen III**: **Deoxys** is the only case. Its forme was fixed per game version, so each version's entry is really a forme's entry:
  - Ruby / Sapphire → **Normal Forme**
  - FireRed → **Attack Forme**
  - LeafGreen → **Defense Forme**
  - Emerald → **Speed Forme**

Later generations have more form-specific entries and are intentionally left for follow-up PRs, which keeps this one small and easy to review.

Text is copied verbatim (including line breaks and page-break characters) from the matching `pokemon_species_flavor_text` rows, re-keyed to the correct `pokemon_form_id`. English is the only language present for these entries.

## Changes

- New `PokemonFormFlavorText` model + migration.
- Serializer: `flavor_text_entries` on the pokemon-form detail endpoint.
- `build.py` loader + `pokemon_form_flavor_text.csv` (5 rows).
- OpenAPI / Hasura metadata updated.

## Open question for reviewers

These 5 Gen III Deoxys entries currently **also** live in `pokemon_species_flavor_text` (versions 7–11), where they read as generic species entries even though they're really forme-specific.

I've **kept** them in place, because:
- They match what each Gen III game actually shows (the forme was version-locked, so the per-version species entry is accurate for that game).
- `/pokemon-species/deoxys` is the common path consumers read; removing them would leave the species with no Gen III flavor text, which is a backwards-incompatible change.

That said, one could argue they're now redundant and better represented here, so they could be dropped from the species table. I'm happy to do that (here or in a follow-up) if maintainers prefer. I'm flagging it so you can decide.

## AI coding assistance disclosure

Checking everything I did is fine.

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
