### PR TITLE
Quick Fix: Encounter methods out of order

### DIFF
--- a/Resources/scripts/data/shift_ids.py
+++ b/Resources/scripts/data/shift_ids.py
@@ -5,14 +5,14 @@
 #  Helpful script to deal with any merge conflicts for certain endpoints.
 #  Currently includes endpoints relevant to encounter PRs
 
-import os
-import csv
 import argparse
+import csv
+import os
 
-CSVDIR = os.path.join(os.path.dirname(__file__), "../../../data/v2/csv")
+CSVDIR = os.path.join(os.path.dirname(__file__), "../data/v2/csv")
 
 
-def write_shifted_entries(filename: str, key: str, args):
+def write_shifted_entries(filename: str, args, *keys):
     if not filename.endswith(".csv"):
         filename += ".csv"
 
@@ -25,8 +25,9 @@ def write_shifted_entries(filename: str, key: str, args):
     # Shift IDs
     result = []
     for entry in entries:
-        if int(entry[key]) >= args.start_id:
-            entry[key] = str(int(entry[key]) + args.shift)
+        for key in keys:
+            if int(entry[key]) >= args.start_id:
+                entry[key] = str(int(entry[key]) + args.shift)
         result.append(entry)
 
     # Write CSV
@@ -40,47 +41,47 @@ def write_shifted_entries(filename: str, key: str, args):
 
 
 def shift_encs(args):
-    write_shifted_entries("encounters", "id", args)
-    write_shifted_entries("encounter_condition_value_map", "encounter_id", args)
+    write_shifted_entries("encounters", args, "id")
+    write_shifted_entries("encounter_condition_value_map", args, "encounter_id")
 
 
 def shift_methods(args):
-    write_shifted_entries("encounter_methods", "id", args)
-    write_shifted_entries("encounter_method_prose", "encounter_method_id", args)
-    write_shifted_entries("encounter_slots", "encounter_method_id", args)
-    write_shifted_entries("location_area_encounter_rates", "encounter_method_id", args)
+    write_shifted_entries("encounter_methods", args, "id", "order")
+    write_shifted_entries("encounter_method_prose", args, "encounter_method_id")
+    write_shifted_entries("encounter_slots", args, "encounter_method_id")
+    write_shifted_entries("location_area_encounter_rates", args, "encounter_method_id")
 
 
 def shift_slots(args):
-    write_shifted_entries("encounter_slots", "id", args)
-    write_shifted_entries("encounters", "encounter_slot_id", args)
+    write_shifted_entries("encounter_slots", args, "id")
+    write_shifted_entries("encounters", args, "encounter_slot_id")
 
 
 def shift_conds(args):
-    write_shifted_entries("encounter_conditions", "id", args)
-    write_shifted_entries("encounter_condition_prose", "encounter_condition_id", args)
-    write_shifted_entries("encounter_condition_values", "encounter_condition_id", args)
+    write_shifted_entries("encounter_conditions", args, "id")
+    write_shifted_entries("encounter_condition_prose", args, "encounter_condition_id")
+    write_shifted_entries("encounter_condition_values", args, "encounter_condition_id")
 
 
 def shift_cond_vals(args):
-    write_shifted_entries("encounter_condition_values", "id", args)
-    write_shifted_entries("encounter_condition_value_prose", "encounter_condition_value_id", args)
-    write_shifted_entries("encounter_condition_value_map", "encounter_condition_value_id", args)
+    write_shifted_entries("encounter_condition_values", args, "id")
+    write_shifted_entries("encounter_condition_value_prose", args, "encounter_condition_value_id")
+    write_shifted_entries("encounter_condition_value_map", args, "encounter_condition_value_id")
 
 
 def shift_locs(args):
-    write_shifted_entries("locations", "id", args)
-    write_shifted_entries("location_names", "location_id", args)
-    write_shifted_entries("location_areas", "location_id", args)
-    write_shifted_entries("location_game_indices", "location_id", args)
-    write_shifted_entries("pokemon_evolution", "location_id", args)
+    write_shifted_entries("locations", args, "id")
+    write_shifted_entries("location_names", args, "location_id")
+    write_shifted_entries("location_areas", args, "location_id")
+    write_shifted_entries("location_game_indices", args, "location_id")
+    write_shifted_entries("pokemon_evolution", args, "location_id")
 
 
 def shift_areas(args):
-    write_shifted_entries("location_areas", "id", args)
-    write_shifted_entries("location_area_prose", "location_area_id", args)
-    write_shifted_entries("encounters", "location_area_id", args)
-    write_shifted_entries("location_area_encounter_rates", "location_area_id", args)
+    write_shifted_entries("location_areas", args, "id")
+    write_shifted_entries("location_area_prose", args, "location_area_id")
+    write_shifted_entries("encounters", args, "location_area_id")
+    write_shifted_entries("location_area_encounter_rates", args, "location_area_id")
 
 
 ENDPOINT_FUNC_MAP = {

--- a/data/v2/csv/encounter_methods.csv
+++ b/data/v2/csv/encounter_methods.csv
@@ -60,8 +60,8 @@ id,identifier,order
 59,chase-water,59
 60,dynamax-adventure,60
 61,max-raid,61
-62,trash-can-ambush,57
-63,rustling-bush-ambush,58
-64,ceiling-ambush,59
-65,ground-ambush,60
-66,sky-ambush,61
+62,trash-can-ambush,62
+63,rustling-bush-ambush,63
+64,ceiling-ambush,64
+65,ground-ambush,65
+66,sky-ambush,66


### PR DESCRIPTION
# Change description

This is a small PR to address the `order` field for encounter methods being different from their IDs. This was simply a result of me not addressing that appropriately in my `Resources/scripts/data/shift_ids.py` helper script, so I've fixed the fields and updated the helper script.

## AI coding assistance disclosure

No AI was used.

## Contributor check list

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
