### PR TITLE
fix: complete Wishiwashi's Schooling form condition

### DIFF
--- a/data/v2/csv/pokemon_form_conditions.csv
+++ b/data/v2/csv/pokemon_form_conditions.csv
@@ -3,6 +3,7 @@ pokemon_form_id,form_trigger_id,trigger_item_id,trigger_ability_id,trigger_move_
 681,4,,176,,
 718,1,884,,,
 741,2,889,,,
+746,4,,208,,10229
 1017,1,2102,,,
 10028,4,,59,,
 10029,4,,59,,
@@ -97,7 +98,7 @@ pokemon_form_id,form_trigger_id,trigger_item_id,trigger_ability_id,trigger_move_
 10225,2,890,,,
 10226,2,891,,,
 10227,2,892,,,
-10229,4,,208,,
+10229,4,,208,,746
 10232,1,902,,,
 10233,1,903,,,
 10234,1,904,,,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

Wishiwashi's School form declared the Schooling ability trigger but the Solo form did not, and the two weren't linked. This PR adds the trigger to the Solo form and set `base_form` on both so the transformation is described bidirectionally (like Minior's Shields Down).

## AI coding assistance disclosure

Checking numbers and commit message.

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
