### PR TITLE
Fix translations

### DIFF
--- a/data/v2/csv/item_names.csv
+++ b/data/v2/csv/item_names.csv
@@ -17485,5608 +17485,5608 @@ item_id,local_language_id,name
 1658,12,牵绊缰绳
 1658,14,Riendas Unión
 1659,1,だいこんごうだま
+1659,3,큰금강옥
 1659,4,大金剛寶玉
 1659,5,Globe Adamant
-1659,9,Adamant Crystal
-1659,11,だいこんごうだま
-1659,3,큰금강옥
 1659,6,Adamantkristall
 1659,7,Gran Diamansfera
 1659,8,Adamasferoide
+1659,9,Adamant Crystal
+1659,11,だいこんごうだま
 1659,12,大金刚宝玉
 1660,1,だいしらたま
+1660,3,큰백옥
 1660,4,大白寶玉
 1660,5,Globe Perlé
-1660,9,Lustrous Globe
-1660,11,だいしらたま
-1660,3,큰백옥
 1660,6,Weißkristall
 1660,7,Gran Lustresfera
 1660,8,Splendisferoide
+1660,9,Lustrous Globe
+1660,11,だいしらたま
 1660,12,大白宝玉
 1661,1,だいはっきんだま
+1661,3,큰백금옥
 1661,4,大白金寶玉
 1661,5,Globe Platiné
-1661,9,Griseous Core
-1661,11,だいはっきんだま
-1661,3,큰백금옥
 1661,6,Platinumkristall
 1661,7,Gran Griseosfera
 1661,8,Grigiosferoide
+1661,9,Griseous Core
+1661,11,だいはっきんだま
 1661,12,大白金宝玉
 1662,1,まっさらプレート
+1662,3,순백플레이트
 1662,4,淨空石板
 1662,5,Plaque Renouveau
-1662,9,Blank Plate
-1662,11,まっさらプレート
-1662,3,순백플레이트
 1662,6,Neutraltafel
 1662,7,Tabla Neutra
 1662,8,Lastraripristino
+1662,9,Blank Plate
+1662,11,まっさらプレート
 1662,12,净空石板
 1663,1,ストレンジボール
+1663,3,스트레인지볼
 1663,4,奇異球
 1663,5,Étrange Ball
-1663,9,Strange Ball
-1663,11,ストレンジボール
-1663,3,스트레인지볼
 1663,6,Rätselball
 1663,7,Extraña Ball
 1663,8,Strange Ball
+1663,9,Strange Ball
+1663,11,ストレンジボール
 1663,12,奇异球
 1664,1,レジェンドプレート
+1664,3,레전드플레이트
 1664,4,傳說石板
 1664,5,Plaque Légende
-1664,9,Legend Plate
-1664,11,レジェンドプレート
-1664,3,레전드플레이트
 1664,6,Legendentafel
 1664,7,Tabla Legendaria
 1664,8,Lastraleggenda
+1664,9,Legend Plate
+1664,11,レジェンドプレート
 1664,12,传说石板
 1665,1,スマホロトム
+1665,3,스마트로토무
 1665,4,手機洛托姆
 1665,5,Motismart
-1665,9,Rotom Phone
-1665,11,スマホロトム
-1665,3,스마트로토무
 1665,6,Smart-Rotom
 1665,7,SmartRotom
 1665,8,Smart Rotom
+1665,9,Rotom Phone
+1665,11,スマホロトム
 1665,12,手机洛托姆
 1666,1,サンドウィッチ
+1666,3,샌드위치
 1666,4,三明治
 1666,5,Sandwich
-1666,9,Sandwich
-1666,11,サンドウィッチ
-1666,3,샌드위치
 1666,6,Sandwich
 1666,7,Bocadillo
 1666,8,Panino
+1666,9,Sandwich
+1666,11,サンドウィッチ
 1666,12,三明治
 1667,1,コライドンのボール
+1667,3,코라이돈의 볼
 1667,4,故勒頓的球
 1667,5,Poké Ball de Koraidon
-1667,9,Koraidon’s Poké Ball
-1667,11,コライドンのボール
-1667,3,코라이돈의 볼
 1667,6,Koraidons Pokéball
 1667,7,Poké Ball de Koraidon
 1667,8,Poké Ball Koraidon
+1667,9,Koraidon’s Poké Ball
+1667,11,コライドンのボール
 1667,12,故勒顿的球
 1668,1,ミライドンのボール
+1668,3,미라이돈의 볼
 1668,4,密勒頓的球
 1668,5,Poké Ball de Miraidon
-1668,9,Miraidon’s Poké Ball
-1668,11,ミライドンのボール
-1668,3,미라이돈의 볼
 1668,6,Miraidons Pokéball
 1668,7,Poké Ball de Miraidon
 1668,8,Poké Ball Miraidon
+1668,9,Miraidon’s Poké Ball
+1668,11,ミライドンのボール
 1668,12,密勒顿的球
 1669,1,テラスタルオーブ
+1669,3,테라스탈오브
 1669,4,太晶珠
 1669,5,Orbe Téracristal
-1669,9,Tera Orb
-1669,11,テラスタルオーブ
-1669,3,테라스탈오브
 1669,6,Terakristall-Orb
 1669,7,Orbe Teracristal
 1669,8,Terasfera
+1669,9,Tera Orb
+1669,11,テラスタルオーブ
 1669,12,太晶珠
 1670,1,スカーレットブック
+1670,3,스칼렛북
 1670,4,朱之書
 1670,5,Livre Écarlate
-1670,9,Scarlet Book
-1670,11,スカーレットブック
-1670,3,스칼렛북
 1670,6,Karmesinbuch
 1670,7,Libro Escarlata
 1670,8,Libro scarlatto
+1670,9,Scarlet Book
+1670,11,スカーレットブック
 1670,12,朱之书
 1671,1,バイオレットブック
+1671,3,바이올렛북
 1671,4,紫之書
 1671,5,Livre Violet
-1671,9,Violet Book
-1671,11,バイオレットブック
-1671,3,바이올렛북
 1671,6,Purpurbuch
 1671,7,Libro Púrpura
 1671,8,Libro violetto
+1671,9,Violet Book
+1671,11,バイオレットブック
 1671,12,紫之书
 1672,1,ハイダイのサイフ
+1672,3,곤포의 지갑
 1672,4,海岱的錢包
 1672,5,Portefeuille de Kombu
-1672,9,Kofu’s Wallet
-1672,11,ハイダイのサイフ
-1672,3,곤포의 지갑
 1672,6,Kombus Geldbörse
 1672,7,Cartera de Fuco
 1672,8,Portafogli di Algaro
+1672,9,Kofu’s Wallet
+1672,11,ハイダイのサイフ
 1672,12,海岱的钱包
 1673,1,ちいさなタケノコ
+1673,3,작은죽순
 1673,4,小竹筍
 1673,5,Petit Bambou
-1673,9,Tiny Bamboo Shoot
-1673,11,ちいさなタケノコ
-1673,3,작은죽순
 1673,6,Minibambusspross
 1673,7,Bambú Pequeño
 1673,8,Minibambù
+1673,9,Tiny Bamboo Shoot
+1673,11,ちいさなタケノコ
 1673,12,小竹笋
 1674,1,おおきなタケノコ
+1674,3,큰죽순
 1674,4,大竹筍
 1674,5,Gros Bambou
-1674,9,Big Bamboo Shoot
-1674,11,おおきなタケノコ
-1674,3,큰죽순
 1674,6,Riesenbambusspross
 1674,7,Bambú Grande
 1674,8,Grande bambù
+1674,9,Big Bamboo Shoot
+1674,11,おおきなタケノコ
 1674,12,大竹笋
 1675,1,あくのかけじく
+1675,3,악의 족자
 1675,4,惡之掛軸
 1675,5,Rouleau des Ténèbres
-1675,9,Scroll of Darkness
-1675,11,あくのかけじく
-1675,3,악의 족자
 1675,6,Unlicht-Schriftrolle
 1675,7,Manuscrito Sombras
 1675,8,Rotolo del Buio
+1675,9,Scroll of Darkness
+1675,11,あくのかけじく
 1675,12,恶之挂轴
 1676,1,みずのかけじく
+1676,3,물의 족자
 1676,4,水之掛軸
 1676,5,Rouleau de l'Eau
-1676,9,Scroll of Waters
-1676,11,みずのかけじく
-1676,3,물의 족자
 1676,6,Wasser-Schriftrolle
 1676,7,Manuscrito Aguas
 1676,8,Rotolo dell’Acqua
+1676,9,Scroll of Waters
+1676,11,みずのかけじく
 1676,12,水之挂轴
 1677,1,ノロイノヨロイ
+1677,3,저주받은갑옷
 1677,4,詛咒之鎧
 1677,5,Armure de la Rancune
-1677,9,Malicious Armor
-1677,11,ノロイノヨロイ
-1677,3,저주받은갑옷
 1677,6,Fluchrüstung
 1677,7,Armadura Maldita
 1677,8,Armatura infausta
+1677,9,Malicious Armor
+1677,11,ノロイノヨロイ
 1677,12,咒术之铠
 1678,1,テラピースノーマル
+1678,3,테라피스 노말
 1678,4,一般太晶碎塊
 1678,5,Téra-Éclat Normal
-1678,9,Normal Tera Shard
-1678,11,テラピースノーマル
-1678,3,테라피스 노말
 1678,6,Tera-Stück (Normal)
 1678,7,Teralito Normal
 1678,8,Teralite Normale
+1678,9,Normal Tera Shard
+1678,11,テラピースノーマル
 1678,12,一般太晶碎块
 1679,1,テラピースほのお
+1679,3,테라피스 불꽃
 1679,4,火太晶碎塊
 1679,5,Téra-Éclat Feu
-1679,9,Fire Tera Shard
-1679,11,テラピースほのお
-1679,3,테라피스 불꽃
 1679,6,Tera-Stück (Feuer)
 1679,7,Teralito Fuego
 1679,8,Teralite Fuoco
+1679,9,Fire Tera Shard
+1679,11,テラピースほのお
 1679,12,火太晶碎块
 1680,1,テラピースみず
+1680,3,테라피스 물
 1680,4,水太晶碎塊
 1680,5,Téra-Éclat Eau
-1680,9,Water Tera Shard
-1680,11,テラピースみず
-1680,3,테라피스 물
 1680,6,Tera-Stück (Wasser)
 1680,7,Teralito Agua
 1680,8,Teralite Acqua
+1680,9,Water Tera Shard
+1680,11,テラピースみず
 1680,12,水太晶碎块
 1681,1,テラピースでんき
+1681,3,테라피스 전기
 1681,4,電太晶碎塊
 1681,5,Téra-Éclat Électrik
-1681,9,Electric Tera Shard
-1681,11,テラピースでんき
-1681,3,테라피스 전기
 1681,6,Tera-Stück (Elektro)
 1681,7,Teralito Eléctrico
 1681,8,Teralite Elettro
+1681,9,Electric Tera Shard
+1681,11,テラピースでんき
 1681,12,电太晶碎块
 1682,1,テラピースくさ
+1682,3,테라피스 풀
 1682,4,草太晶碎塊
 1682,5,Téra-Éclat Plante
-1682,9,Grass Tera Shard
-1682,11,テラピースくさ
-1682,3,테라피스 풀
 1682,6,Tera-Stück (Pflanze)
 1682,7,Teralito Planta
 1682,8,Teralite Erba
+1682,9,Grass Tera Shard
+1682,11,テラピースくさ
 1682,12,草太晶碎块
 1683,1,テラピースこおり
+1683,3,테라피스 얼음
 1683,4,冰太晶碎塊
 1683,5,Téra-Éclat Glace
-1683,9,Ice Tera Shard
-1683,11,テラピースこおり
-1683,3,테라피스 얼음
 1683,6,Tera-Stück (Eis)
 1683,7,Teralito Hielo
 1683,8,Teralite Ghiaccio
+1683,9,Ice Tera Shard
+1683,11,テラピースこおり
 1683,12,冰太晶碎块
 1684,1,テラピースかくとう
+1684,3,테라피스 격투
 1684,4,格鬥太晶碎塊
 1684,5,Téra-Éclat Combat
-1684,9,Fighting Tera Shard
-1684,11,テラピースかくとう
-1684,3,테라피스 격투
 1684,6,Tera-Stück (Kampf)
 1684,7,Teralito Lucha
 1684,8,Teralite Lotta
+1684,9,Fighting Tera Shard
+1684,11,テラピースかくとう
 1684,12,格斗太晶碎块
 1685,1,テラピースどく
+1685,3,테라피스 독
 1685,4,毒太晶碎塊
 1685,5,Téra-Éclat Poison
-1685,9,Poison Tera Shard
-1685,11,テラピースどく
-1685,3,테라피스 독
 1685,6,Tera-Stück (Gift)
 1685,7,Teralito Veneno
 1685,8,Teralite Veleno
+1685,9,Poison Tera Shard
+1685,11,テラピースどく
 1685,12,毒太晶碎块
 1686,1,テラピースじめん
+1686,3,테라피스 땅
 1686,4,地面太晶碎塊
 1686,5,Téra-Éclat Sol
-1686,9,Ground Tera Shard
-1686,11,テラピースじめん
-1686,3,테라피스 땅
 1686,6,Tera-Stück (Boden)
 1686,7,Teralito Tierra
 1686,8,Teralite Terra
+1686,9,Ground Tera Shard
+1686,11,テラピースじめん
 1686,12,地面太晶碎块
 1687,1,テラピースひこう
+1687,3,테라피스 비행
 1687,4,飛行太晶碎塊
 1687,5,Téra-Éclat Vol
-1687,9,Flying Tera Shard
-1687,11,テラピースひこう
-1687,3,테라피스 비행
 1687,6,Tera-Stück (Flug)
 1687,7,Teralito Volador
 1687,8,Teralite Volante
+1687,9,Flying Tera Shard
+1687,11,テラピースひこう
 1687,12,飞行太晶碎块
 1688,1,テラピースエスパー
+1688,3,테라피스 에스퍼
 1688,4,超能力太晶碎塊
 1688,5,Téra-Éclat Psy
-1688,9,Psychic Tera Shard
-1688,11,テラピースエスパー
-1688,3,테라피스 에스퍼
 1688,6,Tera-Stück (Psycho)
 1688,7,Teralito Psíquico
 1688,8,Teralite Psico
+1688,9,Psychic Tera Shard
+1688,11,テラピースエスパー
 1688,12,超能力太晶碎块
 1689,1,テラピースむし
+1689,3,테라피스 벌레
 1689,4,蟲太晶碎塊
 1689,5,Téra-Éclat Insecte
-1689,9,Bug Tera Shard
-1689,11,テラピースむし
-1689,3,테라피스 벌레
 1689,6,Tera-Stück (Käfer)
 1689,7,Teralito Bicho
 1689,8,Teralite Coleottero
+1689,9,Bug Tera Shard
+1689,11,テラピースむし
 1689,12,虫太晶碎块
 1690,1,テラピースいわ
+1690,3,테라피스 바위
 1690,4,岩石太晶碎塊
 1690,5,Téra-Éclat Roche
-1690,9,Rock Tera Shard
-1690,11,テラピースいわ
-1690,3,테라피스 바위
 1690,6,Tera-Stück (Gestein)
 1690,7,Teralito Roca
 1690,8,Teralite Roccia
+1690,9,Rock Tera Shard
+1690,11,テラピースいわ
 1690,12,岩石太晶碎块
 1691,1,テラピースゴースト
+1691,3,테라피스 고스트
 1691,4,幽靈太晶碎塊
 1691,5,Téra-Éclat Spectre
-1691,9,Ghost Tera Shard
-1691,11,テラピースゴースト
-1691,3,테라피스 고스트
 1691,6,Tera-Stück (Geist)
 1691,7,Teralito Fantasma
 1691,8,Teralite Spettro
+1691,9,Ghost Tera Shard
+1691,11,テラピースゴースト
 1691,12,幽灵太晶碎块
 1692,1,テラピースドラゴン
+1692,3,테라피스 드래곤
 1692,4,龍太晶碎塊
 1692,5,Téra-Éclat Dragon
-1692,9,Dragon Tera Shard
-1692,11,テラピースドラゴン
-1692,3,테라피스 드래곤
 1692,6,Tera-Stück (Drache)
 1692,7,Teralito Dragón
 1692,8,Teralite Drago
+1692,9,Dragon Tera Shard
+1692,11,テラピースドラゴン
 1692,12,龙太晶碎块
 1693,1,テラピースあく
+1693,3,테라피스 악
 1693,4,惡太晶碎塊
 1693,5,Téra-Éclat Ténèbres
-1693,9,Dark Tera Shard
-1693,11,テラピースあく
-1693,3,테라피스 악
 1693,6,Tera-Stück (Unlicht)
 1693,7,Teralito Siniestro
 1693,8,Teralite Buio
+1693,9,Dark Tera Shard
+1693,11,テラピースあく
 1693,12,恶太晶碎块
 1694,1,テラピースはがね
+1694,3,테라피스 강철
 1694,4,鋼太晶碎塊
 1694,5,Téra-Éclat Acier
-1694,9,Steel Tera Shard
-1694,11,テラピースはがね
-1694,3,테라피스 강철
 1694,6,Tera-Stück (Stahl)
 1694,7,Teralito Acero
 1694,8,Teralite Acciaio
+1694,9,Steel Tera Shard
+1694,11,テラピースはがね
 1694,12,钢太晶碎块
 1695,1,テラピースフェアリー
+1695,3,테라피스 페어리
 1695,4,妖精太晶碎塊
 1695,5,Téra-Éclat Fée
-1695,9,Fairy Tera Shard
-1695,11,テラピースフェアリー
-1695,3,테라피스 페어리
 1695,6,Tera-Stück (Fee)
 1695,7,Teralito Hada
 1695,8,Teralite Folletto
+1695,9,Fairy Tera Shard
+1695,11,テラピースフェアリー
 1695,12,妖精太晶碎块
 1696,1,ブーストエナジー
+1696,3,부스트에너지
 1696,4,驅勁能量
 1696,5,Énergie Booster
-1696,9,Booster Energy
-1696,11,ブーストエナジー
-1696,3,부스트에너지
 1696,6,Energiekapsel
 1696,7,Energía Potenciadora
 1696,8,Capsula energetica
+1696,9,Booster Energy
+1696,11,ブーストエナジー
 1696,12,驱劲能量
 1697,1,とくせいガード
+1697,3,특성가드
 1697,4,特性護具
 1697,5,Garde-Talent
-1697,9,Ability Shield
-1697,11,とくせいガード
-1697,3,특성가드
 1697,6,Fähigkeitenschild
 1697,7,Escudo Habilidad
 1697,8,Scudo abilità
+1697,9,Ability Shield
+1697,11,とくせいガード
 1697,12,特性护具
 1698,1,クリアチャーム
+1698,3,클리어참
 1698,4,清淨墜飾
 1698,5,Talisman Sain
-1698,9,Clear Amulet
-1698,11,クリアチャーム
-1698,3,클리어참
 1698,6,Neutralschmuck
 1698,7,Amuleto Puro
 1698,8,Ciondolochiaro
+1698,9,Clear Amulet
+1698,11,クリアチャーム
 1698,12,清净坠饰
 1699,1,ものまねハーブ
+1699,3,흉내허브
 1699,4,模仿香草
 1699,5,Feuille Copieuse
-1699,9,Mirror Herb
-1699,11,ものまねハーブ
-1699,3,흉내허브
 1699,6,Kopierkraut
 1699,7,Hierba Copia
 1699,8,Foglia carbone
+1699,9,Mirror Herb
+1699,11,ものまねハーブ
 1699,12,模仿香草
 1700,1,パンチグローブ
+1700,3,펀치글러브
 1700,4,拳擊手套
 1700,5,Gant de Boxe
-1700,9,Punching Glove
-1700,11,パンチグローブ
-1700,3,펀치글러브
 1700,6,Boxhandschuh
 1700,7,Guante de Boxeo
 1700,8,Guantone
+1700,9,Punching Glove
+1700,11,パンチグローブ
 1700,12,拳击手套
 1701,1,おんみつマント
+1701,3,은밀망토
 1701,4,密探斗篷
 1701,5,Cape Obscure
-1701,9,Covert Cloak
-1701,11,おんみつマント
-1701,3,은밀망토
 1701,6,Tarnumhang
 1701,7,Capa Furtiva
 1701,8,Anonimanto
+1701,9,Covert Cloak
+1701,11,おんみつマント
 1701,12,密探斗篷
 1702,1,いかさまダイス
+1702,3,속임수주사위
 1702,4,老千骰子
 1702,5,Dé Pipé
-1702,9,Loaded Dice
-1702,11,いかさまダイス
-1702,3,속임수주사위
 1702,6,Gezinkter Würfel
 1702,7,Dado Trucado
 1702,8,Dado truccato
+1702,9,Loaded Dice
+1702,11,いかさまダイス
 1702,12,机变骰子
 1703,1,バケット
+1703,3,바게트
 1703,4,長棍麵包
 1703,5,Baguette
-1703,9,Baguette
-1703,11,バケット
-1703,3,바게트
 1703,6,Baguette
 1703,7,Barra de Pan
 1703,8,Filoncino
+1703,9,Baguette
+1703,11,バケット
 1703,12,长棍面包
 1704,1,マヨネーズ
+1704,3,마요네즈
 1704,4,美乃滋
 1704,5,Mayonnaise
-1704,9,Mayonnaise
-1704,11,マヨネーズ
-1704,3,마요네즈
 1704,6,Mayonnaise
 1704,7,Mayonesa
 1704,8,Maionese
+1704,9,Mayonnaise
+1704,11,マヨネーズ
 1704,12,蛋黄酱
 1705,1,ケチャップ
+1705,3,케첩
 1705,4,番茄醬
 1705,5,Ketchup
-1705,9,Ketchup
-1705,11,ケチャップ
-1705,3,케첩
 1705,6,Ketchup
 1705,7,Kétchup
 1705,8,Ketchup
+1705,9,Ketchup
+1705,11,ケチャップ
 1705,12,番茄酱
 1706,1,マスタード
+1706,3,머스터드
 1706,4,黃芥末醬
 1706,5,Moutarde
-1706,9,Mustard
-1706,11,マスタード
-1706,3,머스터드
 1706,6,Senf
 1706,7,Mostaza
 1706,8,Senape
+1706,9,Mustard
+1706,11,マスタード
 1706,12,黄芥末酱
 1707,1,バター
+1707,3,버터
 1707,4,奶油
 1707,5,Beurre
-1707,9,Butter
-1707,11,バター
-1707,3,버터
 1707,6,Butter
 1707,7,Mantequilla
 1707,8,Burro
+1707,9,Butter
+1707,11,バター
 1707,12,黄油
 1708,1,ピーナッツバター
+1708,3,땅콩버터
 1708,4,花生醬
 1708,5,Beurre de Cacahuètes
-1708,9,Peanut Butter
-1708,11,ピーナッツバター
-1708,3,땅콩버터
 1708,6,Erdnussbutter
 1708,7,Crema de Cacahuete
 1708,8,Burro di arachidi
+1708,9,Peanut Butter
+1708,11,ピーナッツバター
 1708,12,花生酱
 1709,1,チリソース
+1709,3,칠리소스
 1709,4,辣醬
 1709,5,Sauce Piquante
-1709,9,Chili Sauce
-1709,11,チリソース
-1709,3,칠리소스
 1709,6,Chilisoße
 1709,7,Salsa Picante
 1709,8,Salsa piccante
+1709,9,Chili Sauce
+1709,11,チリソース
 1709,12,辣酱
 1710,1,ソルト
+1710,3,소금
 1710,4,鹽
 1710,5,Sel
-1710,9,Salt
-1710,11,ソルト
-1710,3,소금
 1710,6,Salz
 1710,7,Sal
 1710,8,Sale
+1710,9,Salt
+1710,11,ソルト
 1710,12,盐
 1711,1,ペッパー
+1711,3,후추
 1711,4,胡椒
 1711,5,Poivre
-1711,9,Pepper
-1711,11,ペッパー
-1711,3,후추
 1711,6,Pfeffer
 1711,7,Pimienta
 1711,8,Pepe
+1711,9,Pepper
+1711,11,ペッパー
 1711,12,胡椒
 1712,1,ヨーグルト
+1712,3,요구르트
 1712,4,優格
 1712,5,Yaourt
-1712,9,Yogurt
-1712,11,ヨーグルト
-1712,3,요구르트
 1712,6,Joghurt
 1712,7,Yogur
 1712,8,Yogurt
+1712,9,Yogurt
+1712,11,ヨーグルト
 1712,12,酸奶
 1713,1,ホイップクリーム
+1713,3,휘핑크림
 1713,4,鮮奶油
 1713,5,Creme Fouettée
-1713,9,Whipped Cream
-1713,11,ホイップクリーム
-1713,3,휘핑크림
 1713,6,Schlagsahne
 1713,7,Nata Montada
 1713,8,Panna montata
+1713,9,Whipped Cream
+1713,11,ホイップクリーム
 1713,12,鲜奶油
 1714,1,クリームチーズ
+1714,3,크림치즈
 1714,4,奶油起司
 1714,5,Fromage Frais
-1714,9,Cream Cheese
-1714,11,クリームチーズ
-1714,3,크림치즈
 1714,6,Frischkäse
 1714,7,Queso Crema
 1714,8,Formaggio cremoso
+1714,9,Cream Cheese
+1714,11,クリームチーズ
 1714,12,奶油芝士
 1715,1,ベリージャム
+1715,3,베리잼
 1715,4,莓果醬
 1715,5,Confiture de Baies
-1715,9,Jam
-1715,11,ベリージャム
-1715,3,베리잼
 1715,6,Beerenkonfitüre
 1715,7,Confitura de Bayas
 1715,8,Confettura di bosco
+1715,9,Jam
+1715,11,ベリージャム
 1715,12,莓果酱
 1716,1,マーマレード
+1716,3,마멀레이드
 1716,4,橘子醬
 1716,5,Marmelade
-1716,9,Marmalade
-1716,11,マーマレード
-1716,3,마멀레이드
 1716,6,Marmelade
 1716,7,Mermelada
 1716,8,Marmellata
+1716,9,Marmalade
+1716,11,マーマレード
 1716,12,橘子酱
 1717,1,オリーブオイル
+1717,3,올리브오일
 1717,4,橄欖油
 1717,5,Huile d'Olive
-1717,9,Olive Oil
-1717,11,オリーブオイル
-1717,3,올리브오일
 1717,6,Olivenöl
 1717,7,Aceite de Oliva
 1717,8,Olio d’oliva
+1717,9,Olive Oil
+1717,11,オリーブオイル
 1717,12,橄榄油
 1718,1,ビネガー
+1718,3,비니거
 1718,4,醋
 1718,5,Vinaigre
-1718,9,Vinegar
-1718,11,ビネガー
-1718,3,비니거
 1718,6,Essig
 1718,7,Vinagre
 1718,8,Aceto
+1718,9,Vinegar
+1718,11,ビネガー
 1718,12,醋
 1719,1,ひでん：あまスパイス
+1719,3,비전 달콤스파이스
 1719,4,秘傳：甜味料
 1719,5,Épice Secrète Sucrée
-1719,9,Sweet Herba Mystica
-1719,11,ひでん：あまスパイス
-1719,3,비전 달콤스파이스
 1719,6,Süßes Geheimgewürz
 1719,7,Especia Oculta Dulce
 1719,8,Spezia nascosta dolce
+1719,9,Sweet Herba Mystica
+1719,11,ひでん：あまスパイス
 1719,12,秘传：甜味料
 1720,1,ひでん：しおスパイス
+1720,3,비전 짭짤스파이스
 1720,4,秘傳：鹹味料
 1720,5,Épice Secrète Salée
-1720,9,Salty Herba Mystica
-1720,11,ひでん：しおスパイス
-1720,3,비전 짭짤스파이스
 1720,6,Salziges Geheimgewürz
 1720,7,Especia Oculta Salada
 1720,8,Spezia nascosta salata
+1720,9,Salty Herba Mystica
+1720,11,ひでん：しおスパイス
 1720,12,秘传：咸味料
 1721,1,ひでん：すぱスパイス
+1721,3,비전 새콤스파이스
 1721,4,秘傳：酸味料
 1721,5,Épice Secrète Acide
-1721,9,Sour Herba Mystica
-1721,11,ひでん：すぱスパイス
-1721,3,비전 새콤스파이스
 1721,6,Saures Geheimgewürz
 1721,7,Especia Oculta Ácida
 1721,8,Spezia nascosta aspra
+1721,9,Sour Herba Mystica
+1721,11,ひでん：すぱスパイス
 1721,12,秘传：酸味料
 1722,1,ひでん：にがスパイス
+1722,3,비전 쌉쌀스파이스
 1722,4,秘傳：苦味料
 1722,5,Épice Secrète Amère
-1722,9,Bitter Herba Mystica
-1722,11,ひでん：にがスパイス
-1722,3,비전 쌉쌀스파이스
 1722,6,Bitteres Geheimgewürz
 1722,7,Especia Oculta Amarga
 1722,8,Spezia nascosta amara
+1722,9,Bitter Herba Mystica
+1722,11,ひでん：にがスパイス
 1722,12,秘传：苦味料
 1723,1,ひでん：からスパイス
+1723,3,비전 매콤스파이스
 1723,4,秘傳：辣味料
 1723,5,Épice Secrète Corsée
-1723,9,Spicy Herba Mystica
-1723,11,ひでん：からスパイス
-1723,3,비전 매콤스파이스
 1723,6,Scharfes Geheimgewürz
 1723,7,Especia Oculta Picante
 1723,8,Spezia nascosta pepata
+1723,9,Spicy Herba Mystica
+1723,11,ひでん：からスパイス
 1723,12,秘传：辣味料
 1724,1,レタス
+1724,3,양상추
 1724,4,生菜
 1724,5,Laitue
-1724,9,Lettuce
-1724,11,レタス
-1724,3,양상추
 1724,6,Salat
 1724,7,Lechuga
 1724,8,Lattuga
+1724,9,Lettuce
+1724,11,レタス
 1724,12,生菜
 1725,1,トマトスライス
+1725,3,토마토슬라이스
 1725,4,番茄片
 1725,5,Tomate
-1725,9,Tomato
-1725,11,トマトスライス
-1725,3,토마토슬라이스
 1725,6,Tomate
 1725,7,Tomate
 1725,8,Pomodoro
+1725,9,Tomato
+1725,11,トマトスライス
 1725,12,番茄片
 1726,1,カットミニトマト
+1726,3,방울토마토슬라이스
 1726,4,小番茄塊
 1726,5,Tomate Cerise
-1726,9,Cherry Tomatoes
-1726,11,カットミニトマト
-1726,3,방울토마토슬라이스
 1726,6,Mini-Tomate
 1726,7,Tomate Cherri
 1726,8,Pomodorino
+1726,9,Cherry Tomatoes
+1726,11,カットミニトマト
 1726,12,小番茄块
 1727,1,キュウリスライス
+1727,3,오이슬라이스
 1727,4,小黃瓜片
 1727,5,Concombre
-1727,9,Cucumber
-1727,11,キュウリスライス
-1727,3,오이슬라이스
 1727,6,Gurke
 1727,7,Pepino
 1727,8,Cetriolo
+1727,9,Cucumber
+1727,11,キュウリスライス
 1727,12,小黄瓜片
 1728,1,ピクルススライス
+1728,3,피클슬라이스
 1728,4,酸黃瓜片
 1728,5,Cornichon
-1728,9,Pickle
-1728,11,ピクルススライス
-1728,3,피클슬라이스
 1728,6,Gewürzgurke
 1728,7,Pepinillo
 1728,8,Sottaceto
+1728,9,Pickle
+1728,11,ピクルススライス
 1728,12,酸黄瓜片
 1729,1,たまねぎスライス
+1729,3,양파슬라이스
 1729,4,洋蔥片
 1729,5,Oignon
-1729,9,Onion
-1729,11,たまねぎスライス
-1729,3,양파슬라이스
 1729,6,Zwiebel
 1729,7,Cebolla
 1729,8,Cipolla
+1729,9,Onion
+1729,11,たまねぎスライス
 1729,12,洋葱片
 1730,1,アーリーレッド
+1730,3,적양파
 1730,4,紅洋蔥
 1730,5,Oignon Rouge
-1730,9,Red Onion
-1730,11,アーリーレッド
-1730,3,적양파
 1730,6,Rote Zwiebel
 1730,7,Cebolla Roja
 1730,8,Cipolla rossa
+1730,9,Red Onion
+1730,11,アーリーレッド
 1730,12,红洋葱
 1731,1,ピーマンスライス
+1731,3,피망슬라이스
 1731,4,青椒片
 1731,5,Poivron Vert
-1731,9,Green Bell Pepper
-1731,11,ピーマンスライス
-1731,3,피망슬라이스
 1731,6,Grüne Paprika
 1731,7,Pimiento Verde
 1731,8,Peperone verde
+1731,9,Green Bell Pepper
+1731,11,ピーマンスライス
 1731,12,青椒片
 1732,1,あかパプリカスライス
+1732,3,빨간파프리카슬라이스
 1732,4,紅椒片
 1732,5,Poivron Rouge
-1732,9,Red Bell Pepper
-1732,11,あかパプリカスライス
-1732,3,빨간파프리카슬라이스
 1732,6,Rote Paprika
 1732,7,Pimiento Rojo
 1732,8,Peperone rosso
+1732,9,Red Bell Pepper
+1732,11,あかパプリカスライス
 1732,12,红椒片
 1733,1,きパプリカスライス
+1733,3,노란파프리카슬라이스
 1733,4,黃椒片
 1733,5,Poivron Jaune
-1733,9,Yellow Bell Pepper
-1733,11,きパプリカスライス
-1733,3,노란파프리카슬라이스
 1733,6,Gelbe Paprika
 1733,7,Pimiento Amarillo
 1733,8,Peperone giallo
+1733,9,Yellow Bell Pepper
+1733,11,きパプリカスライス
 1733,12,黄椒片
 1734,1,アボカド
+1734,3,아보카도
 1734,4,酪梨
 1734,5,Avocat
-1734,9,Avocado
-1734,11,アボカド
-1734,3,아보카도
 1734,6,Avocado
 1734,7,Aguacate
 1734,8,Avocado
+1734,9,Avocado
+1734,11,アボカド
 1734,12,牛油果
 1735,1,やきベーコン
+1735,3,구운베이컨
 1735,4,煎培根
 1735,5,Bacon
-1735,9,Bacon
-1735,11,やきベーコン
-1735,3,구운베이컨
 1735,6,Gebratener Speck
 1735,7,Panceta
 1735,8,Pancetta rosolata
+1735,9,Bacon
+1735,11,やきベーコン
 1735,12,煎培根
 1736,1,ハムスライス
+1736,3,슬라이스햄
 1736,4,火腿片
 1736,5,Jambon Blanc
-1736,9,Ham
-1736,11,ハムスライス
-1736,3,슬라이스햄
 1736,6,Kochschinken
 1736,7,Jamón Cocido
 1736,8,Prosciutto cotto
+1736,9,Ham
+1736,11,ハムスライス
 1736,12,火腿片
 1737,1,なまハム
+1737,3,생햄
 1737,4,生火腿
 1737,5,Jambon Cru
-1737,9,Prosciutto
-1737,11,なまハム
-1737,3,생햄
 1737,6,Roher Schinken
 1737,7,Jamón Serrano
 1737,8,Prosciutto crudo
+1737,9,Prosciutto
+1737,11,なまハム
 1737,12,生火腿
 1738,1,やきチョリソー
+1738,3,구운초리조
 1738,4,煎辣香腸
 1738,5,Chorizo Grillé
-1738,9,Chorizo
-1738,11,やきチョリソー
-1738,3,구운초리조
 1738,6,Chorizo
 1738,7,Chorizo
 1738,8,Chorizo rosolato
+1738,9,Chorizo
+1738,11,やきチョリソー
 1738,12,煎辣香肠
 1739,1,ハーブソーセージ
+1739,3,허브소시지
 1739,4,香草香腸
 1739,5,Saucisse aux Herbes
-1739,9,Herbed Sausage
-1739,11,ハーブソーセージ
-1739,3,허브소시지
 1739,6,Kräuterwurst
 1739,7,Butifarra
 1739,8,Salsiccia alle erbe
+1739,9,Herbed Sausage
+1739,11,ハーブソーセージ
 1739,12,香草香肠
 1740,1,ハンバーグ
+1740,3,햄버그
 1740,4,漢堡排
 1740,5,Steak Haché
-1740,9,Hamburger
-1740,11,ハンバーグ
-1740,3,햄버그
 1740,6,Frikadelle
 1740,7,Hamburguesa
 1740,8,Hamburger grigliato
+1740,9,Hamburger
+1740,11,ハンバーグ
 1740,12,汉堡排
 1741,1,ガケガニスティック
+1741,3,절벼게맛살
 1741,4,毛崖蟹棒
 1741,5,Bâtonnet de Craparoi
-1741,9,Klawf Stick
-1741,11,ガケガニスティック
-1741,3,절벼게맛살
 1741,6,Klibbe-Stick
 1741,7,Surimi de Klawf
 1741,8,Surimi di Klawf
+1741,9,Klawf Stick
+1741,11,ガケガニスティック
 1741,12,毛崖蟹棒
 1742,1,スモークきりみ
+1742,3,훈제토막
 1742,4,煙燻魚片
 1742,5,Filet Fumé
-1742,9,Smoked Fillet
-1742,11,スモークきりみ
-1742,3,훈제토막
 1742,6,Räucherfilet
 1742,7,Filete Ahumado
 1742,8,Filetto affumicato
+1742,9,Smoked Fillet
+1742,11,スモークきりみ
 1742,12,烟熏鱼片
 1743,1,きりみフライ
+1743,3,튀긴토막
 1743,4,炸魚片
 1743,5,Filet Frit
-1743,9,Fried Fillet
-1743,11,きりみフライ
-1743,3,튀긴토막
 1743,6,Frittierfilet
 1743,7,Filete Frito
 1743,8,Filetto impanato
+1743,9,Fried Fillet
+1743,11,きりみフライ
 1743,12,炸鱼片
 1744,1,スライスエッグ
+1744,3,에그슬라이스
 1744,4,水煮蛋片
 1744,5,Œuf
-1744,9,Egg
-1744,11,スライスエッグ
-1744,3,에그슬라이스
 1744,6,Ei
 1744,7,Huevo Cocido
 1744,8,Uovo bollito
+1744,9,Egg
+1744,11,スライスエッグ
 1744,12,水煮蛋片
 1745,1,トルティージャ
+1745,3,토르티야
 1745,4,烘蛋
 1745,5,Tortilla
-1745,9,Potato Tortilla
-1745,11,トルティージャ
-1745,3,토르티야
 1745,6,Tortilla
 1745,7,Tortilla
 1745,8,Tortilla
+1745,9,Potato Tortilla
+1745,11,トルティージャ
 1745,12,烘蛋
 1746,1,トーフ
+1746,3,두부
 1746,4,豆腐
 1746,5,Tofu
-1746,9,Tofu
-1746,11,トーフ
-1746,3,두부
 1746,6,Tofu
 1746,7,Tofu
 1746,8,Tofu
+1746,9,Tofu
+1746,11,トーフ
 1746,12,豆腐
 1747,1,ライス
+1747,3,라이스
 1747,4,米飯
 1747,5,Riz
-1747,9,Rice
-1747,11,ライス
-1747,3,라이스
 1747,6,Reis
 1747,7,Arroz
 1747,8,Riso
+1747,9,Rice
+1747,11,ライス
 1747,12,米饭
 1748,1,ヌードル
+1748,3,누들
 1748,4,麵條
 1748,5,Nouilles
-1748,9,Noodles
-1748,11,ヌードル
-1748,3,누들
 1748,6,Nudeln
 1748,7,Fideos
 1748,8,Noodle
+1748,9,Noodles
+1748,11,ヌードル
 1748,12,面条
 1749,1,ポテトサラダ
+1749,3,감자샐러드
 1749,4,馬鈴薯沙拉
 1749,5,Salade de Patates
-1749,9,Potato Salad
-1749,11,ポテトサラダ
-1749,3,감자샐러드
 1749,6,Kartoffelsalat
 1749,7,Ensaladilla
 1749,8,Insalata di patate
+1749,9,Potato Salad
+1749,11,ポテトサラダ
 1749,12,土豆沙拉
 1750,1,スライスチーズ
+1750,3,슬라이스치즈
 1750,4,起司片
 1750,5,Fromage
-1750,9,Cheese
-1750,11,スライスチーズ
-1750,3,슬라이스치즈
 1750,6,Scheibenkäse
 1750,7,Queso
 1750,8,Formaggio
+1750,9,Cheese
+1750,11,スライスチーズ
 1750,12,芝士片
 1751,1,バナナスライス
+1751,3,바나나슬라이스
 1751,4,香蕉片
 1751,5,Banane
-1751,9,Banana
-1751,11,バナナスライス
-1751,3,바나나슬라이스
 1751,6,Banane
 1751,7,Plátano
 1751,8,Banana
+1751,9,Banana
+1751,11,バナナスライス
 1751,12,香蕉片
 1752,1,いちごスライス
+1752,3,딸기슬라이스
 1752,4,草莓片
 1752,5,Fraise
-1752,9,Strawberry
-1752,11,いちごスライス
-1752,3,딸기슬라이스
 1752,6,Erdbeere
 1752,7,Fresa
 1752,8,Fragola
+1752,9,Strawberry
+1752,11,いちごスライス
 1752,12,草莓片
 1753,1,わぎりリンゴ
+1753,3,사과슬라이스
 1753,4,蘋果片
 1753,5,Pomme
-1753,9,Apple
-1753,11,わぎりリンゴ
-1753,3,사과슬라이스
 1753,6,Apfel
 1753,7,Manzana
 1753,8,Mela
+1753,9,Apple
+1753,11,わぎりリンゴ
 1753,12,苹果片
 1754,1,わぎりキウイ
+1754,3,키위슬라이스
 1754,4,奇異果片
 1754,5,Kiwi
-1754,9,Kiwi
-1754,11,わぎりキウイ
-1754,3,키위슬라이스
 1754,6,Kiwi
 1754,7,Kiwi
 1754,8,Kiwi
+1754,9,Kiwi
+1754,11,わぎりキウイ
 1754,12,奇异果片
 1755,1,カットパイン
+1755,3,파인애플슬라이스
 1755,4,鳳梨片
 1755,5,Ananas
-1755,9,Pineapple
-1755,11,カットパイン
-1755,3,파인애플슬라이스
 1755,6,Ananas
 1755,7,Piña
 1755,8,Ananas
+1755,9,Pineapple
+1755,11,カットパイン
 1755,12,凤梨片
 1756,1,バラペーニョ
+1756,3,할라페뇨
 1756,4,小辣椒
 1756,5,Piment
-1756,9,Jalapeño
-1756,11,バラペーニョ
-1756,3,할라페뇨
 1756,6,Jalapeño
 1756,7,Jalapeño
 1756,8,Jalapeño
+1756,9,Jalapeño
+1756,11,バラペーニョ
 1756,12,小辣椒
 1757,1,ホースラディッシュ
+1757,3,호스래디시
 1757,4,辣根
 1757,5,Raifort
-1757,9,Horseradish
-1757,11,ホースラディッシュ
-1757,3,호스래디시
 1757,6,Meerrettich
 1757,7,Rábano Picante
 1757,8,Rafano
+1757,9,Horseradish
+1757,11,ホースラディッシュ
 1757,12,辣根
 1758,1,カレーパウダー
+1758,3,카레파우더
 1758,4,咖哩粉
 1758,5,Curry en Poudre
-1758,9,Curry Powder
-1758,11,カレーパウダー
-1758,3,카레파우더
 1758,6,Currypulver
 1758,7,Curri en Polvo
 1758,8,Curry in polvere
+1758,9,Curry Powder
+1758,11,カレーパウダー
 1758,12,咖喱粉
 1759,1,ワサビソース
+1759,3,와사비소스
 1759,4,芥末醬
 1759,5,Sauce au Wasabi
-1759,9,Wasabi
-1759,11,ワサビソース
-1759,3,와사비소스
 1759,6,Wasabi
 1759,7,Wasabi
 1759,8,Wasabi
+1759,9,Wasabi
+1759,11,ワサビソース
 1759,12,芥末酱
 1760,1,クレソン
+1760,3,물냉이
 1760,4,豆瓣菜
 1760,5,Cresson
-1760,9,Watercress
-1760,11,クレソン
-1760,3,물냉이
 1760,6,Kresse
 1760,7,Berros
 1760,8,Crescione
+1760,9,Watercress
+1760,11,クレソン
 1760,12,豆瓣菜
 1761,1,バジル
+1761,3,바질
 1761,4,羅勒
 1761,5,Basilic
-1761,9,Basil
-1761,11,バジル
-1761,3,바질
 1761,6,Basilikum
 1761,7,Albahaca
 1761,8,Basilico
+1761,9,Basil
+1761,11,バジル
 1761,12,罗勒
 1762,1,コンパンのキバ
+1762,3,콘팡의이빨
 1762,4,毛球的牙
 1762,5,Croc de Mimitoss
-1762,9,Venonat Fang
-1762,11,コンパンのキバ
-1762,3,콘팡의이빨
 1762,6,Bluzuk-Zahn
 1762,7,Colmillo de Venonat
 1762,8,Zanna di Venonat
+1762,9,Venonat Fang
+1762,11,コンパンのキバ
 1762,12,毛球的牙
 1763,1,ディグダのつち
+1763,3,디그다의흙
 1763,4,地鼠的土
 1763,5,Terre de Taupiqueur
-1763,9,Diglett Dirt
-1763,11,ディグダのつち
-1763,3,디그다의흙
 1763,6,Digda-Erde
 1763,7,Tierra de Diglett
 1763,8,Terra di Diglett
+1763,9,Diglett Dirt
+1763,11,ディグダのつち
 1763,12,地鼠的土
 1764,1,ニャースのけ
+1764,3,나옹의털
 1764,4,喵喵的毛
 1764,5,Poils de Miaouss
-1764,9,Meowth Fur
-1764,11,ニャースのけ
-1764,3,나옹의털
 1764,6,Mauzi-Haar
 1764,7,Pelo de Meowth
 1764,8,Pelo di Meowth
+1764,9,Meowth Fur
+1764,11,ニャースのけ
 1764,12,喵喵的毛
 1765,1,コダックのうもう
+1765,3,고라파덕의솜털
 1765,4,可達鴨的羽絨
 1765,5,Duvet de Psykokwak
-1765,9,Psyduck Down
-1765,11,コダックのうもう
-1765,3,고라파덕의솜털
 1765,6,Enton-Daune
 1765,7,Plumón de Psyduck
 1765,8,Piuma di Psyduck
+1765,9,Psyduck Down
+1765,11,コダックのうもう
 1765,12,可达鸭的羽绒
 1766,1,マンキーのけ
+1766,3,망키의털
 1766,4,猴怪的毛
 1766,5,Poils de Férosinge
-1766,9,Mankey Fur
-1766,11,マンキーのけ
-1766,3,망키의털
 1766,6,Menki-Haar
 1766,7,Pelo de Mankey
 1766,8,Pelo di Mankey
+1766,9,Mankey Fur
+1766,11,マンキーのけ
 1766,12,猴怪的毛
 1767,1,ガーディのけ
+1767,3,가디의털
 1767,4,卡蒂狗的毛
 1767,5,Poils de Caninos
-1767,9,Growlithe Fur
-1767,11,ガーディのけ
-1767,3,가디의털
 1767,6,Fukano-Haar
 1767,7,Pelo de Growlithe
 1767,8,Pelo di Growlithe
+1767,9,Growlithe Fur
+1767,11,ガーディのけ
 1767,12,卡蒂狗的毛
 1768,1,ヤドンのツメ
+1768,3,야돈의발톱
 1768,4,呆呆獸的爪子
 1768,5,Griffe de Ramoloss
-1768,9,Slowpoke Claw
-1768,11,ヤドンのツメ
-1768,3,야돈의발톱
 1768,6,Flegmon-Kralle
 1768,7,Garra de Slowpoke
 1768,8,Artiglio di Slowpoke
+1768,9,Slowpoke Claw
+1768,11,ヤドンのツメ
 1768,12,呆呆兽的爪子
 1769,1,コイルのねじ
+1769,3,코일의나사
 1769,4,小磁怪的螺絲
 1769,5,Vis de Magnéti
-1769,9,Magnemite Screw
-1769,11,コイルのねじ
-1769,3,코일의나사
 1769,6,Magnetilo-Schraube
 1769,7,Tornillo de Magnemite
 1769,8,Vite di Magnemite
+1769,9,Magnemite Screw
+1769,11,コイルのねじ
 1769,12,小磁怪的螺丝
 1770,1,ベトベターのどくそ
+1770,3,질퍽이의독소
 1770,4,臭泥的毒素
 1770,5,Poison de Tadmorv
-1770,9,Grimer Toxin
-1770,11,ベトベターのどくそ
-1770,3,질퍽이의독소
 1770,6,Sleima-Toxin
 1770,7,Toxinas de Grimer
 1770,8,Tossine di Grimer
+1770,9,Grimer Toxin
+1770,11,ベトベターのどくそ
 1770,12,臭泥的毒素
 1771,1,シェルダーのしんじゅ
+1771,3,셀러의진주
 1771,4,大舌貝的珍珠
 1771,5,Perle de Kokiyas
-1771,9,Shellder Pearl
-1771,11,シェルダーのしんじゅ
-1771,3,셀러의진주
 1771,6,Muschas-Perle
 1771,7,Perla de Shellder
 1771,8,Perla di Shellder
+1771,9,Shellder Pearl
+1771,11,シェルダーのしんじゅ
 1771,12,大舌贝的珍珠
 1772,1,ゴースのガス
+1772,3,고오스의가스
 1772,4,鬼斯的氣體
 1772,5,Gaz de Fantominus
-1772,9,Gastly Gas
-1772,11,ゴースのガス
-1772,3,고오스의가스
 1772,6,Nebulak-Gas
 1772,7,Gas de Gastly
 1772,8,Gas di Gastly
+1772,9,Gastly Gas
+1772,11,ゴースのガス
 1772,12,鬼斯的气体
 1773,1,スリープのけ
+1773,3,슬리프의털
 1773,4,催眠貘的毛
 1773,5,Poils de Soporifik
-1773,9,Drowzee Fur
-1773,11,スリープのけ
-1773,3,슬리프의털
 1773,6,Traumato-Haar
 1773,7,Pelo de Drowzee
 1773,8,Pelo di Drowzee
+1773,9,Drowzee Fur
+1773,11,スリープのけ
 1773,12,催眠貘的毛
 1774,1,ビリリダマのでんき
+1774,3,찌리리공의전기
 1774,4,霹靂電球的電力
 1774,5,Électricité de Voltorbe
-1774,9,Voltorb Sparks
-1774,11,ビリリダマのでんき
-1774,3,찌리리공의전기
 1774,6,Voltobal-Strom
 1774,7,Electricidad de Voltorb
 1774,8,Elettricità di Voltorb
+1774,9,Voltorb Sparks
+1774,11,ビリリダマのでんき
 1774,12,霹雳电球的电力
 1775,1,ストライクのツメ
+1775,3,스라크의발톱
 1775,4,飛天螳螂的爪子
 1775,5,Griffe d'Insécateur
-1775,9,Scyther Claw
-1775,11,ストライクのツメ
-1775,3,스라크의발톱
 1775,6,Sichlor-Kralle
 1775,7,Garra de Scyther
 1775,8,Artiglio di Scyther
+1775,9,Scyther Claw
+1775,11,ストライクのツメ
 1775,12,飞天螳螂的爪子
 1776,1,ケンタロスのけ
+1776,3,켄타로스의털
 1776,4,肯泰羅的毛
 1776,5,Poils de Tauros
-1776,9,Tauros Hair
-1776,11,ケンタロスのけ
-1776,3,켄타로스의털
 1776,6,Tauros-Haar
 1776,7,Pelo de Tauros
 1776,8,Pelo di Tauros
+1776,9,Tauros Hair
+1776,11,ケンタロスのけ
 1776,12,肯泰罗的毛
 1777,1,コイキングのウロコ
+1777,3,잉어킹의비늘
 1777,4,鯉魚王的鱗片
 1777,5,Écaille de Magicarpe
-1777,9,Magikarp Scales
-1777,11,コイキングのウロコ
-1777,3,잉어킹의비늘
 1777,6,Karpador-Schuppe
 1777,7,Escama de Magikarp
 1777,8,Squama di Magikarp
+1777,9,Magikarp Scales
+1777,11,コイキングのウロコ
 1777,12,鲤鱼王的鳞片
 1778,1,メタモンのべたべた
+1778,3,메타몽의끈끈이
 1778,4,百變怪的黏糊
 1778,5,Substance de Métamorph
-1778,9,Ditto Goo
-1778,11,メタモンのべたべた
-1778,3,메타몽의끈끈이
 1778,6,Ditto-Glibber
 1778,7,Pegote de Ditto
 1778,8,Appiccicume di Ditto
+1778,9,Ditto Goo
+1778,11,メタモンのべたべた
 1778,12,百变怪的黏糊
 1779,1,イーブイのけ
+1779,3,이브이의털
 1779,4,伊布的毛
 1779,5,Poils d’Évoli
-1779,9,Eevee Fur
-1779,11,イーブイのけ
-1779,3,이브이의털
 1779,6,Evoli-Haar
 1779,7,Pelo de Eevee
 1779,8,Pelo di Eevee
+1779,9,Eevee Fur
+1779,11,イーブイのけ
 1779,12,伊布的毛
 1780,1,ミニリュウのウロコ
+1780,3,미뇽의비늘
 1780,4,迷你龍的鱗片
 1780,5,Écaille de Minidraco
-1780,9,Dratini Scales
-1780,11,ミニリュウのウロコ
-1780,3,미뇽의비늘
 1780,6,Dratini-Schuppe
 1780,7,Escama de Dratini
 1780,8,Squama di Dratini
+1780,9,Dratini Scales
+1780,11,ミニリュウのウロコ
 1780,12,迷你龙的鳞片
 1781,1,ピチューのけ
+1781,3,피츄의털
 1781,4,皮丘的毛
 1781,5,Poils de Pichu
-1781,9,Pichu Fur
-1781,11,ピチューのけ
-1781,3,피츄의털
 1781,6,Pichu-Haar
 1781,7,Pelo de Pichu
 1781,8,Pelo di Pichu
+1781,9,Pichu Fur
+1781,11,ピチューのけ
 1781,12,皮丘的毛
 1782,1,ププリンのけ
+1782,3,푸푸린의털
 1782,4,寶寶丁的毛
 1782,5,Poils de Toudoudou
-1782,9,Igglybuff Fluff
-1782,11,ププリンのけ
-1782,3,푸푸린의털
 1782,6,Fluffeluff-Haar
 1782,7,Pelo de Igglybuff
 1782,8,Pelo di Igglybuff
+1782,9,Igglybuff Fluff
+1782,11,ププリンのけ
 1782,12,宝宝丁的毛
 1783,1,メリープのけだま
+1783,3,메리프의털뭉치
 1783,4,咩利羊的毛球
 1783,5,Laine de Wattouat
-1783,9,Mareep Wool
-1783,11,メリープのけだま
-1783,3,메리프의털뭉치
 1783,6,Voltilamm-Wolle
 1783,7,Lana de Mareep
 1783,8,Lana di Mareep
+1783,9,Mareep Wool
+1783,11,メリープのけだま
 1783,12,咩利羊的毛球
 1784,1,ハネッコのはっぱ
+1784,3,통통코의잎
 1784,4,毽子草的葉片
 1784,5,Feuille de Granivol
-1784,9,Hoppip Leaf
-1784,11,ハネッコのはっぱ
-1784,3,통통코의잎
 1784,6,Hoppspross-Blatt
 1784,7,Hoja de Hoppip
 1784,8,Foglia di Hoppip
+1784,9,Hoppip Leaf
+1784,11,ハネッコのはっぱ
 1784,12,毽子草的叶片
 1785,1,ヒマナッツのはっぱ
+1785,3,해너츠의잎
 1785,4,向日種子的葉片
 1785,5,Feuille de Tournegrin
-1785,9,Sunkern Leaf
-1785,11,ヒマナッツのはっぱ
-1785,3,해너츠의잎
 1785,6,Sonnkern-Blatt
 1785,7,Hoja de Sunkern
 1785,8,Foglia di Sunkern
+1785,9,Sunkern Leaf
+1785,11,ヒマナッツのはっぱ
 1785,12,向日种子的叶片
 1786,1,ヤミカラスのおたから
+1786,3,니로우의보물
 1786,4,黑暗鴉的寶物
 1786,5,Trésor de Cornèbre
-1786,9,Murkrow Bauble
-1786,11,ヤミカラスのおたから
-1786,3,니로우의보물
 1786,6,Kramurx-Schatz
 1786,7,Tesoro de Murkrow
 1786,8,Tesoro di Murkrow
+1786,9,Murkrow Bauble
+1786,11,ヤミカラスのおたから
 1786,12,黑暗鸦的宝物
 1787,1,ムウマのなみだ
+1787,3,무우마의눈물
 1787,4,夢妖的眼淚
 1787,5,Larme de Feuforêve
-1787,9,Misdreavus Tears
-1787,11,ムウマのなみだ
-1787,3,무우마의눈물
 1787,6,Traunfugil-Träne
 1787,7,Lágrima de Misdreavus
 1787,8,Lacrime di Misdreavus
+1787,9,Misdreavus Tears
+1787,11,ムウマのなみだ
 1787,12,梦妖的眼泪
 1788,1,キリンリキのけ
+1788,3,키링키의털
 1788,4,麒麟奇的毛
 1788,5,Poils de Girafarig
-1788,9,Girafarig Fur
-1788,11,キリンリキのけ
-1788,3,키링키의털
 1788,6,Girafarig-Haar
 1788,7,Pelo de Girafarig
 1788,8,Pelo di Girafarig
+1788,9,Girafarig Fur
+1788,11,キリンリキのけ
 1788,12,麒麟奇的毛
 1789,1,クヌギダマのから
+1789,3,피콘의껍데기
 1789,4,榛果球的殼
 1789,5,Écorce de Pomdepik
-1789,9,Pineco Husk
-1789,11,クヌギダマのから
-1789,3,피콘의껍데기
 1789,6,Tannza-Schale
 1789,7,Corteza de Pineco
 1789,8,Guscio di Pineco
+1789,9,Pineco Husk
+1789,11,クヌギダマのから
 1789,12,榛果球的壳
 1790,1,ノコッチのウロコ
+1790,3,노고치의비늘
 1790,4,土龍弟弟的鱗片
 1790,5,Écaille d'Insolourdo
-1790,9,Dunsparce Scales
-1790,11,ノコッチのウロコ
-1790,3,노고치의비늘
 1790,6,Dummisel-Schuppe
 1790,7,Escama de Dunsparce
 1790,8,Squama di Dunsparce
+1790,9,Dunsparce Scales
+1790,11,ノコッチのウロコ
 1790,12,土龙弟弟的鳞片
 1791,1,ハリーセンのトゲ
+1791,3,침바루의가시
 1791,4,千針魚的刺
 1791,5,Épine de Qwilfish
-1791,9,Qwilfish Spines
-1791,11,ハリーセンのトゲ
-1791,3,침바루의가시
 1791,6,Baldorfish-Stachel
 1791,7,Púa de Qwilfish
 1791,8,Aculeo di Qwilfish
+1791,9,Qwilfish Spines
+1791,11,ハリーセンのトゲ
 1791,12,千针鱼的刺
 1792,1,ヘラクロスのツメ
+1792,3,헤라크로스의발톱
 1792,4,赫拉克羅斯的爪子
 1792,5,Griffe de Scarhino
-1792,9,Heracross Claw
-1792,11,ヘラクロスのツメ
-1792,3,헤라크로스의발톱
 1792,6,Skaraborn-Kralle
 1792,7,Garra de Heracross
 1792,8,Artiglio di Heracross
+1792,9,Heracross Claw
+1792,11,ヘラクロスのツメ
 1792,12,赫拉克罗斯的爪子
 1793,1,ニューラのツメ
+1793,3,포푸니의손톱
 1793,4,狃拉的爪子
 1793,5,Griffe de Farfuret
-1793,9,Sneasel Claw
-1793,11,ニューラのツメ
-1793,3,포푸니의손톱
 1793,6,Sniebel-Kralle
 1793,7,Garra de Sneasel
 1793,8,Artiglio di Sneasel
+1793,9,Sneasel Claw
+1793,11,ニューラのツメ
 1793,12,狃拉的爪子
 1794,1,ヒメグマのツメ
+1794,3,깜지곰의손톱
 1794,4,熊寶寶的爪子
 1794,5,Griffe de Teddiursa
-1794,9,Teddiursa Claw
-1794,11,ヒメグマのツメ
-1794,3,깜지곰의손톱
 1794,6,Teddiursa-Kralle
 1794,7,Garra de Teddiursa
 1794,8,Artiglio di Teddiursa
+1794,9,Teddiursa Claw
+1794,11,ヒメグマのツメ
 1794,12,熊宝宝的爪子
 1795,1,デリバードのにもつ
+1795,3,딜리버드의짐
 1795,4,信使鳥的行李
 1795,5,Provisions de Cadoizo
-1795,9,Delibird Parcel
-1795,11,デリバードのにもつ
-1795,3,딜리버드의짐
 1795,6,Botogel-Päckchen
 1795,7,Paquete de Delibird
 1795,8,Scorte di Delibird
+1795,9,Delibird Parcel
+1795,11,デリバードのにもつ
 1795,12,信使鸟的行李
 1796,1,デルビルのキバ
+1796,3,델빌의이빨
 1796,4,戴魯比的牙
 1796,5,Croc de Malosse
-1796,9,Houndour Fang
-1796,11,デルビルのキバ
-1796,3,델빌의이빨
 1796,6,Hunduster-Zahn
 1796,7,Colmillo de Houndour
 1796,8,Zanna di Houndour
+1796,9,Houndour Fang
+1796,11,デルビルのキバ
 1796,12,戴鲁比的牙
 1797,1,ゴマゾウのツメ
+1797,3,코코리의발톱
 1797,4,小小象的爪子
 1797,5,Ongle de Phanpy
-1797,9,Phanpy Nail
-1797,11,ゴマゾウのツメ
-1797,3,코코리의발톱
 1797,6,Phanpy-Kralle
 1797,7,Uña de Phanpy
 1797,8,Unghia di Phanpy
+1797,9,Phanpy Nail
+1797,11,ゴマゾウのツメ
 1797,12,小小象的爪子
 1798,1,オドシシのけ
+1798,3,노라키의털
 1798,4,驚角鹿的毛
 1798,5,Poils de Cerfrousse
-1798,9,Stantler Hair
-1798,11,オドシシのけ
-1798,3,노라키의털
 1798,6,Damhirplex-Haar
 1798,7,Pelo de Stantler
 1798,8,Pelo di Stantler
+1798,9,Stantler Hair
+1798,11,オドシシのけ
 1798,12,惊角鹿的毛
 1799,1,ヨーギラスのツメ
+1799,3,애버라스의발톱
 1799,4,幼基拉斯的爪子
 1799,5,Griffe d'Embrylex
-1799,9,Larvitar Claw
-1799,11,ヨーギラスのツメ
-1799,3,애버라스의발톱
 1799,6,Larvitar-Kralle
 1799,7,Garra de Larvitar
 1799,8,Artiglio di Larvitar
+1799,9,Larvitar Claw
+1799,11,ヨーギラスのツメ
 1799,12,幼基拉斯的爪子
 1800,1,キャモメのはね
+1800,3,갈모매의깃털
 1800,4,長翅鷗的羽毛
 1800,5,Plume de Goélise
-1800,9,Wingull Feather
-1800,11,キャモメのはね
-1800,3,갈모매의깃털
 1800,6,Wingull-Feder
 1800,7,Pluma de Wingull
 1800,8,Penna di Wingull
+1800,9,Wingull Feather
+1800,11,キャモメのはね
 1800,12,长翅鸥的羽毛
 1801,1,ラルトスのおとしもの
+1801,3,랄토스의유실물
 1801,4,拉魯拉絲的掉落物
 1801,5,Babiole de Tarsal
-1801,9,Ralts Dust
-1801,11,ラルトスのおとしもの
-1801,3,랄토스의유실물
 1801,6,Trasla-Material
 1801,7,Pertenencia de Ralts
 1801,8,Oggetto di Ralts
+1801,9,Ralts Dust
+1801,11,ラルトスのおとしもの
 1801,12,拉鲁拉丝的掉落物
 1802,1,アメタマのミツ
+1802,3,비구술의꿀
 1802,4,溜溜糖球的蜜
 1802,5,Nectar d'Arakdo
-1802,9,Surskit Syrup
-1802,11,アメタマのミツ
-1802,3,비구술의꿀
 1802,6,Gehweiher-Nektar
 1802,7,Néctar de Surskit
 1802,8,Sciroppo di Surskit
+1802,9,Surskit Syrup
+1802,11,アメタマのミツ
 1802,12,溜溜糖球的蜜
 1803,1,キノココのほうし
+1803,3,버섯꼬의포자
 1803,4,蘑蘑菇的孢子
 1803,5,Spores de Balignon
-1803,9,Shroomish Spores
-1803,11,キノココのほうし
-1803,3,버섯꼬의포자
 1803,6,Knilz-Spore
 1803,7,Esporas de Shroomish
 1803,8,Spore di Shroomish
+1803,9,Shroomish Spores
+1803,11,キノココのほうし
 1803,12,蘑蘑菇的孢子
 1804,1,ナマケロのけ
+1804,3,게을로의털
 1804,4,懶人獺的毛
 1804,5,Poils de Parecool
-1804,9,Slakoth Fur
-1804,11,ナマケロのけ
-1804,3,게을로의털
 1804,6,Bummelz-Haar
 1804,7,Pelo de Slakoth
 1804,8,Pelo di Slakoth
+1804,9,Slakoth Fur
+1804,11,ナマケロのけ
 1804,12,懒人獭的毛
 1805,1,マクノシタのあせ
+1805,3,마크탕의땀
 1805,4,幕下力士的汗
 1805,5,Sueur de Makuhita
-1805,9,Makuhita Sweat
-1805,11,マクノシタのあせ
-1805,3,마크탕의땀
 1805,6,Makuhita-Schweiß
 1805,7,Sudor de Makuhita
 1805,8,Sudore di Makuhita
+1805,9,Makuhita Sweat
+1805,11,マクノシタのあせ
 1805,12,幕下力士的汗
 1806,1,ルリリのけ
+1806,3,루리리의털
 1806,4,露力麗的毛
 1806,5,Poils d'Azurill
-1806,9,Azurill Fur
-1806,11,ルリリのけ
-1806,3,루리리의털
 1806,6,Azurill-Haar
 1806,7,Pelo de Azurill
 1806,8,Pelo di Azurill
+1806,9,Azurill Fur
+1806,11,ルリリのけ
 1806,12,露力丽的毛
 1807,1,ヤミラミのほうせき
+1807,3,깜까미의보석
 1807,4,勾魂眼的寶石
 1807,5,Joyau de Ténéfix
-1807,9,Sableye Gem
-1807,11,ヤミラミのほうせき
-1807,3,깜까미의보석
 1807,6,Zobiris-Edelstein
 1807,7,Gema de Sableye
 1807,8,Gemma di Sableye
+1807,9,Sableye Gem
+1807,11,ヤミラミのほうせき
 1807,12,勾魂眼的宝石
 1808,1,アサナンのあせ
+1808,3,요가랑의땀
 1808,4,瑪沙那的汗
 1808,5,Sueur de Méditikka
-1808,9,Meditite Sweat
-1808,11,アサナンのあせ
-1808,3,요가랑의땀
 1808,6,Meditie-Schweiß
 1808,7,Sudor de Meditite
 1808,8,Sudore di Meditite
+1808,9,Meditite Sweat
+1808,11,アサナンのあせ
 1808,12,玛沙那的汗
 1809,1,ゴクリンのねんえき
+1809,3,꼴깍몬의점액
 1809,4,溶食獸的黏液
 1809,5,Mucus de Gloupti
-1809,9,Gulpin Mucus
-1809,11,ゴクリンのねんえき
-1809,3,꼴깍몬의점액
 1809,6,Schluppuck-Schleim
 1809,7,Secreción de Gulpin
 1809,8,Muco di Gulpin
+1809,9,Gulpin Mucus
+1809,11,ゴクリンのねんえき
 1809,12,溶食兽的黏液
 1810,1,ドンメルのようがん
+1810,3,둔타의용암
 1810,4,呆火駝的熔岩
 1810,5,Lave de Chamallot
-1810,9,Numel Lava
-1810,11,ドンメルのようがん
-1810,3,둔타의용암
 1810,6,Camaub-Lava
 1810,7,Lava de Numel
 1810,8,Lava di Numel
+1810,9,Numel Lava
+1810,11,ドンメルのようがん
 1810,12,呆火驼的熔岩
 1811,1,コータスのせきたん
+1811,3,코터스의석탄
 1811,4,煤炭龜的煤炭
 1811,5,Charbon de Chartor
-1811,9,Torkoal Coal
-1811,11,コータスのせきたん
-1811,3,코터스의석탄
 1811,6,Qurtel-Kohle
 1811,7,Carbón de Torkoal
 1811,8,Carbone di Torkoal
+1811,9,Torkoal Coal
+1811,11,コータスのせきたん
 1811,12,煤炭龟的煤炭
 1812,1,バネブーのしんじゅ
+1812,3,피그점프의진주
 1812,4,跳跳豬的珍珠
 1812,5,Perle de Spoink
-1812,9,Spoink Pearl
-1812,11,バネブーのしんじゅ
-1812,3,피그점프의진주
 1812,6,Spoink-Perle
 1812,7,Perla de Spoink
 1812,8,Perla di Spoink
+1812,9,Spoink Pearl
+1812,11,バネブーのしんじゅ
 1812,12,跳跳猪的珍珠
 1813,1,サボネアのトゲ
+1813,3,선인왕의가시
 1813,4,刺球仙人掌的刺
 1813,5,Épine de Cacnea
-1813,9,Cacnea Needle
-1813,11,サボネアのトゲ
-1813,3,선인왕의가시
 1813,6,Tuska-Stachel
 1813,7,Espina de Cacnea
 1813,8,Spina di Cacnea
+1813,9,Cacnea Needle
+1813,11,サボネアのトゲ
 1813,12,刺球仙人掌的刺
 1814,1,チルットのはね
+1814,3,파비코의깃털
 1814,4,青綿鳥的羽毛
 1814,5,Plume de Tylton
-1814,9,Swablu Fluff
-1814,11,チルットのはね
-1814,3,파비코의깃털
 1814,6,Wablu-Feder
 1814,7,Pluma de Swablu
 1814,8,Piuma di Swablu
+1814,9,Swablu Fluff
+1814,11,チルットのはね
 1814,12,青绵鸟的羽毛
 1815,1,ザングースのツメ
+1815,3,쟝고의발톱
 1815,4,貓鼬斬的爪子
 1815,5,Griffe de Mangriff
-1815,9,Zangoose Claw
-1815,11,ザングースのツメ
-1815,3,쟝고의발톱
 1815,6,Sengo-Kralle
 1815,7,Garra de Zangoose
 1815,8,Artiglio di Zangoose
+1815,9,Zangoose Claw
+1815,11,ザングースのツメ
 1815,12,猫鼬斩的爪子
 1816,1,ハブネークのキバ
+1816,3,세비퍼의이빨
 1816,4,飯匙蛇的牙
 1816,5,Croc de Séviper
-1816,9,Seviper Fang
-1816,11,ハブネークのキバ
-1816,3,세비퍼의이빨
 1816,6,Vipitis-Zahn
 1816,7,Colmillo de Seviper
 1816,8,Zanna di Seviper
+1816,9,Seviper Fang
+1816,11,ハブネークのキバ
 1816,12,饭匙蛇的牙
 1817,1,ドジョッチのねんえき
+1817,3,미꾸리의점액
 1817,4,泥泥鰍的黏液
 1817,5,Mucus de Barloche
-1817,9,Barboach Slime
-1817,11,ドジョッチのねんえき
-1817,3,미꾸리의점액
 1817,6,Schmerbe-Schleim
 1817,7,Secreción de Barboach
 1817,8,Muco di Barboach
+1817,9,Barboach Slime
+1817,11,ドジョッチのねんえき
 1817,12,泥泥鳅的黏液
 1818,1,カゲボウズのきれはし
+1818,3,어둠대신의천조각
 1818,4,怨影娃娃的殘片
 1818,5,Tissu de Polichombr
-1818,9,Shuppet Scrap
-1818,11,カゲボウズのきれはし
-1818,3,어둠대신의천조각
 1818,6,Shuppet-Fetzen
 1818,7,Retal de Shuppet
 1818,8,Brandello di Shuppet
+1818,9,Shuppet Scrap
+1818,11,カゲボウズのきれはし
 1818,12,怨影娃娃的残片
 1819,1,トロピウスのはっぱ
+1819,3,트로피우스의잎
 1819,4,熱帶龍的葉片
 1819,5,Feuille de Tropius
-1819,9,Tropius Leaf
-1819,11,トロピウスのはっぱ
-1819,3,트로피우스의잎
 1819,6,Tropius-Blatt
 1819,7,Hoja de Tropius
 1819,8,Foglia di Tropius
+1819,9,Tropius Leaf
+1819,11,トロピウスのはっぱ
 1819,12,热带龙的叶片
 1820,1,ユキワラシのけ
+1820,3,눈꼬마의털
 1820,4,雪童子的毛
 1820,5,Poils de Stalgamin
-1820,9,Snorunt Fur
-1820,11,ユキワラシのけ
-1820,3,눈꼬마의털
 1820,6,Schneppke-Haar
 1820,7,Pelo de Snorunt
 1820,8,Pelo di Snorunt
+1820,9,Snorunt Fur
+1820,11,ユキワラシのけ
 1820,12,雪童子的毛
 1821,1,ラブカスのウロコ
+1821,3,사랑동이의비늘
 1821,4,愛心魚的鱗片
 1821,5,Écaille de Lovdisc
-1821,9,Luvdisc Scales
-1821,11,ラブカスのウロコ
-1821,3,사랑동이의비늘
 1821,6,Liebiskus-Schuppe
 1821,7,Escama de Luvdisc
 1821,8,Squama di Luvdisc
+1821,9,Luvdisc Scales
+1821,11,ラブカスのウロコ
 1821,12,爱心鱼的鳞片
 1822,1,タツベイのウロコ
+1822,3,아공이의비늘
 1822,4,寶貝龍的鱗片
 1822,5,Écaille de Draby
-1822,9,Bagon Scales
-1822,11,タツベイのウロコ
-1822,3,아공이의비늘
 1822,6,Kindwurm-Schuppe
 1822,7,Escama de Bagon
 1822,8,Squama di Bagon
+1822,9,Bagon Scales
+1822,11,タツベイのウロコ
 1822,12,宝贝龙的鳞片
 1823,1,ムックルのはね
+1823,3,찌르꼬의깃털
 1823,4,姆克兒的羽毛
 1823,5,Plume d’Étourmi
-1823,9,Starly Feather
-1823,11,ムックルのはね
-1823,3,찌르꼬의깃털
 1823,6,Staralili-Feder
 1823,7,Pluma de Starly
 1823,8,Penna di Starly
+1823,9,Starly Feather
+1823,11,ムックルのはね
 1823,12,姆克儿的羽毛
 1824,1,コロボーシのぬけがら
+1824,3,귀뚤뚜기의허물
 1824,4,圓法師的蛻殼
 1824,5,Mue de Crikzik
-1824,9,Kricketot Shell
-1824,11,コロボーシのぬけがら
-1824,3,귀뚤뚜기의허물
 1824,6,Zirpurze-Häutungsrest
 1824,7,Muda de Kricketot
 1824,8,Esuvia di Kricketot
+1824,9,Kricketot Shell
+1824,11,コロボーシのぬけがら
 1824,12,圆法师的蜕壳
 1825,1,コリンクのキバ
+1825,3,꼬링크의이빨
 1825,4,小貓怪的牙
 1825,5,Croc de Lixy
-1825,9,Shinx Fang
-1825,11,コリンクのキバ
-1825,3,꼬링크의이빨
 1825,6,Sheinux-Zahn
 1825,7,Colmillo de Shinx
 1825,8,Zanna di Shinx
+1825,9,Shinx Fang
+1825,11,コリンクのキバ
 1825,12,小猫怪的牙
 1826,1,ミツハニーのミツ
+1826,3,세꿀버리의꿀
 1826,4,三蜜蜂的蜜
 1826,5,Nectar d'Apitrini
-1826,9,Combee Honey
-1826,11,ミツハニーのミツ
-1826,3,세꿀버리의꿀
 1826,6,Wadribie-Honig
 1826,7,Miel de Combee
 1826,8,Nettare di Combee
+1826,9,Combee Honey
+1826,11,ミツハニーのミツ
 1826,12,三蜜蜂的蜜
 1827,1,パチリスのけ
+1827,3,파치리스의털
 1827,4,帕奇利茲的毛
 1827,5,Poils de Pachirisu
-1827,9,Pachirisu Fur
-1827,11,パチリスのけ
-1827,3,파치리스의털
 1827,6,Pachirisu-Haar
 1827,7,Pelo de Pachirisu
 1827,8,Pelo di Pachirisu
+1827,9,Pachirisu Fur
+1827,11,パチリスのけ
 1827,12,帕奇利兹的毛
 1828,1,ブイゼルのけ
+1828,3,브이젤의털
 1828,4,泳圈鼬的毛
 1828,5,Poils de Mustébouée
-1828,9,Buizel Fur
-1828,11,ブイゼルのけ
-1828,3,브이젤의털
 1828,6,Bamelin-Haar
 1828,7,Pelo de Buizel
 1828,8,Pelo di Buizel
+1828,9,Buizel Fur
+1828,11,ブイゼルのけ
 1828,12,泳圈鼬的毛
 1829,1,カラナクシのねんえき
+1829,3,깝질무의점액
 1829,4,無殼海兔的黏液
 1829,5,Mucus de Sancoki
-1829,9,Shellos Mucus
-1829,11,カラナクシのねんえき
-1829,3,깝질무의점액
 1829,6,Schalellos-Schleim
 1829,7,Secreción de Shellos
 1829,8,Bava di Shellos
+1829,9,Shellos Mucus
+1829,11,カラナクシのねんえき
 1829,12,无壳海兔的黏液
 1830,1,フワンテのガス
+1830,3,흔들풍손의가스
 1830,4,飄飄球的氣體
 1830,5,Gaz de Baudrive
-1830,9,Drifloon Gas
-1830,11,フワンテのガス
-1830,3,흔들풍손의가스
 1830,6,Driftlon-Gas
 1830,7,Gas de Drifloon
 1830,8,Gas di Drifloon
+1830,9,Drifloon Gas
+1830,11,フワンテのガス
 1830,12,飘飘球的气体
 1831,1,スカンプーのけ
+1831,3,스컹뿡의털
 1831,4,臭鼬噗的毛
 1831,5,Poils de Moufouette
-1831,9,Stunky Fur
-1831,11,スカンプーのけ
-1831,3,스컹뿡의털
 1831,6,Skunkapuh-Haar
 1831,7,Pelo de Stunky
 1831,8,Pelo di Stunky
+1831,9,Stunky Fur
+1831,11,スカンプーのけ
 1831,12,臭鼬噗的毛
 1832,1,ドーミラーのかけら
+1832,3,동미러의조각
 1832,4,銅鏡怪的碎片
 1832,5,Fragment d'Archéomire
-1832,9,Bronzor Fragment
-1832,11,ドーミラーのかけら
-1832,3,동미러의조각
 1832,6,Bronzel-Splitter
 1832,7,Fragmento de Bronzor
 1832,8,Frammento di Bronzor
+1832,9,Bronzor Fragment
+1832,11,ドーミラーのかけら
 1832,12,铜镜怪的碎片
 1833,1,ウソハチのなみだ
+1833,3,꼬지지의눈물
 1833,4,盆才怪的眼淚
 1833,5,Larme de Manzaï
-1833,9,Bonsly Tears
-1833,11,ウソハチのなみだ
-1833,3,꼬지지의눈물
 1833,6,Mobai-Träne
 1833,7,Lágrima de Bonsly
 1833,8,Lacrime di Bonsly
+1833,9,Bonsly Tears
+1833,11,ウソハチのなみだ
 1833,12,盆才怪的眼泪
 1834,1,ピンプクのおとしもの
+1834,3,핑복의유실물
 1834,4,小福蛋的掉落物
 1834,5,Babiole de Ptiravi
-1834,9,Happiny Dust
-1834,11,ピンプクのおとしもの
-1834,3,핑복의유실물
 1834,6,Wonneira-Material
 1834,7,Pertenencia de Happiny
 1834,8,Oggetto di Happiny
+1834,9,Happiny Dust
+1834,11,ピンプクのおとしもの
 1834,12,小福蛋的掉落物
 1835,1,ミカルゲのかけら
+1835,3,화강돌의조각
 1835,4,花岩怪的碎片
 1835,5,Fragment de Spiritomb
-1835,9,Spiritomb Fragment
-1835,11,ミカルゲのかけら
-1835,3,화강돌의조각
 1835,6,Kryppuk-Splitter
 1835,7,Fragmento de Spiritomb
 1835,8,Frammento di Spiritomb
+1835,9,Spiritomb Fragment
+1835,11,ミカルゲのかけら
 1835,12,花岩怪的碎片
 1836,1,フカマルのウロコ
+1836,3,딥상어동의비늘
 1836,4,圓陸鯊的鱗片
 1836,5,Écaille de Griknot
-1836,9,Gible Scales
-1836,11,フカマルのウロコ
-1836,3,딥상어동의비늘
 1836,6,Kaumalat-Schuppe
 1836,7,Escama de Gible
 1836,8,Squama di Gible
+1836,9,Gible Scales
+1836,11,フカマルのウロコ
 1836,12,圆陆鲨的鳞片
 1837,1,リオルのけ
+1837,3,리오르의털
 1837,4,利歐路的毛
 1837,5,Poils de Riolu
-1837,9,Riolu Fur
-1837,11,リオルのけ
-1837,3,리오르의털
 1837,6,Riolu-Haar
 1837,7,Pelo de Riolu
 1837,8,Pelo di Riolu
+1837,9,Riolu Fur
+1837,11,リオルのけ
 1837,12,利欧路的毛
 1838,1,ヒポポタスのすな
+1838,3,히포포타스의모래
 1838,4,沙河馬的沙
 1838,5,Sable d'Hippopotas
-1838,9,Hippopotas Sand
-1838,11,ヒポポタスのすな
-1838,3,히포포타스의모래
 1838,6,Hippopotas-Sand
 1838,7,Arena de Hippopotas
 1838,8,Sabbia di Hippopotas
+1838,9,Hippopotas Sand
+1838,11,ヒポポタスのすな
 1838,12,沙河马的沙
 1839,1,グレッグルのどくそ
+1839,3,삐딱구리의독소
 1839,4,不良蛙的毒素
 1839,5,Poison de Cradopaud
-1839,9,Croagunk Poison
-1839,11,グレッグルのどくそ
-1839,3,삐딱구리의독소
 1839,6,Glibunkel-Toxin
 1839,7,Toxinas de Croagunk
 1839,8,Tossine di Croagunk
+1839,9,Croagunk Poison
+1839,11,グレッグルのどくそ
 1839,12,不良蛙的毒素
 1840,1,ケイコウオのウロコ
+1840,3,형광어의비늘
 1840,4,螢光魚的鱗片
 1840,5,Écaille d’Écayon
-1840,9,Finneon Scales
-1840,11,ケイコウオのウロコ
-1840,3,형광어의비늘
 1840,6,Finneon-Schuppe
 1840,7,Escama de Finneon
 1840,8,Squama di Finneon
+1840,9,Finneon Scales
+1840,11,ケイコウオのウロコ
 1840,12,荧光鱼的鳞片
 1841,1,ユキカブリのみ
+1841,3,눈쓰개의열매
 1841,4,雪笠怪的果實
 1841,5,Baie de Blizzi
-1841,9,Snover Berries
-1841,11,ユキカブリのみ
-1841,3,눈쓰개의열매
 1841,6,Shnebedeck-Beere
 1841,7,Baya de Snover
 1841,8,Bacca di Snover
+1841,9,Snover Berries
+1841,11,ユキカブリのみ
 1841,12,雪笠怪的果实
 1842,1,ロトムのでんき
+1842,3,로토무의전기
 1842,4,洛托姆的電力
 1842,5,Électricité de Motisma
-1842,9,Rotom Sparks
-1842,11,ロトムのでんき
-1842,3,로토무의전기
 1842,6,Rotom-Strom
 1842,7,Electricidad de Rotom
 1842,8,Elettricità di Rotom
+1842,9,Rotom Sparks
+1842,11,ロトムのでんき
 1842,12,洛托姆的电力
 1843,1,チュリネのはっぱ
+1843,3,치릴리의잎
 1843,4,百合根娃娃的葉片
 1843,5,Feuille de Chlorobule
-1843,9,Petilil Leaf
-1843,11,チュリネのはっぱ
-1843,3,치릴리의잎
 1843,6,Lilminip-Blatt
 1843,7,Hoja de Petilil
 1843,8,Foglia di Petilil
+1843,9,Petilil Leaf
+1843,11,チュリネのはっぱ
 1843,12,百合根娃娃的叶片
 1844,1,バスラオのキバ
+1844,3,배쓰나이의이빨
 1844,4,野蠻鱸魚的牙
 1844,5,Croc de Bargantua
-1844,9,Basculin Fang
-1844,11,バスラオのキバ
-1844,3,배쓰나이의이빨
 1844,6,Barschuft-Zahn
 1844,7,Colmillo de Basculin
 1844,8,Dente di Basculin
+1844,9,Basculin Fang
+1844,11,バスラオのキバ
 1844,12,野蛮鲈鱼的牙
 1845,1,メグロコのツメ
+1845,3,깜눈크의발톱
 1845,4,黑眼鱷的爪子
 1845,5,Griffe de Mascaïman
-1845,9,Sandile Claw
-1845,11,メグロコのツメ
-1845,3,깜눈크의발톱
 1845,6,Ganovil-Kralle
 1845,7,Garra de Sandile
 1845,8,Artiglio di Sandile
+1845,9,Sandile Claw
+1845,11,メグロコのツメ
 1845,12,黑眼鳄的爪子
 1846,1,ゾロアのけ
+1846,3,조로아의털
 1846,4,索羅亞的毛
 1846,5,Poils de Zorua
-1846,9,Zorua Fur
-1846,11,ゾロアのけ
-1846,3,조로아의털
 1846,6,Zorua-Haar
 1846,7,Pelo de Zorua
 1846,8,Pelo di Zorua
+1846,9,Zorua Fur
+1846,11,ゾロアのけ
 1846,12,索罗亚的毛
 1847,1,ゴチムのまつげ
+1847,3,고디탱의속눈썹
 1847,4,哥德寶寶的睫毛
 1847,5,Cils de Scrutella
-1847,9,Gothita Eyelash
-1847,11,ゴチムのまつげ
-1847,3,고디탱의속눈썹
 1847,6,Mollimorba-Wimper
 1847,7,Pestaña de Gothita
 1847,8,Ciglia di Gothita
+1847,9,Gothita Eyelash
+1847,11,ゴチムのまつげ
 1847,12,哥德宝宝的睫毛
 1848,1,シキジカのけ
+1848,3,사철록의털
 1848,4,四季鹿的毛
 1848,5,Poils de Vivaldaim
-1848,9,Deerling Hair
-1848,11,シキジカのけ
-1848,3,사철록의털
 1848,6,Sesokitz-Haar
 1848,7,Pelo de Deerling
 1848,8,Pelo di Deerling
+1848,9,Deerling Hair
+1848,11,シキジカのけ
 1848,12,四季鹿的毛
 1849,1,タマゲタケのほうし
+1849,3,깜놀버슬의포자
 1849,4,哎呀球菇的孢子
 1849,5,Spores de Trompignon
-1849,9,Foongus Spores
-1849,11,タマゲタケのほうし
-1849,3,깜놀버슬의포자
 1849,6,Tarnpignon-Spore
 1849,7,Esporas de Foongus
 1849,8,Spore di Foongus
+1849,9,Foongus Spores
+1849,11,タマゲタケのほうし
 1849,12,哎呀球菇的孢子
 1850,1,ママンボウのねんえき
+1850,3,맘복치의점액
 1850,4,保母曼波的黏液
 1850,5,Mucus de Mamanbo
-1850,9,Alomomola Mucus
-1850,11,ママンボウのねんえき
-1850,3,맘복치의점액
 1850,6,Mamolida-Schleim
 1850,7,Secreción de Alomomola
 1850,8,Muco di Alomomola
+1850,9,Alomomola Mucus
+1850,11,ママンボウのねんえき
 1850,12,保姆曼波的黏液
 1851,1,シビシラスのねんえき
+1851,3,저리어의점액
 1851,4,麻麻小魚的黏液
 1851,5,Mucus d'Anchwatt
-1851,9,Tynamo Slime
-1851,11,シビシラスのねんえき
-1851,3,저리어의점액
 1851,6,Zapplardin-Schleim
 1851,7,Secreción de Tynamo
 1851,8,Muco di Tynamo
+1851,9,Tynamo Slime
+1851,11,シビシラスのねんえき
 1851,12,麻麻小鱼的黏液
 1852,1,キバゴのウロコ
+1852,3,터검니의비늘
 1852,4,牙牙的鱗片
 1852,5,Écaille de Coupenotte
-1852,9,Axew Scales
-1852,11,キバゴのウロコ
-1852,3,터검니의비늘
 1852,6,Milza-Schuppe
 1852,7,Escama de Axew
 1852,8,Squama di Axew
+1852,9,Axew Scales
+1852,11,キバゴのウロコ
 1852,12,牙牙的鳞片
 1853,1,クマシュンのけ
+1853,3,코고미의털
 1853,4,噴嚏熊的毛
 1853,5,Poils de Polarhume
-1853,9,Cubchoo Fur
-1853,11,クマシュンのけ
-1853,3,코고미의털
 1853,6,Petznief-Haar
 1853,7,Pelo de Cubchoo
 1853,8,Pelo di Cubchoo
+1853,9,Cubchoo Fur
+1853,11,クマシュンのけ
 1853,12,喷嚏熊的毛
 1854,1,フリージオのこおり
+1854,3,프리지오의얼음
 1854,4,幾何雪花的冰
 1854,5,Glace d'Hexagel
-1854,9,Cryogonal Ice
-1854,11,フリージオのこおり
-1854,3,프리지오의얼음
 1854,6,Frigometri-Eis
 1854,7,Hielo de Cryogonal
 1854,8,Ghiaccio di Cryogonal
+1854,9,Cryogonal Ice
+1854,11,フリージオのこおり
 1854,12,几何雪花的冰
 1855,1,コマタナのやいば
+1855,3,자망칼의칼날
 1855,4,駒刀小兵的刀
 1855,5,Lame de Scalpion
-1855,9,Pawniard Blade
-1855,11,コマタナのやいば
-1855,3,자망칼의칼날
 1855,6,Gladiantri-Klinge
 1855,7,Cuchilla de Pawniard
 1855,8,Lama di Pawniard
+1855,9,Pawniard Blade
+1855,11,コマタナのやいば
 1855,12,驹刀小兵的刀
 1856,1,ワシボンのはね
+1856,3,수리둥보의깃털
 1856,4,毛頭小鷹的羽毛
 1856,5,Plume de Furaiglon
-1856,9,Rufflet Feather
-1856,11,ワシボンのはね
-1856,3,수리둥보의깃털
 1856,6,Geronimatz-Feder
 1856,7,Pluma de Rufflet
 1856,8,Penna di Rufflet
+1856,9,Rufflet Feather
+1856,11,ワシボンのはね
 1856,12,毛头小鹰的羽毛
 1857,1,モノズのウロコ
+1857,3,모노두의비늘
 1857,4,單首龍的鱗片
 1857,5,Écaille de Solochi
-1857,9,Deino Scales
-1857,11,モノズのウロコ
-1857,3,모노두의비늘
 1857,6,Kapuno-Schuppe
 1857,7,Escama de Deino
 1857,8,Squama di Deino
+1857,9,Deino Scales
+1857,11,モノズのウロコ
 1857,12,单首龙的鳞片
 1858,1,メラルバのけ
+1858,3,활화르바의털
 1858,4,燃燒蟲的毛
 1858,5,Poils de Pyronille
-1858,9,Larvesta Fuzz
-1858,11,メラルバのけ
-1858,3,활화르바의털
 1858,6,Ignivor-Haar
 1858,7,Pelo de Larvesta
 1858,8,Pelo di Larvesta
+1858,9,Larvesta Fuzz
+1858,11,メラルバのけ
 1858,12,燃烧虫的毛
 1859,1,ヤヤコマのはね
+1859,3,화살꼬빈의깃털
 1859,4,小箭雀的羽毛
 1859,5,Plume de Passerouge
-1859,9,Fletchling Feather
-1859,11,ヤヤコマのはね
-1859,3,화살꼬빈의깃털
 1859,6,Dartiri-Feder
 1859,7,Pluma de Fletchling
 1859,8,Penna di Fletchling
+1859,9,Fletchling Feather
+1859,11,ヤヤコマのはね
 1859,12,小箭雀的羽毛
 1860,1,コフキムシのこな
+1860,3,분이벌레의가루
 1860,4,粉蝶蟲的粉
 1860,5,Poudre de Lépidonille
-1860,9,Scatterbug Powder
-1860,11,コフキムシのこな
-1860,3,분이벌레의가루
 1860,6,Purmel-Puder
 1860,7,Polvo de Scatterbug
 1860,8,Polvere di Scatterbug
+1860,9,Scatterbug Powder
+1860,11,コフキムシのこな
 1860,12,粉蝶虫的粉
 1861,1,シシコのたてがみ
+1861,3,레오꼬의갈기
 1861,4,小獅獅的鬃毛
 1861,5,Crinière d'Hélionceau
-1861,9,Litleo Tuft
-1861,11,シシコのたてがみ
-1861,3,레오꼬의갈기
 1861,6,Leufeo-Mähnenhaar
 1861,7,Mechón de Litleo
 1861,8,Crine di Litleo
+1861,9,Litleo Tuft
+1861,11,シシコのたてがみ
 1861,12,小狮狮的鬃毛
 1862,1,フラベベのかふん
+1862,3,플라베베의꽃가루
 1862,4,花蓓蓓的花粉
 1862,5,Pollen de Flabébé
-1862,9,Flabébé Pollen
-1862,11,フラベベのかふん
-1862,3,플라베베의꽃가루
 1862,6,Flabébé-Pollen
 1862,7,Polen de Flabébé
 1862,8,Polline di Flabébé
+1862,9,Flabébé Pollen
+1862,11,フラベベのかふん
 1862,12,花蓓蓓的花粉
 1863,1,メェークルのはっぱ
+1863,3,메이클의잎
 1863,4,坐騎小羊的葉片
 1863,5,Feuille de Cabriolaine
-1863,9,Skiddo Leaf
-1863,11,メェークルのはっぱ
-1863,3,메이클의잎
 1863,6,Mähikel-Blatt
 1863,7,Hoja de Skiddo
 1863,8,Foglia di Skiddo
+1863,9,Skiddo Leaf
+1863,11,メェークルのはっぱ
 1863,12,坐骑小羊的叶片
 1864,1,クズモーのもくず
+1864,3,수레기의해초
 1864,4,垃垃藻的碎藻
 1864,5,Algue de Venalgue
-1864,9,Skrelp Kelp
-1864,11,クズモーのもくず
-1864,3,수레기의해초
 1864,6,Algitt-Alge
 1864,7,Alga de Skrelp
 1864,8,Alga di Skrelp
+1864,9,Skrelp Kelp
+1864,11,クズモーのもくず
 1864,12,垃垃藻的碎藻
 1865,1,ウデッポウのハサミ
+1865,3,완철포의집게
 1865,4,鐵臂槍蝦的鉗子
 1865,5,Pince de Flingouste
-1865,9,Clauncher Claw
-1865,11,ウデッポウのハサミ
-1865,3,완철포의집게
 1865,6,Scampisto-Schere
 1865,7,Pinza de Clauncher
 1865,8,Chela di Clauncher
+1865,9,Clauncher Claw
+1865,11,ウデッポウのハサミ
 1865,12,铁臂枪虾的钳子
 1866,1,ルチャブルのうもう
+1866,3,루차불의솜털
 1866,4,摔角鷹人的羽絨
 1866,5,Duvet de Brutalibré
-1866,9,Hawlucha Down
-1866,11,ルチャブルのうもう
-1866,3,루차불의솜털
 1866,6,Resladero-Daune
 1866,7,Plumón de Hawlucha
 1866,8,Piuma di Hawlucha
+1866,9,Hawlucha Down
+1866,11,ルチャブルのうもう
 1866,12,摔角鹰人的羽绒
 1867,1,デデンネのけ
+1867,3,데덴네의털
 1867,4,咚咚鼠的毛
 1867,5,Poils de Dedenne
-1867,9,Dedenne Fur
-1867,11,デデンネのけ
-1867,3,데덴네의털
 1867,6,Dedenne-Haar
 1867,7,Pelo de Dedenne
 1867,8,Pelo di Dedenne
+1867,9,Dedenne Fur
+1867,11,デデンネのけ
 1867,12,咚咚鼠的毛
 1868,1,ヌメラのねんえき
+1868,3,미끄메라의점액
 1868,4,黏黏寶的黏液
 1868,5,Mucus de Mucuscule
-1868,9,Goomy Goo
-1868,11,ヌメラのねんえき
-1868,3,미끄메라의점액
 1868,6,Viscora-Schleim
 1868,7,Secreción de Goomy
 1868,8,Bava di Goomy
+1868,9,Goomy Goo
+1868,11,ヌメラのねんえき
 1868,12,黏黏宝的黏液
 1869,1,クレッフィのかぎ
+1869,3,클레피의열쇠
 1869,4,鑰圈兒的鑰匙
 1869,5,Clé de Trousselin
-1869,9,Klefki Key
-1869,11,クレッフィのかぎ
-1869,3,클레피의열쇠
 1869,6,Clavion-Schlüssel
 1869,7,Llave de Klefki
 1869,8,Chiave di Klefki
+1869,9,Klefki Key
+1869,11,クレッフィのかぎ
 1869,12,钥圈儿的钥匙
 1870,1,カチコールのこおり
+1870,3,꽁어름의얼음
 1870,4,冰寶的冰
 1870,5,Glace de Grelaçon
-1870,9,Bergmite Ice
-1870,11,カチコールのこおり
-1870,3,꽁어름의얼음
 1870,6,Arktip-Eis
 1870,7,Hielo de Bergmite
 1870,8,Ghiaccio di Bergmite
+1870,9,Bergmite Ice
+1870,11,カチコールのこおり
 1870,12,冰宝的冰
 1871,1,オンバットのけ
+1871,3,음뱃의털
 1871,4,嗡蝠的毛
 1871,5,Poils de Sonistrelle
-1871,9,Noibat Fur
-1871,11,オンバットのけ
-1871,3,음뱃의털
 1871,6,eF-eM-Haar
 1871,7,Pelo de Noibat
 1871,8,Pelo di Noibat
+1871,9,Noibat Fur
+1871,11,オンバットのけ
 1871,12,嗡蝠的毛
 1872,1,ヤングースのけ
+1872,3,영구스의털
 1872,4,貓鼬少的毛
 1872,5,Poils de Manglouton
-1872,9,Yungoos Fur
-1872,11,ヤングースのけ
-1872,3,영구스의털
 1872,6,Mangunior-Haar
 1872,7,Pelo de Yungoos
 1872,8,Pelo di Yungoos
+1872,9,Yungoos Fur
+1872,11,ヤングースのけ
 1872,12,猫鼬少的毛
 1873,1,マケンカニのから
+1873,3,오기지게의껍데기
 1873,4,好勝蟹的殼
 1873,5,Carapace de Crabagarre
-1873,9,Crabrawler Shell
-1873,11,マケンカニのから
-1873,3,오기지게의껍데기
 1873,6,Krabbox-Schale
 1873,7,Cáscara de Crabrawler
 1873,8,Carapace di Crabrawler
+1873,9,Crabrawler Shell
+1873,11,マケンカニのから
 1873,12,好胜蟹的壳
 1874,1,オドリドリのはね
+1874,3,춤추새의깃털
 1874,4,花舞鳥的羽毛
 1874,5,Plume de Plumeline
-1874,9,Oricorio Feather
-1874,11,オドリドリのはね
-1874,3,춤추새의깃털
 1874,6,Choreogel-Feder
 1874,7,Pluma de Oricorio
 1874,8,Penna di Oricorio
+1874,9,Oricorio Feather
+1874,11,オドリドリのはね
 1874,12,花舞鸟的羽毛
 1875,1,イワンコのいわ
+1875,3,암멍이의바위
 1875,4,岩狗狗的岩石
 1875,5,Roche de Rocabot
-1875,9,Rockruff Rock
-1875,11,イワンコのいわ
-1875,3,암멍이의바위
 1875,6,Wuffels-Stein
 1875,7,Roca de Rockruff
 1875,8,Roccia di Rockruff
+1875,9,Rockruff Rock
+1875,11,イワンコのいわ
 1875,12,岩狗狗的岩石
 1876,1,ヒドイデのトゲ
+1876,3,시마사리의가시
 1876,4,好壞星的刺
 1876,5,Épine de Vorastérie
-1876,9,Mareanie Spike
-1876,11,ヒドイデのトゲ
-1876,3,시마사리의가시
 1876,6,Garstella-Stachel
 1876,7,Aguijón de Mareanie
 1876,8,Aculeo di Mareanie
+1876,9,Mareanie Spike
+1876,11,ヒドイデのトゲ
 1876,12,好坏星的刺
 1877,1,ドロバンコのどろ
+1877,3,머드나기의진흙
 1877,4,泥驢仔的泥巴
 1877,5,Boue de Tiboudet
-1877,9,Mudbray Mud
-1877,11,ドロバンコのどろ
-1877,3,머드나기의진흙
 1877,6,Pampuli-Schlamm
 1877,7,Lodo de Mudbray
 1877,8,Fango di Mudbray
+1877,9,Mudbray Mud
+1877,11,ドロバンコのどろ
 1877,12,泥驴仔的泥巴
 1878,1,カリキリのはっぱ
+1878,3,짜랑랑의잎
 1878,4,偽螳草的葉片
 1878,5,Feuille de Mimantis
-1878,9,Fomantis Leaf
-1878,11,カリキリのはっぱ
-1878,3,짜랑랑의잎
 1878,6,Imantis-Blatt
 1878,7,Hoja de Fomantis
 1878,8,Foglia di Fomantis
+1878,9,Fomantis Leaf
+1878,11,カリキリのはっぱ
 1878,12,伪螳草的叶片
 1879,1,ヤトウモリのガス
+1879,3,야도뇽의가스
 1879,4,夜盜火蜥的氣體
 1879,5,Gaz de Tritox
-1879,9,Salandit Gas
-1879,11,ヤトウモリのガス
-1879,3,야도뇽의가스
 1879,6,Molunk-Gas
 1879,7,Gas de Salandit
 1879,8,Gas di Salandit
+1879,9,Salandit Gas
+1879,11,ヤトウモリのガス
 1879,12,夜盗火蜥的气体
 1880,1,アマカジのあせ
+1880,3,달콤아의땀
 1880,4,甜竹竹的汗
 1880,5,Sueur de Croquine
-1880,9,Bounsweet Sweat
-1880,11,アマカジのあせ
-1880,3,달콤아의땀
 1880,6,Frubberl-Schweiß
 1880,7,Sudor de Bounsweet
 1880,8,Sudore di Bounsweet
+1880,9,Bounsweet Sweat
+1880,11,アマカジのあせ
 1880,12,甜竹竹的汗
 1881,1,ヤレユータンのけ
+1881,3,하랑우탄의털
 1881,4,智揮猩的毛
 1881,5,Poils de Gouroutan
-1881,9,Oranguru Fur
-1881,11,ヤレユータンのけ
-1881,3,하랑우탄의털
 1881,6,Kommandutan-Haar
 1881,7,Pelo de Oranguru
 1881,8,Pelo di Oranguru
+1881,9,Oranguru Fur
+1881,11,ヤレユータンのけ
 1881,12,智挥猩的毛
 1882,1,ナゲツケサルのけ
+1882,3,내던숭이의털
 1882,4,投擲猴的毛
 1882,5,Poils de Quartermac
-1882,9,Passimian Fur
-1882,11,ナゲツケサルのけ
-1882,3,내던숭이의털
 1882,6,Quartermak-Haar
 1882,7,Pelo de Passimian
 1882,8,Pelo di Passimian
+1882,9,Passimian Fur
+1882,11,ナゲツケサルのけ
 1882,12,投掷猴的毛
 1883,1,スナバァのすな
+1883,3,모래꿍의모래
 1883,4,沙丘娃的沙
 1883,5,Sable de Bacabouh
-1883,9,Sandygast Sand
-1883,11,スナバァのすな
-1883,3,모래꿍의모래
 1883,6,Sankabuh-Sand
 1883,7,Arena de Sandygast
 1883,8,Sabbia di Sandygast
+1883,9,Sandygast Sand
+1883,11,スナバァのすな
 1883,12,沙丘娃的沙
 1884,1,ネッコアラのツメ
+1884,3,자말라의발톱
 1884,4,樹枕尾熊的爪子
 1884,5,Griffe de Dodoala
-1884,9,Komala Claw
-1884,11,ネッコアラのツメ
-1884,3,자말라의발톱
 1884,6,Koalelu-Kralle
 1884,7,Garra de Komala
 1884,8,Artiglio di Komala
+1884,9,Komala Claw
+1884,11,ネッコアラのツメ
 1884,12,树枕尾熊的爪子
 1885,1,ミミッキュのきれはし
+1885,3,따라큐의천조각
 1885,4,謎擬Ｑ的殘片
 1885,5,Tissu de Mimiqui
-1885,9,Mimikyu Scrap
-1885,11,ミミッキュのきれはし
-1885,3,따라큐의천조각
 1885,6,Mimigma-Fetzen
 1885,7,Retal de Mimikyu
 1885,8,Brandello di Mimikyu
+1885,9,Mimikyu Scrap
+1885,11,ミミッキュのきれはし
 1885,12,谜拟丘的残片
 1886,1,ハギギシリのは
+1886,3,치갈기의이빨
 1886,4,磨牙彩皮魚的牙齒
 1886,5,Dent de Denticrisse
-1886,9,Bruxish Tooth
-1886,11,ハギギシリのは
-1886,3,치갈기의이빨
 1886,6,Knirfish-Zahn
 1886,7,Diente de Bruxish
 1886,8,Dente di Bruxish
+1886,9,Bruxish Tooth
+1886,11,ハギギシリのは
 1886,12,磨牙彩皮鱼的牙齿
 1887,1,カムカメのツメ
+1887,3,깨물부기의발톱
 1887,4,咬咬龜的爪子
 1887,5,Griffe de Khélocrok
-1887,9,Chewtle Claw
-1887,11,カムカメのツメ
-1887,3,깨물부기의발톱
 1887,6,Kamehaps-Kralle
 1887,7,Garra de Chewtle
 1887,8,Unghia di Chewtle
+1887,9,Chewtle Claw
+1887,11,カムカメのツメ
 1887,12,咬咬龟的爪子
 1888,1,ホシガリスのけ
+1888,3,탐리스의털
 1888,4,貪心栗鼠的毛
 1888,5,Poils de Rongourmand
-1888,9,Skwovet Fur
-1888,11,ホシガリスのけ
-1888,3,탐리스의털
 1888,6,Raffel-Haar
 1888,7,Pelo de Skwovet
 1888,8,Pelo di Skwovet
+1888,9,Skwovet Fur
+1888,11,ホシガリスのけ
 1888,12,贪心栗鼠的毛
 1889,1,サシカマスのウロコ
+1889,3,찌로꼬치의비늘
 1889,4,刺梭魚的鱗片
 1889,5,Écaille d'Embrochet
-1889,9,Arrokuda Scales
-1889,11,サシカマスのウロコ
-1889,3,찌로꼬치의비늘
 1889,6,Pikuda-Schuppe
 1889,7,Escama de Arrokuda
 1889,8,Squama di Arrokuda
+1889,9,Arrokuda Scales
+1889,11,サシカマスのウロコ
 1889,12,刺梭鱼的鳞片
 1890,1,ココガラのはね
+1890,3,파라꼬의깃털
 1890,4,稚山雀的羽毛
 1890,5,Plume de Minisange
-1890,9,Rookidee Feather
-1890,11,ココガラのはね
-1890,3,파라꼬의깃털
 1890,6,Meikro-Feder
 1890,7,Pluma de Rookidee
 1890,8,Penna di Rookidee
+1890,9,Rookidee Feather
+1890,11,ココガラのはね
 1890,12,稚山雀的羽毛
 1891,1,エレズンのでんき
+1891,3,일레즌의전기
 1891,4,毒電嬰的電力
 1891,5,Électricité de Toxizap
-1891,9,Toxel Sparks
-1891,11,エレズンのでんき
-1891,3,일레즌의전기
 1891,6,Toxel-Strom
 1891,7,Electricidad de Toxel
 1891,8,Elettricità di Toxel
+1891,9,Toxel Sparks
+1891,11,エレズンのでんき
 1891,12,电音婴的电力
 1892,1,タイレーツのあせ
+1892,3,대여르의땀
 1892,4,列陣兵的汗
 1892,5,Sueur d'Hexadron
-1892,9,Falinks Sweat
-1892,11,タイレーツのあせ
-1892,3,대여르의땀
 1892,6,Legios-Schweiß
 1892,7,Sudor de Falinks
 1892,8,Sudore di Falinks
+1892,9,Falinks Sweat
+1892,11,タイレーツのあせ
 1892,12,列阵兵的汗
 1893,1,ゾウドウのさび
+1893,3,끼리동의녹
 1893,4,銅象的鏽
 1893,5,Rouille de Charibari
-1893,9,Cufant Tarnish
-1893,11,ゾウドウのさび
-1893,3,끼리동의녹
 1893,6,Kupfanti-Patina
 1893,7,Óxido de Cufant
 1893,8,Ruggine di Cufant
+1893,9,Cufant Tarnish
+1893,11,ゾウドウのさび
 1893,12,铜象的锈
 1894,1,タンドンのせきたん
+1894,3,탄동의석탄
 1894,4,小炭仔的煤炭
 1894,5,Charbon de Charbi
-1894,9,Rolycoly Coal
-1894,11,タンドンのせきたん
-1894,3,탄동의석탄
 1894,6,Klonkett-Kohle
 1894,7,Carbón de Rolycoly
 1894,8,Carbone di Rolycoly
+1894,9,Rolycoly Coal
+1894,11,タンドンのせきたん
 1894,12,小炭仔的煤炭
 1895,1,スナヘビのすな
+1895,3,모래뱀의모래
 1895,4,沙包蛇的沙
 1895,5,Sable de Dunaja
-1895,9,Silicobra Sand
-1895,11,スナヘビのすな
-1895,3,모래뱀의모래
 1895,6,Salanga-Sand
 1895,7,Arena de Silicobra
 1895,8,Sabbia di Silicobra
+1895,9,Silicobra Sand
+1895,11,スナヘビのすな
 1895,12,沙包蛇的沙
 1896,1,イエッサンのけ
+1896,3,에써르의털
 1896,4,愛管侍的毛
 1896,5,Poils de Wimessir
-1896,9,Indeedee Fur
-1896,11,イエッサンのけ
-1896,3,에써르의털
 1896,6,Servol-Haar
 1896,7,Pelo de Indeedee
 1896,8,Pelo di Indeedee
+1896,9,Indeedee Fur
+1896,11,イエッサンのけ
 1896,12,爱管侍的毛
 1897,1,バチンウニのはり
+1897,3,찌르성게의가시
 1897,4,啪嚓海膽的針
 1897,5,Épine de Wattapik
-1897,9,Pincurchin Spines
-1897,11,バチンウニのはり
-1897,3,찌르성게의가시
 1897,6,Britzigel-Stachel
 1897,7,Púa de Pincurchin
 1897,8,Aculeo di Pincurchin
+1897,9,Pincurchin Spines
+1897,11,バチンウニのはり
 1897,12,啪嚓海胆的针
 1898,1,ユキハミのいと
+1898,3,누니머기의실
 1898,4,雪吞蟲的絲
 1898,5,Fil de Frissonille
-1898,9,Snom Thread
-1898,11,ユキハミのいと
-1898,3,누니머기의실
 1898,6,Snomnom-Faden
 1898,7,Hilo de Snom
 1898,8,Filo di Snom
+1898,9,Snom Thread
+1898,11,ユキハミのいと
 1898,12,雪吞虫的丝
 1899,1,ベロバーのけ
+1899,3,메롱꿍의털
 1899,4,搗蛋小妖的毛
 1899,5,Poils de Grimalin
-1899,9,Impidimp Hair
-1899,11,ベロバーのけ
-1899,3,메롱꿍의털
 1899,6,Bähmon-Haar
 1899,7,Pelo de Impidimp
 1899,8,Pelo di Impidimp
+1899,9,Impidimp Hair
+1899,11,ベロバーのけ
 1899,12,捣蛋小妖的毛
 1900,1,カジッチュのかじゅう
+1900,3,과사삭벌레의과즙
 1900,4,啃果蟲的果汁
 1900,5,Jus de Verpom
-1900,9,Applin Juice
-1900,11,カジッチュのかじゅう
-1900,3,과사삭벌레의과즙
 1900,6,Knapfel-Fruchtsaft
 1900,7,Zumo de Applin
 1900,8,Succo di Applin
+1900,9,Applin Juice
+1900,11,カジッチュのかじゅう
 1900,12,啃果虫的果汁
 1901,1,ヤバチャのかけら
+1901,3,데인차의조각
 1901,4,來悲茶的碎片
 1901,5,Fragment de Théffroi
-1901,9,Sinistea Chip
-1901,11,ヤバチャのかけら
-1901,3,데인차의조각
 1901,6,Fatalitee-Splitter
 1901,7,Fragmento de Sinistea
 1901,8,Coccio di Sinistea
+1901,9,Sinistea Chip
+1901,11,ヤバチャのかけら
 1901,12,来悲茶的碎片
 1902,1,ミブリムのおとしもの
+1902,3,몸지브림의유실물
 1902,4,迷布莉姆的掉落物
 1902,5,Babiole de Bibichut
-1902,9,Hatenna Dust
-1902,11,ミブリムのおとしもの
-1902,3,몸지브림의유실물
 1902,6,Brimova-Material
 1902,7,Pertenencia de Hatenna
 1902,8,Oggetto di Hatenna
+1902,9,Hatenna Dust
+1902,11,ミブリムのおとしもの
 1902,12,迷布莉姆的掉落物
 1903,1,イシヘンジンのいわ
+1903,3,돌헨진의바위
 1903,4,巨石丁的岩石
 1903,5,Roche de Dolman
-1903,9,Stonjourner Stone
-1903,11,イシヘンジンのいわ
-1903,3,돌헨진의바위
 1903,6,Humanolith-Stein
 1903,7,Roca de Stonjourner
 1903,8,Roccia di Stonjourner
+1903,9,Stonjourner Stone
+1903,11,イシヘンジンのいわ
 1903,12,巨石丁的岩石
 1904,1,コオリッポのうもう
+1904,3,빙큐보의솜털
 1904,4,冰砌鵝的羽絨
 1904,5,Duvet de Bekaglaçon
-1904,9,Eiscue Down
-1904,11,コオリッポのうもう
-1904,3,빙큐보의솜털
 1904,6,Kubuin-Daune
 1904,7,Plumón de Eiscue
 1904,8,Piuma di Eiscue
+1904,9,Eiscue Down
+1904,11,コオリッポのうもう
 1904,12,冰砌鹅的羽绒
 1905,1,ドラメシヤのこな
+1905,3,드라꼰의가루
 1905,4,多龍梅西亞的粉
 1905,5,Poudre de Fantyrm
-1905,9,Dreepy Powder
-1905,11,ドラメシヤのこな
-1905,3,드라꼰의가루
 1905,6,Grolldra-Puder
 1905,7,Polvo de Dreepy
 1905,8,Polvere di Dreepy
+1905,9,Dreepy Powder
+1905,11,ドラメシヤのこな
 1905,12,多龙梅西亚的粉
 1906,1,グルトンのけ
+1906,3,맛보돈의털
 1906,4,愛吃豚的毛
 1906,5,Poils de Gourmelet
-1906,9,Lechonk Hair
-1906,11,グルトンのけ
-1906,3,맛보돈의털
 1906,6,Ferkuli-Haar
 1906,7,Pelo de Lechonk
 1906,8,Pelo di Lechonk
+1906,9,Lechonk Hair
+1906,11,グルトンのけ
 1906,12,爱吃豚的毛
 1907,1,タマンチュラのいと
+1907,3,타랜툴라의실
 1907,4,團珠蛛的絲
 1907,5,Fil de Tissenboule
-1907,9,Tarountula Thread
-1907,11,タマンチュラのいと
-1907,3,타랜툴라의실
 1907,6,Tarundel-Faden
 1907,7,Hilo de Tarountula
 1907,8,Filo di Tarountula
+1907,9,Tarountula Thread
+1907,11,タマンチュラのいと
 1907,12,团珠蛛的丝
 1908,1,マメバッタのツメ
+1908,3,콩알뚜기의발톱
 1908,4,豆蟋蟀的爪子
 1908,5,Griffe de Lilliterelle
-1908,9,Nymble Claw
-1908,11,マメバッタのツメ
-1908,3,콩알뚜기의발톱
 1908,6,Micrick-Kralle
 1908,7,Garra de Nymble
 1908,8,Artiglio di Nymble
+1908,9,Nymble Claw
+1908,11,マメバッタのツメ
 1908,12,豆蟋蟀的爪子
 1909,1,シガロコのどろ
+1909,3,구르데의진흙
 1909,4,蟲滾泥的泥巴
 1909,5,Boue de Léboulérou
-1909,9,Rellor Mud
-1909,11,シガロコのどろ
-1909,3,구르데의진흙
 1909,6,Relluk-Schlamm
 1909,7,Barro de Rellor
 1909,8,Fango di Rellor
+1909,9,Rellor Mud
+1909,11,シガロコのどろ
 1909,12,虫滚泥的泥巴
 1910,1,ボチのろう
+1910,3,망망이의촛농
 1910,4,墓仔狗的蠟
 1910,5,Cire de Toutombe
-1910,9,Greavard Wax
-1910,11,ボチのろう
-1910,3,망망이의촛농
 1910,6,Gruff-Wachs
 1910,7,Cera de Greavard
 1910,8,Cera di Greavard
+1910,9,Greavard Wax
+1910,11,ボチのろう
 1910,12,墓仔狗的蜡
 1911,1,ヒラヒナのうもう
+1911,3,하느라기의솜털
 1911,4,飄飄雛的羽絨
 1911,5,Duvet de Flotillon
-1911,9,Flittle Down
-1911,11,ヒラヒナのうもう
-1911,3,하느라기의솜털
 1911,6,Flattutu-Daune
 1911,7,Plumón de Flittle
 1911,8,Piuma di Flittle
+1911,9,Flittle Down
+1911,11,ヒラヒナのうもう
 1911,12,飘飘雏的羽绒
 1912,1,ウミディグダのすな
+1912,3,바다그다의모래
 1912,4,海地鼠的沙
 1912,5,Sable de Taupikeau
-1912,9,Wiglett Sand
-1912,11,ウミディグダのすな
-1912,3,바다그다의모래
 1912,6,Schligda-Sand
 1912,7,Arena de Wiglett
 1912,8,Sabbia di Wiglett
+1912,9,Wiglett Sand
+1912,11,ウミディグダのすな
 1912,12,海地鼠的沙
 1913,1,ヘイラッシャのヒゲ
+1913,3,어써러셔의수염
 1913,4,吃吼霸的鬍鬚
 1913,5,Barbillon d'Oyacata
-1913,9,Dondozo Whisker
-1913,11,ヘイラッシャのヒゲ
-1913,3,어써러셔의수염
 1913,6,Heerashai-Bartel
 1913,7,Bigote de Dondozo
 1913,8,Barbiglio di Dondozo
+1913,9,Dondozo Whisker
+1913,11,ヘイラッシャのヒゲ
 1913,12,吃吼霸的胡须
 1914,1,ミガルーサのきりみ
+1914,3,가비루사의토막
 1914,4,輕身鱈的魚片
 1914,5,Chair de Délestin
-1914,9,Veluza Fillet
-1914,11,ミガルーサのきりみ
-1914,3,가비루사의토막
 1914,6,Agiluza-Filet
 1914,7,Carne de Veluza
 1914,8,Filetto di Veluza
+1914,9,Veluza Fillet
+1914,11,ミガルーサのきりみ
 1914,12,轻身鳕的鱼片
 1915,1,ナミイルカのねんえき
+1915,3,맨돌핀의점액
 1915,4,波普海豚的黏液
 1915,5,Mucus de Dofin
-1915,9,Finizen Mucus
-1915,11,ナミイルカのねんえき
-1915,3,맨돌핀의점액
 1915,6,Normifin-Schleim
 1915,7,Secreción de Finizen
 1915,8,Muco di Finizen
+1915,9,Finizen Mucus
+1915,11,ナミイルカのねんえき
 1915,12,波普海豚的黏液
 1916,1,ミニーブのオイル
+1916,3,미니브의오일
 1916,4,迷你芙的油
 1916,5,Huile d'Olivini
-1916,9,Smoliv Oil
-1916,11,ミニーブのオイル
-1916,3,미니브의오일
 1916,6,Olini-Öl
 1916,7,Aceite de Smoliv
 1916,8,Olio di Smoliv
+1916,9,Smoliv Oil
+1916,11,ミニーブのオイル
 1916,12,迷你芙的油
 1917,1,カプサイジのたね
+1917,3,캡싸이의씨앗
 1917,4,熱辣娃的種子
 1917,5,Graine de Pimito
-1917,9,Capsakid Seed
-1917,11,カプサイジのたね
-1917,3,캡싸이의씨앗
 1917,6,Chilingel-Samen
 1917,7,Semilla de Capsakid
 1917,8,Seme di Capsakid
+1917,9,Capsakid Seed
+1917,11,カプサイジのたね
 1917,12,热辣娃的种子
 1918,1,ズピカのねんえき
+1918,3,빈나두의점액
 1918,4,光蚪仔的黏液
 1918,5,Mucus de Têtampoule
-1918,9,Tadbulb Mucus
-1918,11,ズピカのねんえき
-1918,3,빈나두의점액
 1918,6,Blipp-Schleim
 1918,7,Secreción de Tadbulb
 1918,8,Muco di Tadbulb
+1918,9,Tadbulb Mucus
+1918,11,ズピカのねんえき
 1918,12,光蚪仔的黏液
 1919,1,ブロロンのガス
+1919,3,부르롱의가스
 1919,4,噗隆隆的氣體
 1919,5,Gaz de Vrombi
-1919,9,Varoom Fume
-1919,11,ブロロンのガス
-1919,3,부르롱의가스
 1919,6,Knattox-Gas
 1919,7,Gas de Varoom
 1919,8,Gas di Varoom
+1919,9,Varoom Fume
+1919,11,ブロロンのガス
 1919,12,噗隆隆的气体
 1920,1,ミミズズのさび
+1920,3,꿈트렁의녹
 1920,4,拖拖蚓的鏽
 1920,5,Rouille de Ferdeter
-1920,9,Orthworm Tarnish
-1920,11,ミミズズのさび
-1920,3,꿈트렁의녹
 1920,6,Schlurm-Patina
 1920,7,Óxido de Orthworm
 1920,8,Ruggine di Orthworm
+1920,9,Orthworm Tarnish
+1920,11,ミミズズのさび
 1920,12,拖拖蚓的锈
 1921,1,ワッカネズミのけ
+1921,3,두리쥐의털
 1921,4,一對鼠的毛
 1921,5,Poils de Compagnol
-1921,9,Tandemaus Fur
-1921,11,ワッカネズミのけ
-1921,3,두리쥐의털
 1921,6,Zwieps-Haar
 1921,7,Pelo de Tandemaus
 1921,8,Pelo di Tandemaus
+1921,9,Tandemaus Fur
+1921,11,ワッカネズミのけ
 1921,12,一对鼠的毛
 1922,1,アルクジラのあぶら
+1922,3,터벅고래의기름
 1922,4,走鯨的油脂
 1922,5,Graisse de Piétacé
-1922,9,Cetoddle Grease
-1922,11,アルクジラのあぶら
-1922,3,터벅고래의기름
 1922,6,Flaniwal-Fett
 1922,7,Grasa de Cetoddle
 1922,8,Grasso di Cetoddle
+1922,9,Cetoddle Grease
+1922,11,アルクジラのあぶら
 1922,12,走鲸的油脂
 1923,1,セビエのウロコ
+1923,3,드니차의비늘
 1923,4,涼脊龍的鱗片
 1923,5,Écaille de Frigodo
-1923,9,Frigibax Scales
-1923,11,セビエのウロコ
-1923,3,드니차의비늘
 1923,6,Frospino-Schuppe
 1923,7,Escama de Frigibax
 1923,8,Squama di Frigibax
+1923,9,Frigibax Scales
+1923,11,セビエのウロコ
 1923,12,凉脊龙的鳞片
 1924,1,シャリタツのウロコ
+1924,3,싸리용의비늘
 1924,4,米立龍的鱗片
 1924,5,Écaille de Nigirigon
-1924,9,Tatsugiri Scales
-1924,11,シャリタツのウロコ
-1924,3,싸리용의비늘
 1924,6,Nigiragi-Schuppe
 1924,7,Escama de Tatsugiri
 1924,8,Squama di Tatsugiri
+1924,9,Tatsugiri Scales
+1924,11,シャリタツのウロコ
 1924,12,米立龙的鳞片
 1925,1,モトトカゲのウロコ
+1925,3,모토마의비늘
 1925,4,摩托蜥的鱗片
 1925,5,Écaille de Motorizard
-1925,9,Cyclizar Scales
-1925,11,モトトカゲのウロコ
-1925,3,모토마의비늘
 1925,6,Mopex-Schuppe
 1925,7,Escama de Cyclizar
 1925,8,Squama di Cyclizar
+1925,9,Cyclizar Scales
+1925,11,モトトカゲのウロコ
 1925,12,摩托蜥的鳞片
 1926,1,パモのけ
+1926,3,빠모의털
 1926,4,布撥的毛
 1926,5,Poils de Pohm
-1926,9,Pawmi Fur
-1926,11,パモのけ
-1926,3,빠모의털
 1926,6,Pamo-Haar
 1926,7,Pelo de Pawmi
 1926,8,Pelo di Pawmi
+1926,9,Pawmi Fur
+1926,11,パモのけ
 1926,12,布拨的毛
 1927,1,カイデンのはね
+1927,3,찌리비의깃털
 1927,4,電海燕的羽毛
 1927,5,Plume de Zapétrel
-1927,9,Wattrel Feather
-1927,11,カイデンのはね
-1927,3,찌리비의깃털
 1927,6,Voltrel-Feder
 1927,7,Pluma de Wattrel
 1927,8,Penna di Wattrel
+1927,9,Wattrel Feather
+1927,11,カイデンのはね
 1927,12,电海燕的羽毛
 1928,1,オトシドリのはね
+1928,3,떨구새의깃털
 1928,4,下石鳥的羽毛
 1928,5,Plume de Lestombaile
-1928,9,Bombirdier Feather
-1928,11,オトシドリのはね
-1928,3,떨구새의깃털
 1928,6,Adebom-Feder
 1928,7,Pluma de Bombirdier
 1928,8,Penna di Bombirdier
+1928,9,Bombirdier Feather
+1928,11,オトシドリのはね
 1928,12,下石鸟的羽毛
 1929,1,イキリンコのはね
+1929,3,시비꼬의깃털
 1929,4,怒鸚哥的羽毛
 1929,5,Plume de Tapatoès
-1929,9,Squawkabilly Feather
-1929,11,イキリンコのはね
-1929,3,시비꼬의깃털
 1929,6,Krawalloro-Feder
 1929,7,Pluma de Squawkabilly
 1929,8,Penna di Squawkabilly
+1929,9,Squawkabilly Feather
+1929,11,イキリンコのはね
 1929,12,怒鹦哥的羽毛
 1930,1,カラミンゴのうもう
+1930,3,꼬이밍고의솜털
 1930,4,纏紅鶴的羽絨
 1930,5,Duvet de Flamenroule
-1930,9,Flamigo Down
-1930,11,カラミンゴのうもう
-1930,3,꼬이밍고의솜털
 1930,6,Flaminkno-Daune
 1930,7,Plumón de Flamigo
 1930,8,Piuma di Flamigo
+1930,9,Flamigo Down
+1930,11,カラミンゴのうもう
 1930,12,缠红鹤的羽绒
 1931,1,ガケガニのハサミ
+1931,3,절벼게의집게
 1931,4,毛崖蟹的鉗子
 1931,5,Pince de Craparoi
-1931,9,Klawf Claw
-1931,11,ガケガニのハサミ
-1931,3,절벼게의집게
 1931,6,Klibbe-Schere
 1931,7,Pinza de Klawf
 1931,8,Chela di Klawf
+1931,9,Klawf Claw
+1931,11,ガケガニのハサミ
 1931,12,毛崖蟹的钳子
 1932,1,コジオのしお
+1932,3,베베솔트의소금
 1932,4,鹽石寶的鹽
 1932,5,Sel de Selutin
-1932,9,Nacli Salt
-1932,11,コジオのしお
-1932,3,베베솔트의소금
 1932,6,Geosali-Salz
 1932,7,Sal de Nacli
 1932,8,Sale di Nacli
+1932,9,Nacli Salt
+1932,11,コジオのしお
 1932,12,盐石宝的盐
 1933,1,キラーメのけっしょう
+1933,3,초롱순의결정
 1933,4,晶光芽的結晶
 1933,5,Cristal de Germéclat
-1933,9,Glimmet Crystal
-1933,11,キラーメのけっしょう
-1933,3,초롱순의결정
 1933,6,Lumispross-Kristall
 1933,7,Cristal de Glimmet
 1933,8,Cristallo di Glimmet
+1933,9,Glimmet Crystal
+1933,11,キラーメのけっしょう
 1933,12,晶光芽的结晶
 1934,1,シルシュルーのインク
+1934,3,땃쭈르의잉크
 1934,4,滋汁鼴的墨汁
 1934,5,Encre de Gribouraigne
-1934,9,Shroodle Ink
-1934,11,シルシュルーのインク
-1934,3,땃쭈르의잉크
 1934,6,Sproxi-Tinte
 1934,7,Tinta de Shroodle
 1934,8,Inchiostro di Shroodle
+1934,9,Shroodle Ink
+1934,11,シルシュルーのインク
 1934,12,滋汁鼹的墨汁
 1935,1,パピモッチのけ
+1935,3,쫀도기의털
 1935,4,狗仔包的毛
 1935,5,Poils de Pâtachiot
-1935,9,Fidough Fur
-1935,11,パピモッチのけ
-1935,3,쫀도기의털
 1935,6,Hefel-Haar
 1935,7,Pelo de Fidough
 1935,8,Pelo di Fidough
+1935,9,Fidough Fur
+1935,11,パピモッチのけ
 1935,12,狗仔包的毛
 1936,1,オラチフのキバ
+1936,3,오라티프의이빨
 1936,4,偶叫獒的牙
 1936,5,Croc de Grondogue
-1936,9,Maschiff Fang
-1936,11,オラチフのキバ
-1936,3,오라티프의이빨
 1936,6,Mobtiff-Zahn
 1936,7,Colmillo de Maschiff
 1936,8,Zanna di Maschiff
+1936,9,Maschiff Fang
+1936,11,オラチフのキバ
 1936,12,偶叫獒的牙
 1937,1,アノクサのえだ
+1937,3,그푸리의가지
 1937,4,納噬草的枝條
 1937,5,Branche de Virovent
-1937,9,Bramblin Twig
-1937,11,アノクサのえだ
-1937,3,그푸리의가지
 1937,6,Weherba-Zweig
 1937,7,Rama de Bramblin
 1937,8,Ramoscello di Bramblin
+1937,9,Bramblin Twig
+1937,11,アノクサのえだ
 1937,12,纳噬草的枝条
 1938,1,コレクレーのコイン
+1938,3,모으령의코인
 1938,4,索財靈的硬幣
 1938,5,Pièce de Mordudor
-1938,9,Gimmighoul Coin
-1938,11,コレクレーのコイン
-1938,3,모으령의코인
 1938,6,Gierspenst-Münze
 1938,7,Moneda de Gimmighoul
 1938,8,Moneta di Gimmighoul
+1938,9,Gimmighoul Coin
+1938,11,コレクレーのコイン
 1938,12,索财灵的硬币
 1939,1,カヌチャンのけ
+1939,3,어리짱의털
 1939,4,小鍛匠的毛
 1939,5,Poils de Forgerette
-1939,9,Tinkatink Hair
-1939,11,カヌチャンのけ
-1939,3,어리짱의털
 1939,6,Forgita-Haar
 1939,7,Pelo de Tinkatink
 1939,8,Pelo di Tinkatink
+1939,9,Tinkatink Hair
+1939,11,カヌチャンのけ
 1939,12,小锻匠的毛
 1940,1,カルボウのすす
+1940,3,카르본의검댕
 1940,4,炭小侍的煤灰
 1940,5,Suie de Charbambin
-1940,9,Charcadet Soot
-1940,11,カルボウのすす
-1940,3,카르본의검댕
 1940,6,Knarbon-Ruß
 1940,7,Hollín de Charcadet
 1940,8,Fuliggine di Charcadet
+1940,9,Charcadet Soot
+1940,11,カルボウのすす
 1940,12,炭小侍的煤灰
 1941,1,ノノクラゲのヒラヒラ
+1941,3,들눈해의갓
 1941,4,原野水母的薄片
 1941,5,Membrane de Tentacool
-1941,9,Toedscool Flaps
-1941,11,ノノクラゲのヒラヒラ
-1941,3,들눈해의갓
 1941,6,Tentagra-Lamelle
 1941,7,Pliegue de Toedscool
 1941,8,Pieghe di Toedscool
+1941,9,Toedscool Flaps
+1941,11,ノノクラゲのヒラヒラ
 1941,12,原野水母的薄片
 1942,1,ウパーのねんえき
+1942,3,우파의점액
 1942,4,烏波的黏液
 1942,5,Mucus d'Axoloto
-1942,9,Wooper Slime
-1942,11,ウパーのねんえき
-1942,3,우파의점액
 1942,6,Felino-Schleim
 1942,7,Secreción de Wooper
 1942,8,Muco di Wooper
+1942,9,Wooper Slime
+1942,11,ウパーのねんえき
 1942,12,乌波的黏液
 1944,1,わざマシン１０１
+1944,3,기술머신101
 1944,4,招式學習器１０１
 1944,5,CT101
-1944,9,TM101
-1944,11,わざマシン１０１
-1944,3,기술머신101
 1944,6,TM101
 1944,7,MT101
 1944,8,MT101
+1944,9,TM101
+1944,11,わざマシン１０１
 1944,12,招式学习器１０１
 1945,1,わざマシン１０２
+1945,3,기술머신102
 1945,4,招式學習器１０２
 1945,5,CT102
-1945,9,TM102
-1945,11,わざマシン１０２
-1945,3,기술머신102
 1945,6,TM102
 1945,7,MT102
 1945,8,MT102
+1945,9,TM102
+1945,11,わざマシン１０２
 1945,12,招式学习器１０２
 1946,1,わざマシン１０３
+1946,3,기술머신103
 1946,4,招式學習器１０３
 1946,5,CT103
-1946,9,TM103
-1946,11,わざマシン１０３
-1946,3,기술머신103
 1946,6,TM103
 1946,7,MT103
 1946,8,MT103
+1946,9,TM103
+1946,11,わざマシン１０３
 1946,12,招式学习器１０３
 1947,1,わざマシン１０４
+1947,3,기술머신104
 1947,4,招式學習器１０４
 1947,5,CT104
-1947,9,TM104
-1947,11,わざマシン１０４
-1947,3,기술머신104
 1947,6,TM104
 1947,7,MT104
 1947,8,MT104
+1947,9,TM104
+1947,11,わざマシン１０４
 1947,12,招式学习器１０４
 1948,1,わざマシン１０５
+1948,3,기술머신105
 1948,4,招式學習器１０５
 1948,5,CT105
-1948,9,TM105
-1948,11,わざマシン１０５
-1948,3,기술머신105
 1948,6,TM105
 1948,7,MT105
 1948,8,MT105
+1948,9,TM105
+1948,11,わざマシン１０５
 1948,12,招式学习器１０５
 1949,1,わざマシン１０６
+1949,3,기술머신106
 1949,4,招式學習器１０６
 1949,5,CT106
-1949,9,TM106
-1949,11,わざマシン１０６
-1949,3,기술머신106
 1949,6,TM106
 1949,7,MT106
 1949,8,MT106
+1949,9,TM106
+1949,11,わざマシン１０６
 1949,12,招式学习器１０６
 1950,1,わざマシン１０７
+1950,3,기술머신107
 1950,4,招式學習器１０７
 1950,5,CT107
-1950,9,TM107
-1950,11,わざマシン１０７
-1950,3,기술머신107
 1950,6,TM107
 1950,7,MT107
 1950,8,MT107
+1950,9,TM107
+1950,11,わざマシン１０７
 1950,12,招式学习器１０７
 1951,1,わざマシン１０８
+1951,3,기술머신108
 1951,4,招式學習器１０８
 1951,5,CT108
-1951,9,TM108
-1951,11,わざマシン１０８
-1951,3,기술머신108
 1951,6,TM108
 1951,7,MT108
 1951,8,MT108
+1951,9,TM108
+1951,11,わざマシン１０８
 1951,12,招式学习器１０８
 1952,1,わざマシン１０９
+1952,3,기술머신109
 1952,4,招式學習器１０９
 1952,5,CT109
-1952,9,TM109
-1952,11,わざマシン１０９
-1952,3,기술머신109
 1952,6,TM109
 1952,7,MT109
 1952,8,MT109
+1952,9,TM109
+1952,11,わざマシン１０９
 1952,12,招式学习器１０９
 1953,1,わざマシン１１０
+1953,3,기술머신110
 1953,4,招式學習器１１０
 1953,5,CT110
-1953,9,TM110
-1953,11,わざマシン１１０
-1953,3,기술머신110
 1953,6,TM110
 1953,7,MT110
 1953,8,MT110
+1953,9,TM110
+1953,11,わざマシン１１０
 1953,12,招式学习器１１０
 1954,1,わざマシン１１１
+1954,3,기술머신111
 1954,4,招式學習器１１１
 1954,5,CT111
-1954,9,TM111
-1954,11,わざマシン１１１
-1954,3,기술머신111
 1954,6,TM111
 1954,7,MT111
 1954,8,MT111
+1954,9,TM111
+1954,11,わざマシン１１１
 1954,12,招式学习器１１１
 1955,1,わざマシン１１２
+1955,3,기술머신112
 1955,4,招式學習器１１２
 1955,5,CT112
-1955,9,TM112
-1955,11,わざマシン１１２
-1955,3,기술머신112
 1955,6,TM112
 1955,7,MT112
 1955,8,MT112
+1955,9,TM112
+1955,11,わざマシン１１２
 1955,12,招式学习器１１２
 1956,1,わざマシン１１３
+1956,3,기술머신113
 1956,4,招式學習器１１３
 1956,5,CT113
-1956,9,TM113
-1956,11,わざマシン１１３
-1956,3,기술머신113
 1956,6,TM113
 1956,7,MT113
 1956,8,MT113
+1956,9,TM113
+1956,11,わざマシン１１３
 1956,12,招式学习器１１３
 1957,1,わざマシン１１４
+1957,3,기술머신114
 1957,4,招式學習器１１４
 1957,5,CT114
-1957,9,TM114
-1957,11,わざマシン１１４
-1957,3,기술머신114
 1957,6,TM114
 1957,7,MT114
 1957,8,MT114
+1957,9,TM114
+1957,11,わざマシン１１４
 1957,12,招式学习器１１４
 1958,1,わざマシン１１５
+1958,3,기술머신115
 1958,4,招式學習器１１５
 1958,5,CT115
-1958,9,TM115
-1958,11,わざマシン１１５
-1958,3,기술머신115
 1958,6,TM115
 1958,7,MT115
 1958,8,MT115
+1958,9,TM115
+1958,11,わざマシン１１５
 1958,12,招式学习器１１５
 1959,1,わざマシン１１６
+1959,3,기술머신116
 1959,4,招式學習器１１６
 1959,5,CT116
-1959,9,TM116
-1959,11,わざマシン１１６
-1959,3,기술머신116
 1959,6,TM116
 1959,7,MT116
 1959,8,MT116
+1959,9,TM116
+1959,11,わざマシン１１６
 1959,12,招式学习器１１６
 1960,1,わざマシン１１７
+1960,3,기술머신117
 1960,4,招式學習器１１７
 1960,5,CT117
-1960,9,TM117
-1960,11,わざマシン１１７
-1960,3,기술머신117
 1960,6,TM117
 1960,7,MT117
 1960,8,MT117
+1960,9,TM117
+1960,11,わざマシン１１７
 1960,12,招式学习器１１７
 1961,1,わざマシン１１８
+1961,3,기술머신118
 1961,4,招式學習器１１８
 1961,5,CT118
-1961,9,TM118
-1961,11,わざマシン１１８
-1961,3,기술머신118
 1961,6,TM118
 1961,7,MT118
 1961,8,MT118
+1961,9,TM118
+1961,11,わざマシン１１８
 1961,12,招式学习器１１８
 1962,1,わざマシン１１９
+1962,3,기술머신119
 1962,4,招式學習器１１９
 1962,5,CT119
-1962,9,TM119
-1962,11,わざマシン１１９
-1962,3,기술머신119
 1962,6,TM119
 1962,7,MT119
 1962,8,MT119
+1962,9,TM119
+1962,11,わざマシン１１９
 1962,12,招式学习器１１９
 1963,1,わざマシン１２０
+1963,3,기술머신120
 1963,4,招式學習器１２０
 1963,5,CT120
-1963,9,TM120
-1963,11,わざマシン１２０
-1963,3,기술머신120
 1963,6,TM120
 1963,7,MT120
 1963,8,MT120
+1963,9,TM120
+1963,11,わざマシン１２０
 1963,12,招式学习器１２０
 1964,1,わざマシン１２１
+1964,3,기술머신121
 1964,4,招式學習器１２１
 1964,5,CT121
-1964,9,TM121
-1964,11,わざマシン１２１
-1964,3,기술머신121
 1964,6,TM121
 1964,7,MT121
 1964,8,MT121
+1964,9,TM121
+1964,11,わざマシン１２１
 1964,12,招式学习器１２１
 1965,1,わざマシン１２２
+1965,3,기술머신122
 1965,4,招式學習器１２２
 1965,5,CT122
-1965,9,TM122
-1965,11,わざマシン１２２
-1965,3,기술머신122
 1965,6,TM122
 1965,7,MT122
 1965,8,MT122
+1965,9,TM122
+1965,11,わざマシン１２２
 1965,12,招式学习器１２２
 1966,1,わざマシン１２３
+1966,3,기술머신123
 1966,4,招式學習器１２３
 1966,5,CT123
-1966,9,TM123
-1966,11,わざマシン１２３
-1966,3,기술머신123
 1966,6,TM123
 1966,7,MT123
 1966,8,MT123
+1966,9,TM123
+1966,11,わざマシン１２３
 1966,12,招式学习器１２３
 1967,1,わざマシン１２４
+1967,3,기술머신124
 1967,4,招式學習器１２４
 1967,5,CT124
-1967,9,TM124
-1967,11,わざマシン１２４
-1967,3,기술머신124
 1967,6,TM124
 1967,7,MT124
 1967,8,MT124
+1967,9,TM124
+1967,11,わざマシン１２４
 1967,12,招式学习器１２４
 1968,1,わざマシン１２５
+1968,3,기술머신125
 1968,4,招式學習器１２５
 1968,5,CT125
-1968,9,TM125
-1968,11,わざマシン１２５
-1968,3,기술머신125
 1968,6,TM125
 1968,7,MT125
 1968,8,MT125
+1968,9,TM125
+1968,11,わざマシン１２５
 1968,12,招式学习器１２５
 1969,1,わざマシン１２６
+1969,3,기술머신126
 1969,4,招式學習器１２６
 1969,5,CT126
-1969,9,TM126
-1969,11,わざマシン１２６
-1969,3,기술머신126
 1969,6,TM126
 1969,7,MT126
 1969,8,MT126
+1969,9,TM126
+1969,11,わざマシン１２６
 1969,12,招式学习器１２６
 1970,1,わざマシン１２７
+1970,3,기술머신127
 1970,4,招式學習器１２７
 1970,5,CT127
-1970,9,TM127
-1970,11,わざマシン１２７
-1970,3,기술머신127
 1970,6,TM127
 1970,7,MT127
 1970,8,MT127
+1970,9,TM127
+1970,11,わざマシン１２７
 1970,12,招式学习器１２７
 1971,1,わざマシン１２８
+1971,3,기술머신128
 1971,4,招式學習器１２８
 1971,5,CT128
-1971,9,TM128
-1971,11,わざマシン１２８
-1971,3,기술머신128
 1971,6,TM128
 1971,7,MT128
 1971,8,MT128
+1971,9,TM128
+1971,11,わざマシン１２８
 1971,12,招式学习器１２８
 1972,1,わざマシン１２９
+1972,3,기술머신129
 1972,4,招式學習器１２９
 1972,5,CT129
-1972,9,TM129
-1972,11,わざマシン１２９
-1972,3,기술머신129
 1972,6,TM129
 1972,7,MT129
 1972,8,MT129
+1972,9,TM129
+1972,11,わざマシン１２９
 1972,12,招式学习器１２９
 1973,1,わざマシン１３０
+1973,3,기술머신130
 1973,4,招式學習器１３０
 1973,5,CT130
-1973,9,TM130
-1973,11,わざマシン１３０
-1973,3,기술머신130
 1973,6,TM130
 1973,7,MT130
 1973,8,MT130
+1973,9,TM130
+1973,11,わざマシン１３０
 1973,12,招式学习器１３０
 1974,1,わざマシン１３１
+1974,3,기술머신131
 1974,4,招式學習器１３１
 1974,5,CT131
-1974,9,TM131
-1974,11,わざマシン１３１
-1974,3,기술머신131
 1974,6,TM131
 1974,7,MT131
 1974,8,MT131
+1974,9,TM131
+1974,11,わざマシン１３１
 1974,12,招式学习器１３１
 1975,1,わざマシン１３２
+1975,3,기술머신132
 1975,4,招式學習器１３２
 1975,5,CT132
-1975,9,TM132
-1975,11,わざマシン１３２
-1975,3,기술머신132
 1975,6,TM132
 1975,7,MT132
 1975,8,MT132
+1975,9,TM132
+1975,11,わざマシン１３２
 1975,12,招式学习器１３２
 1976,1,わざマシン１３３
+1976,3,기술머신133
 1976,4,招式學習器１３３
 1976,5,CT133
-1976,9,TM133
-1976,11,わざマシン１３３
-1976,3,기술머신133
 1976,6,TM133
 1976,7,MT133
 1976,8,MT133
+1976,9,TM133
+1976,11,わざマシン１３３
 1976,12,招式学习器１３３
 1977,1,わざマシン１３４
+1977,3,기술머신134
 1977,4,招式學習器１３４
 1977,5,CT134
-1977,9,TM134
-1977,11,わざマシン１３４
-1977,3,기술머신134
 1977,6,TM134
 1977,7,MT134
 1977,8,MT134
+1977,9,TM134
+1977,11,わざマシン１３４
 1977,12,招式学习器１３４
 1978,1,わざマシン１３５
+1978,3,기술머신135
 1978,4,招式學習器１３５
 1978,5,CT135
-1978,9,TM135
-1978,11,わざマシン１３５
-1978,3,기술머신135
 1978,6,TM135
 1978,7,MT135
 1978,8,MT135
+1978,9,TM135
+1978,11,わざマシン１３５
 1978,12,招式学习器１３５
 1979,1,わざマシン１３６
+1979,3,기술머신136
 1979,4,招式學習器１３６
 1979,5,CT136
-1979,9,TM136
-1979,11,わざマシン１３６
-1979,3,기술머신136
 1979,6,TM136
 1979,7,MT136
 1979,8,MT136
+1979,9,TM136
+1979,11,わざマシン１３６
 1979,12,招式学习器１３６
 1980,1,わざマシン１３７
+1980,3,기술머신137
 1980,4,招式學習器１３７
 1980,5,CT137
-1980,9,TM137
-1980,11,わざマシン１３７
-1980,3,기술머신137
 1980,6,TM137
 1980,7,MT137
 1980,8,MT137
+1980,9,TM137
+1980,11,わざマシン１３７
 1980,12,招式学习器１３７
 1981,1,わざマシン１３８
+1981,3,기술머신138
 1981,4,招式學習器１３８
 1981,5,CT138
-1981,9,TM138
-1981,11,わざマシン１３８
-1981,3,기술머신138
 1981,6,TM138
 1981,7,MT138
 1981,8,MT138
+1981,9,TM138
+1981,11,わざマシン１３８
 1981,12,招式学习器１３８
 1982,1,わざマシン１３９
+1982,3,기술머신139
 1982,4,招式學習器１３９
 1982,5,CT139
-1982,9,TM139
-1982,11,わざマシン１３９
-1982,3,기술머신139
 1982,6,TM139
 1982,7,MT139
 1982,8,MT139
+1982,9,TM139
+1982,11,わざマシン１３９
 1982,12,招式学习器１３９
 1983,1,わざマシン１４０
+1983,3,기술머신140
 1983,4,招式學習器１４０
 1983,5,CT140
-1983,9,TM140
-1983,11,わざマシン１４０
-1983,3,기술머신140
 1983,6,TM140
 1983,7,MT140
 1983,8,MT140
+1983,9,TM140
+1983,11,わざマシン１４０
 1983,12,招式学习器１４０
 1984,1,わざマシン１４１
+1984,3,기술머신141
 1984,4,招式學習器１４１
 1984,5,CT141
-1984,9,TM141
-1984,11,わざマシン１４１
-1984,3,기술머신141
 1984,6,TM141
 1984,7,MT141
 1984,8,MT141
+1984,9,TM141
+1984,11,わざマシン１４１
 1984,12,招式学习器１４１
 1985,1,わざマシン１４２
+1985,3,기술머신142
 1985,4,招式學習器１４２
 1985,5,CT142
-1985,9,TM142
-1985,11,わざマシン１４２
-1985,3,기술머신142
 1985,6,TM142
 1985,7,MT142
 1985,8,MT142
+1985,9,TM142
+1985,11,わざマシン１４２
 1985,12,招式学习器１４２
 1986,1,わざマシン１４３
+1986,3,기술머신143
 1986,4,招式學習器１４３
 1986,5,CT143
-1986,9,TM143
-1986,11,わざマシン１４３
-1986,3,기술머신143
 1986,6,TM143
 1986,7,MT143
 1986,8,MT143
+1986,9,TM143
+1986,11,わざマシン１４３
 1986,12,招式学习器１４３
 1987,1,わざマシン１４４
+1987,3,기술머신144
 1987,4,招式學習器１４４
 1987,5,CT144
-1987,9,TM144
-1987,11,わざマシン１４４
-1987,3,기술머신144
 1987,6,TM144
 1987,7,MT144
 1987,8,MT144
+1987,9,TM144
+1987,11,わざマシン１４４
 1987,12,招式学习器１４４
 1988,1,わざマシン１４５
+1988,3,기술머신145
 1988,4,招式學習器１４５
 1988,5,CT145
-1988,9,TM145
-1988,11,わざマシン１４５
-1988,3,기술머신145
 1988,6,TM145
 1988,7,MT145
 1988,8,MT145
+1988,9,TM145
+1988,11,わざマシン１４５
 1988,12,招式学习器１４５
 1989,1,わざマシン１４６
+1989,3,기술머신146
 1989,4,招式學習器１４６
 1989,5,CT146
-1989,9,TM146
-1989,11,わざマシン１４６
-1989,3,기술머신146
 1989,6,TM146
 1989,7,MT146
 1989,8,MT146
+1989,9,TM146
+1989,11,わざマシン１４６
 1989,12,招式学习器１４６
 1990,1,わざマシン１４７
+1990,3,기술머신147
 1990,4,招式學習器１４７
 1990,5,CT147
-1990,9,TM147
-1990,11,わざマシン１４７
-1990,3,기술머신147
 1990,6,TM147
 1990,7,MT147
 1990,8,MT147
+1990,9,TM147
+1990,11,わざマシン１４７
 1990,12,招式学习器１４７
 1991,1,わざマシン１４８
+1991,3,기술머신148
 1991,4,招式學習器１４８
 1991,5,CT148
-1991,9,TM148
-1991,11,わざマシン１４８
-1991,3,기술머신148
 1991,6,TM148
 1991,7,MT148
 1991,8,MT148
+1991,9,TM148
+1991,11,わざマシン１４８
 1991,12,招式学习器１４８
 1992,1,わざマシン１４９
+1992,3,기술머신149
 1992,4,招式學習器１４９
 1992,5,CT149
-1992,9,TM149
-1992,11,わざマシン１４９
-1992,3,기술머신149
 1992,6,TM149
 1992,7,MT149
 1992,8,MT149
+1992,9,TM149
+1992,11,わざマシン１４９
 1992,12,招式学习器１４９
 1993,1,わざマシン１５０
+1993,3,기술머신150
 1993,4,招式學習器１５０
 1993,5,CT150
-1993,9,TM150
-1993,11,わざマシン１５０
-1993,3,기술머신150
 1993,6,TM150
 1993,7,MT150
 1993,8,MT150
+1993,9,TM150
+1993,11,わざマシン１５０
 1993,12,招式学习器１５０
 1994,1,わざマシン１５１
+1994,3,기술머신151
 1994,4,招式學習器１５１
 1994,5,CT151
-1994,9,TM151
-1994,11,わざマシン１５１
-1994,3,기술머신151
 1994,6,TM151
 1994,7,MT151
 1994,8,MT151
+1994,9,TM151
+1994,11,わざマシン１５１
 1994,12,招式学习器１５１
 1995,1,わざマシン１５２
+1995,3,기술머신152
 1995,4,招式學習器１５２
 1995,5,CT152
-1995,9,TM152
-1995,11,わざマシン１５２
-1995,3,기술머신152
 1995,6,TM152
 1995,7,MT152
 1995,8,MT152
+1995,9,TM152
+1995,11,わざマシン１５２
 1995,12,招式学习器１５２
 1996,1,わざマシン１５３
+1996,3,기술머신153
 1996,4,招式學習器１５３
 1996,5,CT153
-1996,9,TM153
-1996,11,わざマシン１５３
-1996,3,기술머신153
 1996,6,TM153
 1996,7,MT153
 1996,8,MT153
+1996,9,TM153
+1996,11,わざマシン１５３
 1996,12,招式学习器１５３
 1997,1,わざマシン１５４
+1997,3,기술머신154
 1997,4,招式學習器１５４
 1997,5,CT154
-1997,9,TM154
-1997,11,わざマシン１５４
-1997,3,기술머신154
 1997,6,TM154
 1997,7,MT154
 1997,8,MT154
+1997,9,TM154
+1997,11,わざマシン１５４
 1997,12,招式学习器１５４
 1998,1,わざマシン１５５
+1998,3,기술머신155
 1998,4,招式學習器１５５
 1998,5,CT155
-1998,9,TM155
-1998,11,わざマシン１５５
-1998,3,기술머신155
 1998,6,TM155
 1998,7,MT155
 1998,8,MT155
+1998,9,TM155
+1998,11,わざマシン１５５
 1998,12,招式学习器１５５
 1999,1,わざマシン１５６
+1999,3,기술머신156
 1999,4,招式學習器１５６
 1999,5,CT156
-1999,9,TM156
-1999,11,わざマシン１５６
-1999,3,기술머신156
 1999,6,TM156
 1999,7,MT156
 1999,8,MT156
+1999,9,TM156
+1999,11,わざマシン１５６
 1999,12,招式学习器１５６
 2000,1,わざマシン１５７
+2000,3,기술머신157
 2000,4,招式學習器１５７
 2000,5,CT157
-2000,9,TM157
-2000,11,わざマシン１５７
-2000,3,기술머신157
 2000,6,TM157
 2000,7,MT157
 2000,8,MT157
+2000,9,TM157
+2000,11,わざマシン１５７
 2000,12,招式学习器１５７
 2001,1,わざマシン１５８
+2001,3,기술머신158
 2001,4,招式學習器１５８
 2001,5,CT158
-2001,9,TM158
-2001,11,わざマシン１５８
-2001,3,기술머신158
 2001,6,TM158
 2001,7,MT158
 2001,8,MT158
+2001,9,TM158
+2001,11,わざマシン１５８
 2001,12,招式学习器１５８
 2002,1,わざマシン１５９
+2002,3,기술머신159
 2002,4,招式學習器１５９
 2002,5,CT159
-2002,9,TM159
-2002,11,わざマシン１５９
-2002,3,기술머신159
 2002,6,TM159
 2002,7,MT159
 2002,8,MT159
+2002,9,TM159
+2002,11,わざマシン１５９
 2002,12,招式学习器１５９
 2003,1,わざマシン１６０
+2003,3,기술머신160
 2003,4,招式學習器１６０
 2003,5,CT160
-2003,9,TM160
-2003,11,わざマシン１６０
-2003,3,기술머신160
 2003,6,TM160
 2003,7,MT160
 2003,8,MT160
+2003,9,TM160
+2003,11,わざマシン１６０
 2003,12,招式学习器１６０
 2004,1,わざマシン１６１
+2004,3,기술머신161
 2004,4,招式學習器１６１
 2004,5,CT161
-2004,9,TM161
-2004,11,わざマシン１６１
-2004,3,기술머신161
 2004,6,TM161
 2004,7,MT161
 2004,8,MT161
+2004,9,TM161
+2004,11,わざマシン１６１
 2004,12,招式学习器１６１
 2005,1,わざマシン１６２
+2005,3,기술머신162
 2005,4,招式學習器１６２
 2005,5,CT162
-2005,9,TM162
-2005,11,わざマシン１６２
-2005,3,기술머신162
 2005,6,TM162
 2005,7,MT162
 2005,8,MT162
+2005,9,TM162
+2005,11,わざマシン１６２
 2005,12,招式学习器１６２
 2006,1,わざマシン１６３
+2006,3,기술머신163
 2006,4,招式學習器１６３
 2006,5,CT163
-2006,9,TM163
-2006,11,わざマシン１６３
-2006,3,기술머신163
 2006,6,TM163
 2006,7,MT163
 2006,8,MT163
+2006,9,TM163
+2006,11,わざマシン１６３
 2006,12,招式学习器１６３
 2007,1,わざマシン１６４
+2007,3,기술머신164
 2007,4,招式學習器１６４
 2007,5,CT164
-2007,9,TM164
-2007,11,わざマシン１６４
-2007,3,기술머신164
 2007,6,TM164
 2007,7,MT164
 2007,8,MT164
+2007,9,TM164
+2007,11,わざマシン１６４
 2007,12,招式学习器１６４
 2008,1,わざマシン１６５
+2008,3,기술머신165
 2008,4,招式學習器１６５
 2008,5,CT165
-2008,9,TM165
-2008,11,わざマシン１６５
-2008,3,기술머신165
 2008,6,TM165
 2008,7,MT165
 2008,8,MT165
+2008,9,TM165
+2008,11,わざマシン１６５
 2008,12,招式学习器１６５
 2009,1,わざマシン１６６
+2009,3,기술머신166
 2009,4,招式學習器１６６
 2009,5,CT166
-2009,9,TM166
-2009,11,わざマシン１６６
-2009,3,기술머신166
 2009,6,TM166
 2009,7,MT166
 2009,8,MT166
+2009,9,TM166
+2009,11,わざマシン１６６
 2009,12,招式学习器１６６
 2010,1,わざマシン１６７
+2010,3,기술머신167
 2010,4,招式學習器１６７
 2010,5,CT167
-2010,9,TM167
-2010,11,わざマシン１６７
-2010,3,기술머신167
 2010,6,TM167
 2010,7,MT167
 2010,8,MT167
+2010,9,TM167
+2010,11,わざマシン１６７
 2010,12,招式学习器１６７
 2011,1,わざマシン１６８
+2011,3,기술머신168
 2011,4,招式學習器１６８
 2011,5,CT168
-2011,9,TM168
-2011,11,わざマシン１６８
-2011,3,기술머신168
 2011,6,TM168
 2011,7,MT168
 2011,8,MT168
+2011,9,TM168
+2011,11,わざマシン１６８
 2011,12,招式学习器１６８
 2012,1,わざマシン１６９
+2012,3,기술머신169
 2012,4,招式學習器１６９
 2012,5,CT169
-2012,9,TM169
-2012,11,わざマシン１６９
-2012,3,기술머신169
 2012,6,TM169
 2012,7,MT169
 2012,8,MT169
+2012,9,TM169
+2012,11,わざマシン１６９
 2012,12,招式学习器１６９
 2013,1,わざマシン１７０
+2013,3,기술머신170
 2013,4,招式學習器１７０
 2013,5,CT170
-2013,9,TM170
-2013,11,わざマシン１７０
-2013,3,기술머신170
 2013,6,TM170
 2013,7,MT170
 2013,8,MT170
+2013,9,TM170
+2013,11,わざマシン１７０
 2013,12,招式学习器１７０
 2014,1,わざマシン１７１
+2014,3,기술머신171
 2014,4,招式學習器１７１
 2014,5,CT171
-2014,9,TM171
-2014,11,わざマシン１７１
-2014,3,기술머신171
 2014,6,TM171
 2014,7,MT171
 2014,8,MT171
+2014,9,TM171
+2014,11,わざマシン１７１
 2014,12,招式学习器１７１
 2015,1,ピクニックセット
+2015,3,피크닉세트
 2015,4,野餐組合
 2015,5,Set de Pique-Nique
-2015,9,Picnic Set
-2015,11,ピクニックセット
-2015,3,피크닉세트
 2015,6,Picknick-Set
 2015,7,Kit de Pícnic
 2015,8,Set da picnic
+2015,9,Picnic Set
+2015,11,ピクニックセット
 2015,12,野餐组合
 2016,1,スクールボトル
+2016,3,스쿨 보틀
 2016,4,校園水壺
 2016,5,Gourde de l'Académie
-2016,9,Academy Bottle
-2016,11,スクールボトル
-2016,3,스쿨 보틀
 2016,6,Akademie-Flasche
 2016,7,Termo Academia
 2016,8,Borraccia accademia
+2016,9,Academy Bottle
+2016,11,スクールボトル
 2016,12,校园水壶
 2018,1,みずたまボトル
+2018,3,물방울 보틀
 2018,4,圓點水壺
 2018,5,Gourde à Pois
-2018,9,Polka-Dot Bottle
-2018,11,みずたまボトル
-2018,3,물방울 보틀
 2018,6,Punkte-Flasche
 2018,7,Termo Lunares
 2018,8,Borraccia a pois
+2018,9,Polka-Dot Bottle
+2018,11,みずたまボトル
 2018,12,圆点水壶
 2019,1,ストライプボトル
+2019,3,줄무늬 보틀
 2019,4,條紋水壺
 2019,5,Gourde à Rayures
-2019,9,Striped Bottle
-2019,11,ストライプボトル
-2019,3,줄무늬 보틀
 2019,6,Streifen-Flasche
 2019,7,Termo Rayas
 2019,8,Borraccia a righe
+2019,9,Striped Bottle
+2019,11,ストライプボトル
 2019,12,条纹水壶
 2020,1,ダイヤボトル
+2020,3,다이아 보틀
 2020,4,菱紋水壺
 2020,5,Gourde à Losanges
-2020,9,Diamond Bottle
-2020,11,ダイヤボトル
-2020,3,다이아 보틀
 2020,6,Rauten-Flasche
 2020,7,Termo Rombos
 2020,8,Borraccia a rombi
+2020,9,Diamond Bottle
+2020,11,ダイヤボトル
 2020,12,菱纹水壶
 2021,1,スクールカップ
+2021,3,스쿨 컵
 2021,4,校園水杯
 2021,5,Tasse de l'Académie
-2021,9,Academy Cup
-2021,11,スクールカップ
-2021,3,스쿨 컵
 2021,6,Akademie-Tasse
 2021,7,Taza Academia
 2021,8,Tazza accademia
+2021,9,Academy Cup
+2021,11,スクールカップ
 2021,12,校园水杯
 2023,1,たてストライプカップ
+2023,3,세로 줄무늬 컵
 2023,4,直條紋水杯
 2023,5,Tasse à Rayures Jaunes
-2023,9,Striped Cup
-2023,11,たてストライプカップ
-2023,3,세로 줄무늬 컵
 2023,6,Längsstreifen-Tasse
 2023,7,Taza Raya Vertical
 2023,8,Tazza a righe verticali
+2023,9,Striped Cup
+2023,11,たてストライプカップ
 2023,12,直条纹水杯
 2024,1,みずたまカップ
+2024,3,물방울 컵
 2024,4,圓點水杯
 2024,5,Tasse à Pois
-2024,9,Polka-Dot Cup
-2024,11,みずたまカップ
-2024,3,물방울 컵
 2024,6,Punkte-Tasse
 2024,7,Taza Lunares
 2024,8,Tazza a pois
+2024,9,Polka-Dot Cup
+2024,11,みずたまカップ
 2024,12,圆点水杯
 2025,1,フラワーカップ
+2025,3,플라워 컵
 2025,4,花朵水杯
 2025,5,Tasse à Fleurs
-2025,9,Flower Pattern Cup
-2025,11,フラワーカップ
-2025,3,플라워 컵
 2025,6,Blümchen-Tasse
 2025,7,Taza Flores
 2025,8,Tazza a fiori
+2025,9,Flower Pattern Cup
+2025,11,フラワーカップ
 2025,12,花朵水杯
 2026,1,スクールクロス
+2026,3,스쿨 테이블보
 2026,4,校園桌巾
 2026,5,Nappe de l'Académie
-2026,9,Academy Tablecloth
-2026,11,スクールクロス
-2026,3,스쿨 테이블보
 2026,6,Akademie-Tischtuch
 2026,7,Mantel Academia
 2026,8,Tovaglia accademia
+2026,9,Academy Tablecloth
+2026,11,スクールクロス
 2026,12,校园桌巾
 2028,1,ファンシークロス
+2028,3,팬시 테이블보
 2028,4,幻彩桌巾
 2028,5,Nappe Fantaisie
-2028,9,Whimsical Tablecloth
-2028,11,ファンシークロス
-2028,3,팬시 테이블보
 2028,6,Zauber-Tischtuch
 2028,7,Mantel Cuco
 2028,8,Tovaglia carina
+2028,9,Whimsical Tablecloth
+2028,11,ファンシークロス
 2028,12,幻彩桌巾
 2029,1,ネイチャークロス
+2029,3,네이처 테이블보
 2029,4,大自然桌巾
 2029,5,Nappe Verdoyante
-2029,9,Leafy Tablecloth
-2029,11,ネイチャークロス
-2029,3,네이처 테이블보
 2029,6,Natur-Tischtuch
 2029,7,Mantel Naturaleza
 2029,8,Tovaglia natura
+2029,9,Leafy Tablecloth
+2029,11,ネイチャークロス
 2029,12,大自然桌巾
 2030,1,うらめしクロス
+2030,3,원망 테이블보
 2030,4,鬼祟桌巾
 2030,5,Nappe Hantée
-2030,9,Spooky Tablecloth
-2030,11,うらめしクロス
-2030,3,원망 테이블보
 2030,6,Groll-Tischtuch
 2030,7,Mantel Espectral
 2030,8,Tovaglia dispetto
+2030,9,Spooky Tablecloth
+2030,11,うらめしクロス
 2030,12,鬼祟桌巾
 2031,1,スクールボール
+2031,3,스쿨볼
 2031,4,校園球
 2031,5,Ballon de l'Académie
-2031,9,Academy Ball
-2031,11,スクールボール
-2031,3,스쿨볼
 2031,6,Akademie-Ball
 2031,7,Pelota Academia
 2031,8,Palla accademia
+2031,9,Academy Ball
+2031,11,スクールボール
 2031,12,校园球
 2033,1,マリルボール
+2033,3,마릴볼
 2033,4,瑪力露球
 2033,5,Ballon Marill
-2033,9,Marill Ball
-2033,11,マリルボール
-2033,3,마릴볼
 2033,6,Marill-Ball
 2033,7,Pelota Marill
 2033,8,Palla Marill
+2033,9,Marill Ball
+2033,11,マリルボール
 2033,12,玛力露球
 2034,1,けいとボール
+2034,3,털실볼
 2034,4,毛線球
 2034,5,Pelote de Laine
-2034,9,Yarn Ball
-2034,11,けいとボール
-2034,3,털실볼
 2034,6,Woll-Ball
 2034,7,Pelota Ovillo
 2034,8,Palla gomitolo
+2034,9,Yarn Ball
+2034,11,けいとボール
 2034,12,毛线球
 2035,1,ゲーミングボール
+2035,3,게이밍볼
 2035,4,電競球
 2035,5,Ballon Gaming
-2035,9,Cyber Ball
-2035,11,ゲーミングボール
-2035,3,게이밍볼
 2035,6,Cyber-Ball
 2035,7,Pelota Cibernética
 2035,8,Palla gaming
+2035,9,Cyber Ball
+2035,11,ゲーミングボール
 2035,12,电竞球
 2036,1,ゴールドピック
+2036,3,골드 픽
 2036,4,金色三明治籤
 2036,5,Pique Dorée
-2036,9,Gold Pick
-2036,11,ゴールドピック
-2036,3,골드 픽
 2036,6,Gold-Pikser
 2036,7,Palillo Dorado
 2036,8,Stecchino oro
+2036,9,Gold Pick
+2036,11,ゴールドピック
 2036,12,金色三明治签
 2037,1,シルバーピック
+2037,3,실버 픽
 2037,4,銀色三明治籤
 2037,5,Pique Argentée
-2037,9,Silver Pick
-2037,11,シルバーピック
-2037,3,실버 픽
 2037,6,Silber-Pikser
 2037,7,Palillo Plateado
 2037,8,Stecchino argento
+2037,9,Silver Pick
+2037,11,シルバーピック
 2037,12,银色三明治签
 2038,1,あかいはたピック
+2038,3,빨강 깃발 픽
 2038,4,紅旗子三明治籤
 2038,5,Pique à Fanion Rouge
-2038,9,Red-Flag Pick
-2038,11,あかいはたピック
-2038,3,빨강 깃발 픽
 2038,6,Rotfahnen-Pikser
 2038,7,Palillo Bandera Roja
 2038,8,Bandierina rossa
+2038,9,Red-Flag Pick
+2038,11,あかいはたピック
 2038,12,红旗子三明治签
 2039,1,あおいはたピック
+2039,3,파랑 깃발 픽
 2039,4,藍旗子三明治籤
 2039,5,Pique à Fanion Bleu
-2039,9,Blue-Flag Pick
-2039,11,あおいはたピック
-2039,3,파랑 깃발 픽
 2039,6,Blaufahnen-Pikser
 2039,7,Palillo Bandera Azul
 2039,8,Bandierina blu
+2039,9,Blue-Flag Pick
+2039,11,あおいはたピック
 2039,12,蓝旗子三明治签
 2040,1,ピカピカピック
+2040,3,피카피카 픽
 2040,4,皮卡丘三明治籤
 2040,5,Pique Pikapika
-2040,9,Pika-Pika Pick
-2040,11,ピカピカピック
-2040,3,피카피카 픽
 2040,6,Pikapika-Pikser
 2040,7,Palillo Pikachu
 2040,8,Stecchino Pikachu
+2040,9,Pika-Pika Pick
+2040,11,ピカピカピック
 2040,12,皮卡丘三明治签
 2041,1,パチピカピック
+2041,3,윙크피카 픽
 2041,4,眨眼皮卡丘三明治籤
 2041,5,Pique à Chu Fripon
-2041,9,Winking Pika Pick
-2041,11,パチピカピック
-2041,3,윙크피카 픽
 2041,6,Zwinker-Pika-Pikser
 2041,7,Palillo Pikaguiño
 2041,8,Stecchino pikapika
+2041,9,Winking Pika Pick
+2041,11,パチピカピック
 2041,12,眨眼皮卡丘三明治签
 2042,1,ブイブイピック
+2042,3,브이브이 픽
 2042,4,伊布三明治籤
 2042,5,Pique Volivoli
-2042,9,Vee-Vee Pick
-2042,11,ブイブイピック
-2042,3,브이브이 픽
 2042,6,Volivoli-Pikser
 2042,7,Palillo Eevee
 2042,8,Stecchino Eevee
+2042,9,Vee-Vee Pick
+2042,11,ブイブイピック
 2042,12,伊布三明治签
 2043,1,ニコブイピック
+2043,3,방긋브이 픽
 2043,4,笑臉伊布三明治籤
 2043,5,Pique Évo Rit
-2043,9,Smiling Vee Pick
-2043,11,ニコブイピック
-2043,3,방긋브이 픽
 2043,6,Kicher-Voli-Pikser
 2043,7,Palillo Eevee Feliz
 2043,8,Stecchino veevee
+2043,9,Smiling Vee Pick
+2043,11,ニコブイピック
 2043,12,笑脸伊布三明治签
 2044,1,あおボールピック
+2044,3,파랑 볼 픽
 2044,4,藍珠珠三明治籤
 2044,5,Pique à Ball Bleue
-2044,9,Blue Poké Ball Pick
-2044,11,あおボールピック
-2044,3,파랑 볼 픽
 2044,6,Blauball-Pikser
 2044,7,Palillo Ball Azul
 2044,8,Stecchino Ball blu
+2044,9,Blue Poké Ball Pick
+2044,11,あおボールピック
 2044,12,蓝珠珠三明治签
 2045,1,イワイノヨロイ
+2045,3,축복받은갑옷
 2045,4,慶祝之鎧
 2045,5,Armure de la Fortune
-2045,9,Auspicious Armor
-2045,11,イワイノヨロイ
-2045,3,축복받은갑옷
 2045,6,Glorienrüstung
 2045,7,Armadura Auspiciosa
 2045,8,Armatura fausta
+2045,9,Auspicious Armor
+2045,11,イワイノヨロイ
 2045,12,庆祝之铠
 2046,1,かしらのしるし
+2046,3,대장의징표
 2046,4,頭領憑證
 2046,5,Emblème du Général
-2046,9,Leader’s Crest
-2046,11,かしらのしるし
-2046,3,대장의징표
 2046,6,Anführersymbol
 2046,7,Distintivo de Líder
 2046,8,Simbolo del capo
+2046,9,Leader’s Crest
+2046,11,かしらのしるし
 2046,12,头领凭证
 2047,1,ピンクボトル
+2047,3,핑크 보틀
 2047,4,粉紅水壺
 2047,5,Gourde Rose
-2047,9,Pink Bottle
-2047,11,ピンクボトル
-2047,3,핑크 보틀
 2047,6,Pinke Flasche
 2047,7,Termo Rosa
 2047,8,Borraccia rosa
+2047,9,Pink Bottle
+2047,11,ピンクボトル
 2047,12,粉红水壶
 2048,1,ブルーボトル
+2048,3,블루 보틀
 2048,4,藍色水壺
 2048,5,Gourde Bleue
-2048,9,Blue Bottle
-2048,11,ブルーボトル
-2048,3,블루 보틀
 2048,6,Blaue Flasche
 2048,7,Termo Azul
 2048,8,Borraccia celeste
+2048,9,Blue Bottle
+2048,11,ブルーボトル
 2048,12,蓝色水壶
 2049,1,イエローボトル
+2049,3,옐로 보틀
 2049,4,黃色水壺
 2049,5,Gourde Jaune
-2049,9,Yellow Bottle
-2049,11,イエローボトル
-2049,3,옐로 보틀
 2049,6,Gelbe Flasche
 2049,7,Termo Amarillo
 2049,8,Borraccia gialla
+2049,9,Yellow Bottle
+2049,11,イエローボトル
 2049,12,黄色水壶
 2050,1,Rステンレスボトル
+2050,3,R 스테인리스 보틀
 2050,4,紅紋不鏽鋼水壺
 2050,5,Gourde Inox (Rouge)
-2050,9,Steel Bottle (R)
-2050,11,Rステンレスボトル
-2050,3,R 스테인리스 보틀
 2050,6,Edelstahlflasche (R)
 2050,7,Termo Metal Rojo
 2050,8,Borraccia inox R
+2050,9,Steel Bottle (R)
+2050,11,Rステンレスボトル
 2050,12,红纹不锈钢水壶
 2051,1,Yステンレスボトル
+2051,3,Y 스테인리스 보틀
 2051,4,黃紋不鏽鋼水壺
 2051,5,Gourde Inox (Jaune)
-2051,9,Steel Bottle (Y)
-2051,11,Yステンレスボトル
-2051,3,Y 스테인리스 보틀
 2051,6,Edelstahlflasche (G)
 2051,7,Termo Metal Amarillo
 2051,8,Borraccia inox G
+2051,9,Steel Bottle (Y)
+2051,11,Yステンレスボトル
 2051,12,黄纹不锈钢水壶
 2052,1,Bステンレスボトル
+2052,3,B 스테인리스 보틀
 2052,4,藍紋不鏽鋼水壺
 2052,5,Gourde Inox (Bleue)
-2052,9,Steel Bottle (B)
-2052,11,Bステンレスボトル
-2052,3,B 스테인리스 보틀
 2052,6,Edelstahlflasche (B)
 2052,7,Termo Metal Azul
 2052,8,Borraccia inox B
+2052,9,Steel Bottle (B)
+2052,11,Bステンレスボトル
 2052,12,蓝纹不锈钢水壶
 2053,1,シルバーチタンボトル
+2053,3,실버 티탄 보틀
 2053,4,銀鈦水壺
 2053,5,Gourde Titane (Argent)
-2053,9,Silver Bottle
-2053,11,シルバーチタンボトル
-2053,3,실버 티탄 보틀
 2053,6,Silber-Titanflasche
 2053,7,Termo Plateado
 2053,8,Borraccia argento
+2053,9,Silver Bottle
+2053,11,シルバーチタンボトル
 2053,12,银钛水壶
 2054,1,よこストライプカップ
+2054,3,가로 줄무늬 컵
 2054,4,橫條紋水杯
 2054,5,Tasse à Rayures Bleues
-2054,9,Barred Cup
-2054,11,よこストライプカップ
-2054,3,가로 줄무늬 컵
 2054,6,Querstreifen-Tasse
 2054,7,Taza Raya Horizontal
 2054,8,Tazza a righe orizzontali
+2054,9,Barred Cup
+2054,11,よこストライプカップ
 2054,12,横条纹水杯
 2055,1,ダイヤカップ
+2055,3,다이아 컵
 2055,4,菱紋水杯
 2055,5,Tasse à Losanges
-2055,9,Diamond Pattern Cup
-2055,11,ダイヤカップ
-2055,3,다이아 컵
 2055,6,Rauten-Tasse
 2055,7,Taza Rombos
 2055,8,Tazza a rombi
+2055,9,Diamond Pattern Cup
+2055,11,ダイヤカップ
 2055,12,菱纹水杯
 2056,1,ファイヤーカップ
+2056,3,파이어 컵
 2056,4,火焰水杯
 2056,5,Tasse à Flammes
-2056,9,Fire Pattern Cup
-2056,11,ファイヤーカップ
-2056,3,파이어 컵
 2056,6,Flammen-Tasse
 2056,7,Taza Llamas
 2056,8,Tazza con fiamme
+2056,9,Fire Pattern Cup
+2056,11,ファイヤーカップ
 2056,12,火焰水杯
 2057,1,ピンクカップ
+2057,3,핑크 컵
 2057,4,粉紅水杯
 2057,5,Tasse Rose
-2057,9,Pink Cup
-2057,11,ピンクカップ
-2057,3,핑크 컵
 2057,6,Pinke Tasse
 2057,7,Taza Rosa
 2057,8,Tazza rosa
+2057,9,Pink Cup
+2057,11,ピンクカップ
 2057,12,粉红水杯
 2058,1,ブルーカップ
+2058,3,블루 컵
 2058,4,藍色水杯
 2058,5,Tasse Bleue
-2058,9,Blue Cup
-2058,11,ブルーカップ
-2058,3,블루 컵
 2058,6,Blaue Tasse
 2058,7,Taza Azul
 2058,8,Tazza celeste
+2058,9,Blue Cup
+2058,11,ブルーカップ
 2058,12,蓝色水杯
 2059,1,イエローカップ
+2059,3,옐로 컵
 2059,4,黃色水杯
 2059,5,Tasse Jaune
-2059,9,Yellow Cup
-2059,11,イエローカップ
-2059,3,옐로 컵
 2059,6,Gelbe Tasse
 2059,7,Taza Amarilla
 2059,8,Tazza gialla
+2059,9,Yellow Cup
+2059,11,イエローカップ
 2059,12,黄色水杯
 2060,1,ピカチュウカップ
+2060,3,피카츄 컵
 2060,4,皮卡丘水杯
 2060,5,Tasse Pikachu
-2060,9,Pikachu Cup
-2060,11,ピカチュウカップ
-2060,3,피카츄 컵
 2060,6,Pikachu-Tasse
 2060,7,Taza Pikachu
 2060,8,Tazza Pikachu
+2060,9,Pikachu Cup
+2060,11,ピカチュウカップ
 2060,12,皮卡丘水杯
 2061,1,イーブイカップ
+2061,3,이브이 컵
 2061,4,伊布水杯
 2061,5,Tasse Évoli
-2061,9,Eevee Cup
-2061,11,イーブイカップ
-2061,3,이브이 컵
 2061,6,Evoli-Tasse
 2061,7,Taza Eevee
 2061,8,Tazza Eevee
+2061,9,Eevee Cup
+2061,11,イーブイカップ
 2061,12,伊布水杯
 2062,1,ヤドンカップ
+2062,3,야돈 컵
 2062,4,呆呆獸水杯
 2062,5,Tasse Ramoloss
-2062,9,Slowpoke Cup
-2062,11,ヤドンカップ
-2062,3,야돈 컵
 2062,6,Flegmon-Tasse
 2062,7,Taza Slowpoke
 2062,8,Tazza Slowpoke
+2062,9,Slowpoke Cup
+2062,11,ヤドンカップ
 2062,12,呆呆兽水杯
 2063,1,シルバーチタンカップ
+2063,3,실버 티탄 컵
 2063,4,銀鈦水杯
 2063,5,Tasse Titane (Argent)
-2063,9,Silver Cup
-2063,11,シルバーチタンカップ
-2063,3,실버 티탄 컵
 2063,6,Silber-Titantasse
 2063,7,Taza Plateada
 2063,8,Tazza argento
+2063,9,Silver Cup
+2063,11,シルバーチタンカップ
 2063,12,银钛水杯
 2064,1,バランスボール
+2064,3,밸런스볼
 2064,4,瑜珈球
 2064,5,Ballon d'Exercice
-2064,9,Exercise Ball
-2064,11,バランスボール
-2064,3,밸런스볼
 2064,6,Gymnastik-Ball
 2064,7,Pelota Pilates
 2064,8,Palla fitness
+2064,9,Exercise Ball
+2064,11,バランスボール
 2064,12,瑜珈球
 2065,1,きいろチェッククロス
+2065,3,옐로 체크 테이블보
 2065,4,黃色格子桌巾
 2065,5,Nappe Tartan Jaune
-2065,9,Plaid Tablecloth (Y)
-2065,11,きいろチェッククロス
-2065,3,옐로 체크 테이블보
 2065,6,Gelbkaro-Tischtuch
 2065,7,Mantel Cuadros Ámbar
 2065,8,Tovaglia a quadri gialla
+2065,9,Plaid Tablecloth (Y)
+2065,11,きいろチェッククロス
 2065,12,黄色格子桌巾
 2066,1,あおチェッククロス
+2066,3,블루 체크 테이블보
 2066,4,藍色格子桌巾
 2066,5,Nappe Tartan Bleue
-2066,9,Plaid Tablecloth (B)
-2066,11,あおチェッククロス
-2066,3,블루 체크 테이블보
 2066,6,Blaukaro-Tischtuch
 2066,7,Mantel Cuadros Azul
 2066,8,Tovaglia a quadri viola
+2066,9,Plaid Tablecloth (B)
+2066,11,あおチェッククロス
 2066,12,蓝色格子桌巾
 2067,1,あかチェッククロス
+2067,3,레드 체크 테이블보
 2067,4,紅色格子桌巾
 2067,5,Nappe Tartan Rouge
-2067,9,Plaid Tablecloth (R)
-2067,11,あかチェッククロス
-2067,3,레드 체크 테이블보
 2067,6,Rotkaro-Tischtuch
 2067,7,Mantel Cuadros Rojo
 2067,8,Tovaglia a quadri rossa
+2067,9,Plaid Tablecloth (R)
+2067,11,あかチェッククロス
 2067,12,红色格子桌巾
 2068,1,くさむらモノクロス
+2068,3,풀숲 흑백 테이블보
 2068,4,黑白草叢桌巾
 2068,5,Nappe Hautes Herbes
-2068,9,B&W Grass Tablecloth
-2068,11,くさむらモノクロス
-2068,3,풀숲 흑백 테이블보
 2068,6,Retro-Gras-Tischtuch
 2068,7,Mantel Hierba Alta
 2068,8,Tovaglia erba alta
+2068,9,B&W Grass Tablecloth
+2068,11,くさむらモノクロス
 2068,12,黑白草丛桌巾
 2069,1,しょうぶクロス
+2069,3,배틀 테이블보
 2069,4,對決桌巾
 2069,5,Nappe Combat Pokémon
-2069,9,Battle Tablecloth
-2069,11,しょうぶクロス
-2069,3,배틀 테이블보
 2069,6,Action-Tischtuch
 2069,7,Mantel Combate
 2069,8,Tovaglia sfida
+2069,9,Battle Tablecloth
+2069,11,しょうぶクロス
 2069,12,对决桌巾
 2070,1,かいじゅうクロス
+2070,3,괴수 테이블보
 2070,4,怪獸桌巾
 2070,5,Nappe Kaiju
-2070,9,Monstrous Tablecloth
-2070,11,かいじゅうクロス
-2070,3,괴수 테이블보
 2070,6,Ungeheuer-Tischtuch
 2070,7,Mantel Monstruoso
 2070,8,Tovaglia mostruosa
+2070,9,Monstrous Tablecloth
+2070,11,かいじゅうクロス
 2070,12,怪兽桌巾
 2071,1,ストライプクロス
+2071,3,줄무늬 테이블보
 2071,4,條紋桌巾
 2071,5,Nappe à Rayures
-2071,9,Striped Tablecloth
-2071,11,ストライプクロス
-2071,3,줄무늬 테이블보
 2071,6,Streifen-Tischtuch
 2071,7,Mantel Rayas
 2071,8,Tovaglia a righe
+2071,9,Striped Tablecloth
+2071,11,ストライプクロス
 2071,12,条纹桌巾
 2072,1,ダイヤクロス
+2072,3,다이아 테이블보
 2072,4,菱紋桌巾
 2072,5,Nappe à Losanges
-2072,9,Diamond Tablecloth
-2072,11,ダイヤクロス
-2072,3,다이아 테이블보
 2072,6,Rauten-Tischtuch
 2072,7,Mantel Rombos
 2072,8,Tovaglia a rombi
+2072,9,Diamond Tablecloth
+2072,11,ダイヤクロス
 2072,12,菱纹桌巾
 2073,1,みずたまクロス
+2073,3,물방울 테이블보
 2073,4,圓點桌巾
 2073,5,Nappe à Pois
-2073,9,Polka-Dot Tablecloth
-2073,11,みずたまクロス
-2073,3,물방울 테이블보
 2073,6,Punkte-Tischtuch
 2073,7,Mantel Lunares
 2073,8,Tovaglia a pois
+2073,9,Polka-Dot Tablecloth
+2073,11,みずたまクロス
 2073,12,圆点桌巾
 2074,1,パープルクロス
+2074,3,퍼플 테이블보
 2074,4,紫色桌巾
 2074,5,Nappe Mauve
-2074,9,Lilac Tablecloth
-2074,11,パープルクロス
-2074,3,퍼플 테이블보
 2074,6,Violettes Tischtuch
 2074,7,Mantel Malva
 2074,8,Tovaglia lilla
+2074,9,Lilac Tablecloth
+2074,11,パープルクロス
 2074,12,紫色桌巾
 2075,1,ミントクロス
+2075,3,민트 테이블보
 2075,4,淺綠桌巾
 2075,5,Nappe Menthe
-2075,9,Mint Tablecloth
-2075,11,ミントクロス
-2075,3,민트 테이블보
 2075,6,Türkises Tischtuch
 2075,7,Mantel Menta
 2075,8,Tovaglia menta
+2075,9,Mint Tablecloth
+2075,11,ミントクロス
 2075,12,浅绿桌巾
 2076,1,ベージュクロス
+2076,3,베이지 테이블보
 2076,4,米色桌巾
 2076,5,Nappe Beige
-2076,9,Peach Tablecloth
-2076,11,ベージュクロス
-2076,3,베이지 테이블보
 2076,6,Beiges Tischtuch
 2076,7,Mantel Beis
 2076,8,Tovaglia pesca
+2076,9,Peach Tablecloth
+2076,11,ベージュクロス
 2076,12,米色桌巾
 2077,1,イエロークロス
+2077,3,옐로 테이블보
 2077,4,黃色桌巾
 2077,5,Nappe Jaune
-2077,9,Yellow Tablecloth
-2077,11,イエロークロス
-2077,3,옐로 테이블보
 2077,6,Gelbes Tischtuch
 2077,7,Mantel Amarillo
 2077,8,Tovaglia gialla
+2077,9,Yellow Tablecloth
+2077,11,イエロークロス
 2077,12,黄色桌巾
 2078,1,ブルークロス
+2078,3,블루 테이블보
 2078,4,藍色桌巾
 2078,5,Nappe Bleue
-2078,9,Blue Tablecloth
-2078,11,ブルークロス
-2078,3,블루 테이블보
 2078,6,Blaues Tischtuch
 2078,7,Mantel Azul
 2078,8,Tovaglia blu
+2078,9,Blue Tablecloth
+2078,11,ブルークロス
 2078,12,蓝色桌巾
 2079,1,ピンククロス
+2079,3,핑크 테이블보
 2079,4,粉紅桌巾
 2079,5,Nappe Rose
-2079,9,Pink Tablecloth
-2079,11,ピンククロス
-2079,3,핑크 테이블보
 2079,6,Pinkes Tischtuch
 2079,7,Mantel Rosa
 2079,8,Tovaglia rosa
+2079,9,Pink Tablecloth
+2079,11,ピンククロス
 2079,12,粉红桌巾
 2080,1,ゴールドチタンボトル
+2080,3,골드 티탄 보틀
 2080,4,金鈦水壺
 2080,5,Gourde Titane (Or)
-2080,9,Gold Bottle
-2080,11,ゴールドチタンボトル
-2080,3,골드 티탄 보틀
 2080,6,Gold-Titanflasche
 2080,7,Termo Dorado
 2080,8,Borraccia oro
+2080,9,Gold Bottle
+2080,11,ゴールドチタンボトル
 2080,12,金钛水壶
 2081,1,ブロンズチタンボトル
+2081,3,브론즈 티탄 보틀
 2081,4,銅鈦水壺
 2081,5,Gourde Titane (Bronze)
-2081,9,Bronze Bottle
-2081,11,ブロンズチタンボトル
-2081,3,브론즈 티탄 보틀
 2081,6,Bronze-Titanflasche
 2081,7,Termo Bronceado
 2081,8,Borraccia bronzo
+2081,9,Bronze Bottle
+2081,11,ブロンズチタンボトル
 2081,12,铜钛水壶
 2082,1,ゴールドチタンカップ
+2082,3,골드 티탄 컵
 2082,4,金鈦水杯
 2082,5,Tasse Titane (Or)
-2082,9,Gold Cup
-2082,11,ゴールドチタンカップ
-2082,3,골드 티탄 컵
 2082,6,Gold-Titantasse
 2082,7,Taza Dorada
 2082,8,Tazza oro
+2082,9,Gold Cup
+2082,11,ゴールドチタンカップ
 2082,12,金钛水杯
 2083,1,ブロンズチタンカップ
+2083,3,브론즈 티탄 컵
 2083,4,銅鈦水杯
 2083,5,Tasse Titane (Bronze)
-2083,9,Bronze Cup
-2083,11,ブロンズチタンカップ
-2083,3,브론즈 티탄 컵
 2083,6,Bronze-Titantasse
 2083,7,Taza Bronceada
 2083,8,Tazza bronzo
+2083,9,Bronze Cup
+2083,11,ブロンズチタンカップ
 2083,12,铜钛水杯
 2084,1,みどりボールピック
+2084,3,초록 볼 픽
 2084,4,綠珠珠三明治籤
 2084,5,Pique à Ball Verte
-2084,9,Green Poké Ball Pick
-2084,11,みどりボールピック
-2084,3,초록 볼 픽
 2084,6,Grünball-Pikser
 2084,7,Palillo Ball Verde
 2084,8,Stecchino Ball verde
+2084,9,Green Poké Ball Pick
+2084,11,みどりボールピック
 2084,12,绿珠珠三明治签
 2085,1,あかボールピック
+2085,3,빨강 볼 픽
 2085,4,紅珠珠三明治籤
 2085,5,Pique à Ball Rouge
-2085,9,Red Poké Ball Pick
-2085,11,あかボールピック
-2085,3,빨강 볼 픽
 2085,6,Rotball-Pikser
 2085,7,Palillo Ball Roja
 2085,8,Stecchino Ball rosso
+2085,9,Red Poké Ball Pick
+2085,11,あかボールピック
 2085,12,红珠珠三明治签
 2086,1,おいわいはなびピック
+2086,3,축하 폭죽 픽
 2086,4,煙火祝慶三明治籤
 2086,5,Pique Feu d'Artifice
-2086,9,Party Sparkler Pick
-2086,11,おいわいはなびピック
-2086,3,축하 폭죽 픽
 2086,6,Wunderkerzen-Pikser
 2086,7,Palillo Bengala
 2086,8,Stecchino scintille
+2086,9,Party Sparkler Pick
+2086,11,おいわいはなびピック
 2086,12,烟花祝庆三明治签
 2087,1,ゆうしゃのけんピック
+2087,3,용사의 검 픽
 2087,4,勇者之劍三明治籤
 2087,5,Pique Épée du Héros
-2087,9,Heroic Sword Pick
-2087,11,ゆうしゃのけんピック
-2087,3,용사의 검 픽
 2087,6,Heldenschwert-Pikser
 2087,7,Palillo Heroico
 2087,8,Stecchino spadone
+2087,9,Heroic Sword Pick
+2087,11,ゆうしゃのけんピック
 2087,12,勇者之剑三明治签
 2088,1,マジカルスターピック
+2088,3,매지컬 스타 픽
 2088,4,魔法星星三明治籤
 2088,5,Pique Étoile Magique
-2088,9,Magical Star Pick
-2088,11,マジカルスターピック
-2088,3,매지컬 스타 픽
 2088,6,Zauberstern-Pikser
 2088,7,Palillo Estrella
 2088,8,Stecchino magistella
+2088,9,Magical Star Pick
+2088,11,マジカルスターピック
 2088,12,魔法星星三明治签
 2089,1,マジカルハートピック
+2089,3,매지컬 하트 픽
 2089,4,魔法甜心三明治籤
 2089,5,Pique Cœur Magique
-2089,9,Magical Heart Pick
-2089,11,マジカルハートピック
-2089,3,매지컬 하트 픽
 2089,6,Zauberherz-Pikser
 2089,7,Palillo Corazón
 2089,8,Stecchino magicuore
+2089,9,Magical Heart Pick
+2089,11,マジカルハートピック
 2089,12,魔法甜心三明治签
 2090,1,パラソルピック
+2090,3,파라솔 픽
 2090,4,陽傘三明治籤
 2090,5,Pique Parasol
-2090,9,Parasol Pick
-2090,11,パラソルピック
-2090,3,파라솔 픽
 2090,6,Schirmchen-Pikser
 2090,7,Palillo Sombrilla
 2090,8,Ombrellino
+2090,9,Parasol Pick
+2090,11,パラソルピック
 2090,12,阳伞三明治签
 2091,1,あおぞらおはなピック
+2091,3,푸른하늘 꽃 픽
 2091,4,晴空花三明治籤
 2091,5,Pique Fleur d'Azur
-2091,9,Blue-Sky Flower Pick
-2091,11,あおぞらおはなピック
-2091,3,푸른하늘 꽃 픽
 2091,6,Mittagsblumen-Pikser
 2091,7,Palillo Flor Azul
 2091,8,Stecchino fiore blu
+2091,9,Blue-Sky Flower Pick
+2091,11,あおぞらおはなピック
 2091,12,晴空花三明治签
 2092,1,ゆうやけおはなピック
+2092,3,저녁노을 꽃 픽
 2092,4,夕陽花三明治籤
 2092,5,Pique Fleur du Ponant
-2092,9,Sunset Flower Pick
-2092,11,ゆうやけおはなピック
-2092,3,저녁노을 꽃 픽
 2092,6,Abendblumen-Pikser
 2092,7,Palillo Flor Naranja
 2092,8,Stecchino fiore arancio
+2092,9,Sunset Flower Pick
+2092,11,ゆうやけおはなピック
 2092,12,夕阳花三明治签
 2093,1,あさやけおはなピック
+2093,3,아침노을 꽃 픽
 2093,4,朝霞花三明治籤
 2093,5,Pique Fleur du Levant
-2093,9,Sunrise Flower Pick
-2093,11,あさやけおはなピック
-2093,3,아침노을 꽃 픽
 2093,6,Morgenblumen-Pikser
 2093,7,Palillo Flor Rosa
 2093,8,Stecchino fiore rosso
+2093,9,Sunrise Flower Pick
+2093,11,あさやけおはなピック
 2093,12,朝霞花三明治签
 2094,1,ブループレート
+2094,3,블루 플레이트
 2094,4,藍色盤子
 2094,5,Assiette Bleue
-2094,9,Blue Dish
-2094,11,ブループレート
-2094,3,블루 플레이트
 2094,6,Blauer Teller
 2094,7,Plato Azul
 2094,8,Piatto celeste
+2094,9,Blue Dish
+2094,11,ブループレート
 2094,12,蓝色盘子
 2095,1,グリーンプレート
+2095,3,그린 플레이트
 2095,4,綠色盤子
 2095,5,Assiette Verte
-2095,9,Green Dish
-2095,11,グリーンプレート
-2095,3,그린 플레이트
 2095,6,Grüner Teller
 2095,7,Plato Verde
 2095,8,Piatto verde
+2095,9,Green Dish
+2095,11,グリーンプレート
 2095,12,绿色盘子
 2096,1,オレンジプレート
+2096,3,오렌지 플레이트
 2096,4,橘色盤子
 2096,5,Assiette Orange
-2096,9,Orange Dish
-2096,11,オレンジプレート
-2096,3,오렌지 플레이트
 2096,6,Oranger Teller
 2096,7,Plato Naranja
 2096,8,Piatto arancione
+2096,9,Orange Dish
+2096,11,オレンジプレート
 2096,12,橘色盘子
 2097,1,レッドプレート
+2097,3,레드 플레이트
 2097,4,紅色盤子
 2097,5,Assiette Rouge
-2097,9,Red Dish
-2097,11,レッドプレート
-2097,3,레드 플레이트
 2097,6,Roter Teller
 2097,7,Plato Rojo
 2097,8,Piatto rosso
+2097,9,Red Dish
+2097,11,レッドプレート
 2097,12,红色盘子
 2098,1,ホワイトプレート
+2098,3,화이트 플레이트
 2098,4,白色盤子
 2098,5,Assiette Blanche
-2098,9,White Dish
-2098,11,ホワイトプレート
-2098,3,화이트 플레이트
 2098,6,Weißer Teller
 2098,7,Plato Blanco
 2098,8,Piatto bianco
+2098,9,White Dish
+2098,11,ホワイトプレート
 2098,12,白色盘子
 2099,1,イエロープレート
+2099,3,옐로 플레이트
 2099,4,黃色盤子
 2099,5,Assiette Jaune
-2099,9,Yellow Dish
-2099,11,イエロープレート
-2099,3,옐로 플레이트
 2099,6,Gelber Teller
 2099,7,Plato Amarillo
 2099,8,Piatto giallo
+2099,9,Yellow Dish
+2099,11,イエロープレート
 2099,12,黄色盘子
 2100,1,ロトりぼう
 2100,5,Perche à Motismart
 2100,9,Roto Stick
 2100,11,ロトりぼう
 2101,1,おしゃれカードみどり
-2101,5,Carte Élégance Verte
-2101,9,Teal Style Card
-2101,11,おしゃれカードみどり
 2101,3,멋쟁이카드 그린
 2101,4,碧之時尚名人卡
+2101,5,Carte Élégance Verte
 2101,6,Grüne Style-Karte
 2101,7,Tarjeta Chic Verde
 2101,8,Tessera chic verde
+2101,9,Teal Style Card
+2101,11,おしゃれカードみどり
 2101,12,碧之时尚名人卡
 2102,1,みどりのめん
-2102,5,Masque Turquoise
-2102,9,Teal Mask
-2102,11,みどりのめん
 2102,3,벽록의가면
 2102,4,碧草面具
+2102,5,Masque Turquoise
 2102,6,Türkisgrüne Maske
 2102,7,Máscara Turquesa
 2102,8,Maschera Turchese
+2102,9,Teal Mask
+2102,11,みどりのめん
 2102,12,碧草面具
 2103,1,きらめくおまもり
-2103,5,Charme Éclatant
-2103,9,Glimmering Charm
-2103,11,きらめくおまもり
 2103,3,반짝이는부적
 2103,4,晶耀護符
+2103,5,Charme Éclatant
 2103,6,Glitzerpin
 2103,7,Amuleto Cristalino
 2103,8,Brillamuleto
+2103,9,Glimmering Charm
+2103,11,きらめくおまもり
 2103,12,晶耀护符
 2104,1,けっしょうのかけら
-2104,5,Morceau de Cristal
-2104,9,Crystal Cluster
-2104,11,けっしょうのかけら
 2104,3,결정조각
 2104,4,結晶碎片
+2104,5,Morceau de Cristal
 2104,6,Kristallfragment
 2104,7,Fragmento de Cristal
 2104,8,Pezzo di cristallo
+2104,9,Crystal Cluster
+2104,11,けっしょうのかけら
 2104,12,结晶碎片
 2105,1,ようせいのハネ
-2105,5,Plume Enchantée
-2105,9,Fairy Feather
-2105,11,ようせいのハネ
-2105,14,Pluma Feérica
-2105,7,Pluma Feérica
 2105,3,요정의깃털
 2105,4,妖精之羽
+2105,5,Plume Enchantée
 2105,6,Feendaune
 2105,8,Piuma fatata
+2105,9,Fairy Feather
+2105,11,ようせいのハネ
 2105,12,妖精之羽
+2105,14,Pluma Feérica
+2105,7,Pluma Feérica
 2106,1,いどのめん
-2106,5,Masque du Puits
-2106,9,Wellspring Mask
-2106,11,いどのめん
 2106,3,우물의가면
 2106,4,水井面具
+2106,5,Masque du Puits
 2106,6,Brunnenmaske
 2106,7,Máscara Fuente
 2106,8,Maschera Pozzo
+2106,9,Wellspring Mask
+2106,11,いどのめん
 2106,12,水井面具
 2107,1,かまどのめん
-2107,5,Masque du Fourneau
-2107,9,Hearthflame Mask
-2107,11,かまどのめん
 2107,3,화덕의가면
 2107,4,火灶面具
+2107,5,Masque du Fourneau
 2107,6,Ofenmaske
 2107,7,Máscara Horno
 2107,8,Maschera Focolare
+2107,9,Hearthflame Mask
+2107,11,かまどのめん
 2107,12,火灶面具
 2108,1,いしずえのめん
-2108,5,Masque de la Pierre
-2108,9,Cornerstone Mask
-2108,11,いしずえのめん
 2108,3,주춧돌의가면
 2108,4,礎石面具
+2108,5,Masque de la Pierre
 2108,6,Fundamentmaske
 2108,7,Máscara Cimiento
 2108,8,Maschera Fondamenta
+2108,9,Cornerstone Mask
+2108,11,いしずえのめん
 2108,12,础石面具
 2109,1,みついりりんご
-2109,5,Pomme Nectar
-2109,6,Saftiger Apfel
-2109,9,Syrupy Apple
-2109,11,みついりりんご
 2109,3,꿀맛사과
 2109,4,蜜汁蘋果
+2109,5,Pomme Nectar
+2109,6,Saftiger Apfel
 2109,7,Manzana Melosa
 2109,8,Sciroppomo
+2109,9,Syrupy Apple
+2109,11,みついりりんご
 2109,12,蜜汁苹果
 2110,1,ボンサクのちゃわん
-2110,5,Bol Médiocre
-2110,9,Unremarkable Teacup
-2110,11,ボンサクのちゃわん
 2110,3,범작찻잔
 2110,4,凡作茶碗
+2110,5,Bol Médiocre
 2110,6,Simple Teeschale
 2110,7,Cuenco Mediocre
 2110,8,Tazza dozzinale
+2110,9,Unremarkable Teacup
+2110,11,ボンサクのちゃわん
 2110,12,凡作茶碗
 2111,1,ケッサクのちゃわん
-2111,5,Bol Exceptionnel
-2111,9,Masterpiece Teacup
-2111,11,ボンサクのちゃわん
 2111,3,걸작찻잔
 2111,4,傑作茶碗
+2111,5,Bol Exceptionnel
 2111,6,Edle Teeschale
 2111,7,Cuenco Exquisito
 2111,8,Tazza eccezionale
+2111,9,Masterpiece Teacup
+2111,11,ボンサクのちゃわん
 2111,12,杰作茶碗
 2112,1,たいりょくのもち
-2112,5,Mochi Santé
-2112,9,Health Mochi
-2112,11,たいりょくのもち
 2112,3,체력떡
 2112,4,體力糬
+2112,5,Mochi Santé
 2112,6,Heil-Mochi
 2112,7,Mochi Vigor
 2112,8,Mochi della salute
+2112,9,Health Mochi
+2112,11,たいりょくのもち
 2112,12,体力粘糕
 2113,1,きんりょくのもち
-2113,5,Mochi Force
-2113,9,Muscle Mochi
-2113,11,きんりょくのもち
 2113,3,근력떡
 2113,4,肌力糬
+2113,5,Mochi Force
 2113,6,Kraft-Mochi
 2113,7,Mochi Músculo
 2113,8,Mochi della potenza
+2113,9,Muscle Mochi
+2113,11,きんりょくのもち
 2113,12,肌力粘糕
 2114,1,ていこうのもち
-2114,5,Mochi Armure
-2114,9,Resist Mochi
-2114,11,ていこうのもち
 2114,3,저항력떡
 2114,4,抵抗糬
+2114,5,Mochi Armure
 2114,6,Abwehr-Mochi
 2114,7,Mochi Aguante
 2114,8,Mochi della tutela
+2114,9,Resist Mochi
+2114,11,ていこうのもち
 2114,12,抵抗粘糕
 2115,1,ちりょくのもち
-2115,5,Mochi Esprit
-2115,9,Genius Mochi
-2115,11,ちりょくのもち
 2115,3,지력떡
 2115,4,智力糬
+2115,5,Mochi Esprit
 2115,6,Genie-Mochi
 2115,7,Mochi Intelecto
 2115,8,Mochi dell’ingegno
+2115,9,Genius Mochi
+2115,11,ちりょくのもち
 2115,12,智力粘糕
 2116,1,せいしんのもち
-2116,5,Mochi Mental
-2116,9,Clever Mochi
-2116,11,せいしんのもち
 2116,3,정신력떡
 2116,4,精神糬
+2116,5,Mochi Mental
 2116,6,Esprit-Mochi
 2116,7,Mochi Mente
 2116,8,Mochi dell’intuito
+2116,9,Clever Mochi
+2116,11,せいしんのもち
 2116,12,精神粘糕
 2117,1,しゅんぱつのもち
-2117,5,Mochi Sprint
-2117,9,Swift Mochi
-2117,11,しゅんぱつのもち
 2117,3,순발력떡
 2117,4,瞬發糬
+2117,5,Mochi Sprint
 2117,6,Flink-Mochi
 2117,7,Mochi Ímpetu
 2117,8,Mochi della reazione
+2117,9,Swift Mochi
+2117,11,しゅんぱつのもち
 2117,12,瞬发粘糕
 2118,1,まっさらもち
 2118,5,Mochi Renouveau
 2118,9,Fresh Start Mochi
 2118,11,まっさらもち
 2119,1,アーボのきば
-2119,5,Croc d'Abo
-2119,9,Ekans Fang
-2119,11,アーボのきば
 2119,3,아보의이빨
 2119,4,阿柏蛇的牙
+2119,5,Croc d'Abo
 2119,6,Rettan-Zahn
 2119,7,Colmillo de Ekans
 2119,8,Zanna di Ekans
+2119,9,Ekans Fang
+2119,11,アーボのきば
 2119,12,阿柏蛇的牙
 2120,1,サンドのツメ
-2120,5,Griffe de Sabelette
-2120,9,Sandshrew Claw
-2120,11,サンドのツメ
 2120,3,모래두지의발톱
 2120,4,穿山鼠的爪子
+2120,5,Griffe de Sabelette
 2120,6,Sandan-Kralle
 2120,7,Garra de Sandshrew
 2120,8,Artiglio di Sandshrew
+2120,9,Sandshrew Claw
+2120,11,サンドのツメ
 2120,12,穿山鼠的爪子
 2121,1,ピィのけ
-2121,5,Poils de Mélo
-2121,9,Cleffa Fur
-2121,11,ピィのけ
 2121,3,삐의털
 2121,4,皮寶寶的毛
+2121,5,Poils de Mélo
 2121,6,Pii-Haar
 2121,7,Pelo de Cleffa
 2121,8,Pelo di Cleffa
+2121,9,Cleffa Fur
+2121,11,ピィのけ
 2121,12,皮宝宝的毛
 2122,1,ロコンのけ
-2122,5,Poils de Goupix
-2122,9,Vulpix Fur
-2122,11,ロコンのけ
 2122,3,식스테일의털
 2122,4,六尾的毛
+2122,5,Poils de Goupix
 2122,6,Vulpix-Haar
 2122,7,Pelo de Vulpix
 2122,8,Pelo di Vulpix
+2122,9,Vulpix Fur
+2122,11,ロコンのけ
 2122,12,六尾的毛
 2123,1,ニョロモのめんえき
-2123,5,Mucus de Ptitard
-2123,9,Poliwag Slime
-2123,11,ニョロモのめんえき
 2123,3,발챙이의점액
 2123,4,蚊香蝌蚪的黏液
+2123,5,Mucus de Ptitard
 2123,6,Quapsel-Schleim
 2123,7,Secreción de Poliwag
 2123,8,Muco di Poliwag
+2123,9,Poliwag Slime
+2123,11,ニョロモのめんえき
 2123,12,蚊香蝌蚪的黏液
 2124,1,マダツボミのツル
-2124,5,Liane de Chétiflor
-2124,9,Bellsprout Vine
-2124,11,マダツボミのツル
 2124,3,모다피의덩굴
 2124,4,喇叭芽的藤蔓
+2124,5,Liane de Chétiflor
 2124,6,Knofensa-Ranke
 2124,7,Liana de Bellsprout
 2124,8,Viticcio di Bellsprout
+2124,9,Bellsprout Vine
+2124,11,マダツボミのツル
 2124,12,喇叭芽的藤蔓
 2125,1,イシツブテのかけら
-2125,5,Fragment de Racaillou
-2125,9,Geodude Fragment
-2125,11,イシツブテのかけら
 2125,3,꼬마돌의조각
 2125,4,小拳石的碎片
+2125,5,Fragment de Racaillou
 2125,6,Kleinstein-Splitter
 2125,7,Fragmento de Geodude
 2125,8,Frammento di Geodude
+2125,9,Geodude Fragment
+2125,11,イシツブテのかけら
 2125,12,小拳石的碎片
 2126,1,ドガースのガス
-2126,5,Gaz de Smogo
-2126,9,Koffing Gas
-2126,11,ドガースのガス
 2126,3,또가스의가스
 2126,4,瓦斯彈的氣體
+2126,5,Gaz de Smogo
 2126,6,Smogon-Gas
 2126,7,Gas de Koffing
 2126,8,Gas di Koffing
+2126,9,Koffing Gas
+2126,11,ドガースのガス
 2126,12,瓦斯弹的气体
 2127,1,ゴンベのキバ
-2127,5,Croc de Goinfrex
-2127,9,Munchlax Fang
-2127,11,ゴンベのキバ
 2127,3,먹고자의이빨
 2127,4,小卡比獸的牙
+2127,5,Croc de Goinfrex
 2127,6,Mampfaxo-Zahn
 2127,7,Colmillo de Munchlax
 2127,8,Zanna di Munchlax
+2127,9,Munchlax Fang
+2127,11,ゴンベのキバ
 2127,12,小卡比兽的牙
 2128,1,オタチのけ
-2128,5,Poils de Fouinette
-2128,9,Sentret Fur
-2128,11,オタチのけ
 2128,3,꼬리선의털
 2128,4,尾立的毛
+2128,5,Poils de Fouinette
 2128,6,Wiesor-Haar
 2128,7,Pelo de Sentret
 2128,8,Pelo di Sentret
+2128,9,Sentret Fur
+2128,11,オタチのけ
 2128,12,尾立的毛
 2129,1,ホーホーのはね
-2129,5,Plume de Hoothoot
-2129,9,Hoothoot Feather
-2129,11,ホーホーのはね
 2129,3,부우부의깃털
 2129,4,咕咕的羽毛
+2129,5,Plume de Hoothoot
 2129,6,Hoothoot-Feder
 2129,7,Pluma de Hoothoot
 2129,8,Penna di Hoothoot
+2129,9,Hoothoot Feather
+2129,11,ホーホーのはね
 2129,12,咕咕的羽毛
 2130,1,イトマルのいと
-2130,5,Fil de Mimigal
-2130,9,Spinarak Thread
-2130,11,イトマルのいと
 2130,3,페이검의실
 2130,4,圓絲蛛的絲
+2130,5,Fil de Mimigal
 2130,6,Webarak-Faden
 2130,7,Hilo de Spinarak
 2130,8,Filo di Spinarak
+2130,9,Spinarak Thread
+2130,11,イトマルのいと
 2130,12,圆丝蛛的丝
 2131,1,エイパムのけ
-2131,5,Poils de Capumain
-2131,9,Aipom Hair
-2131,11,エイパムのけ
 2131,3,에이팜의털
 2131,4,長尾怪手的毛
+2131,5,Poils de Capumain
 2131,6,Griffel-Haar
 2131,7,Pelo de Aipom
 2131,8,Pelo di Aipom
+2131,9,Aipom Hair
+2131,11,エイパムのけ
 2131,12,长尾怪手的毛
 2132,1,ヤンヤンマのトゲ
-2132,5,Dard de Yanma
-2132,9,Yanma Spike
-2132,11,ヤンヤンマのトゲ
 2132,3,왕자리의가시
 2132,4,蜻蜻蜓的刺
+2132,5,Dard de Yanma
 2132,6,Yanma-Stachel
 2132,7,Aguijón de Yanma
 2132,8,Aculeo di Yanma
+2132,9,Yanma Spike
+2132,11,ヤンヤンマのトゲ
 2132,12,蜻蜻蜓的刺
 2133,1,グライガーのキバ
-2133,5,Croc de Scorplane
-2133,9,Gligar Fang
-2133,11,グライガーのキバ
 2133,3,글라이거의이빨
 2133,4,天蠍的牙
+2133,5,Croc de Scorplane
 2133,6,Skorgla-Zahn
 2133,7,Colmillo de Gligar
 2133,8,Zanna di Gligar
+2133,9,Gligar Fang
+2133,11,グライガーのキバ
 2133,12,天蝎的牙
 2134,1,マグマッグのようがん
-2134,5,Lave de Limagma
-2134,9,Slugma Lava
-2134,11,マグマッグのようがん
 2134,3,마그마그의용암
 2134,4,熔岩蟲的熔岩
+2134,5,Lave de Limagma
 2134,6,Schneckmag-Lava
 2134,7,Lava de Slugma
 2134,8,Lava di Slugma
+2134,9,Slugma Lava
+2134,11,マグマッグのようがん
 2134,12,熔岩虫的熔岩
 2135,1,ウリムーのけ
-2135,5,Poils de Marcacrin
-2135,9,Swinub Hair
-2135,11,ウリムーのけ
 2135,3,꾸꾸리의털
 2135,4,小山豬的毛
+2135,5,Poils de Marcacrin
 2135,6,Quiekel-Haar
 2135,7,Pelo de Swinub
 2135,8,Pelo di Swinub
+2135,9,Swinub Hair
+2135,11,ウリムーのけ
 2135,12,小山猪的毛
 2136,1,ポチエナのキバ
-2136,5,Croc de Medhyèna
-2136,9,Poochyena Fang
-2136,11,ポチエナのキバ
 2136,3,포챠나의이빨
 2136,4,土狼犬的牙
+2136,5,Croc de Medhyèna
 2136,6,Fiffyen-Zahn
 2136,7,Colmillo de Poochyena
 2136,8,Zanna di Poochyena
+2136,9,Poochyena Fang
+2136,11,ポチエナのキバ
 2136,12,土狼犬的牙
 2137,1,ハスボーのはっぱ
-2137,5,Feuille de Nénupiot
-2137,9,Lotad Leaf
-2137,11,ハスボーのはっぱ
 2137,3,연꽃몬의잎
 2137,4,蓮葉童子的葉片
+2137,5,Feuille de Nénupiot
 2137,6,Loturzel-Blatt
 2137,7,Hoja de Lotad
 2137,8,Foglia di Lotad
+2137,9,Lotad Leaf
+2137,11,ハスボーのはっぱ
 2137,12,莲叶童子的叶片
 2138,1,タネボーのえだ
-2138,5,Tige de Grainipiot
-2138,9,Seedot Stem
-2138,11,タネボーのえだ
 2138,3,도토링의가지
 2138,4,橡實果的枝條
+2138,5,Tige de Grainipiot
 2138,6,Samurzel-Zweig
 2138,7,Tallo de Seedot
 2138,8,Picciolo di Seedot
+2138,9,Seedot Stem
+2138,11,タネボーのえだ
 2138,12,橡实果的枝条
 2139,1,ノズパスのかけら
-2139,5,Fragment de Tarinor
-2139,9,Nosepass Fragment
-2139,11,ノズパスのかけら
 2139,3,코코파스의조각
 2139,4,朝北鼻的碎片
+2139,5,Fragment de Tarinor
 2139,6,Nasgnet-Splitter
 2139,7,Fragmento de Nosepass
 2139,8,Frammento di Nosepass
+2139,9,Nosepass Fragment
+2139,11,ノズパスのかけら
 2139,12,朝北鼻的碎片
 2140,1,バルビートのしる
-2140,5,Fluide de Muciole
-2140,9,Volbeat Fluid
-2140,11,バルビートのしる
 2140,3,볼비트의체액
 2140,4,電螢蟲的汁液
+2140,5,Fluide de Muciole
 2140,6,Volbeat-Sekret
 2140,7,Fluido de Volbeat
 2140,8,Fluido di Volbeat
+2140,9,Volbeat Fluid
+2140,11,バルビートのしる
 2140,12,电萤虫的汁液
 2141,1,イルミーゼのしる
-2141,5,Fluide de Lumivole
-2141,9,Illumise Fluid
-2141,11,イルミーゼのしる
 2141,3,네오비트의체액
 2141,4,甜甜螢的汁液
+2141,5,Fluide de Lumivole
 2141,6,Illumise-Sekret
 2141,7,Fluido de Illumise
 2141,8,Fluido di Illumise
+2141,9,Illumise Fluid
+2141,11,イルミーゼのしる
 2141,12,甜甜萤的汁液
 2142,1,ヘイガニのから
-2142,5,Carapace d’Écrapince
-2142,9,Corphish Shell
-2142,11,ヘイガニのから
 2142,3,가재군의껍데기
 2142,4,龍蝦小兵的殼
+2142,5,Carapace d’Écrapince
 2142,6,Krebscorps-Schale
 2142,7,Cáscara de Corphish
 2142,8,Carapace di Corphish
+2142,9,Corphish Shell
+2142,11,ヘイガニのから
 2142,12,龙虾小兵的壳
 2143,1,ヒンバスのうろこ
-2143,5,Écaille de Barpau
-2143,9,Feebas Scales
-2143,11,ヒンバスのうろこ
 2143,3,빈티나의비늘
 2143,4,醜醜魚的鱗片
+2143,5,Écaille de Barpau
 2143,6,Barschwa-Schuppe
 2143,7,Escama de Feebas
 2143,8,Squama di Feebas
+2143,9,Feebas Scales
+2143,11,ヒンバスのうろこ
 2143,12,丑丑鱼的鳞片
 2144,1,ヨマワルのかけら
-2144,5,Fragment de Skelénox
-2144,9,Duskull Fragment
-2144,11,ヨマワルのかけら
 2144,3,해골몽의조각
 2144,4,夜巡靈的碎片
+2144,5,Fragment de Skelénox
 2144,6,Zwirrlicht-Splitter
 2144,7,Fragmento de Duskull
 2144,8,Frammento di Duskull
+2144,9,Duskull Fragment
+2144,11,ヨマワルのかけら
 2144,12,夜巡灵的碎片
 2145,1,リーシャンのかけら
-2145,5,Fragment de Korillon
-2145,9,Chingling Fragment
-2145,11,リーシャンのかけら
 2145,3,랑딸랑의조각
 2145,4,鈴鐺響的碎片
+2145,5,Fragment de Korillon
 2145,6,Klingplim-Splitter
 2145,7,Fragmento de Chingling
 2145,8,Frammento di Chingling
+2145,9,Chingling Fragment
+2145,11,リーシャンのかけら
 2145,12,铃铛响的碎片
 2146,1,ドッコラーのあせ
-2146,5,Sueur de Charpenti
-2146,9,Timburr Sweat
-2146,11,ドッコラーのあせ
 2146,3,으랏차의땀
 2146,4,搬運小匠的汗
+2146,5,Sueur de Charpenti
 2146,6,Praktibalk-Schweiß
 2146,7,Sudor de Timburr
 2146,8,Sudore di Timburr
+2146,9,Timburr Sweat
+2146,11,ドッコラーのあせ
 2146,12,搬运小匠的汗
 2147,1,クルミルのはっぱ
-2147,5,Feuille de Larveyette
-2147,9,Sewaddle Leaf
-2147,11,クルミルのはっぱ
 2147,3,두르보의잎
 2147,4,蟲寶包的葉片
+2147,5,Feuille de Larveyette
 2147,6,Strawickl-Blatt
 2147,7,Hoja de Sewaddle
 2147,8,Foglia di Sewaddle
+2147,9,Sewaddle Leaf
+2147,11,クルミルのはっぱ
 2147,12,虫宝包的叶片
 2148,1,コアルヒーのはね
-2148,5,Plume de Couaneton
-2148,9,Ducklett Feather
-2148,11,コアルヒーのはね
 2148,3,꼬지보리의깃털
 2148,4,鴨寶寶的羽毛
+2148,5,Plume de Couaneton
 2148,6,Piccolente-Feder
 2148,7,Pluma de Ducklett
 2148,8,Penna di Ducklett
+2148,9,Ducklett Feather
+2148,11,コアルヒーのはね
 2148,12,鸭宝宝的羽毛
 2149,1,ヒトモシのすす
-2149,5,Suie de Funécire
-2149,9,Litwick Soot
-2149,11,ヒトモシのすす
 2149,3,불켜미의검댕
 2149,4,燭光靈的煤灰
+2149,5,Suie de Funécire
 2149,6,Lichtel-Ruß
 2149,7,Hollín de Litwick
 2149,8,Fuliggine di Litwick
+2149,9,Litwick Soot
+2149,11,ヒトモシのすす
 2149,12,烛光灵的煤灰
 2150,1,コジョフーのツメ
-2150,5,Griffe de Kungfouine
-2150,9,Mienfoo Claw
-2150,11,コジョフーのツメ
 2150,3,비조푸의손톱
 2150,4,功夫鼬的爪子
+2150,5,Griffe de Kungfouine
 2150,6,Lin-Fu-Kralle
 2150,7,Garra de Mienfoo
 2150,8,Artiglio di Mienfoo
+2150,9,Mienfoo Claw
+2150,11,コジョフーのツメ
 2150,12,功夫鼬的爪子
 2151,1,バルチャイのはね
-2151,5,Plume de Vostourno
-2151,9,Vullaby Feather
-2151,11,バルチャイのはね
 2151,3,벌차이의깃털
 2151,4,禿鷹丫頭的羽毛
+2151,5,Plume de Vostourno
 2151,6,Skallyk-Feder
 2151,7,Pluma de Vullaby
 2151,8,Penna di Vullaby
+2151,9,Vullaby Feather
+2151,11,バルチャイのはね
 2151,12,秃鹰丫头的羽毛
 2152,1,メレシーのほうせき
-2152,5,Joyau de Strassie
-2152,9,Carbink Jewel
-2152,11,メレシーのほうせき
 2152,3,멜리시의보석
 2152,4,小碎鑽的寶石
+2152,5,Joyau de Strassie
 2152,6,Rocara-Edelstein
 2152,7,Gema de Carbink
 2152,8,Gemma di Carbink
+2152,9,Carbink Jewel
+2152,11,メレシーのほうせき
 2152,12,小碎钻的宝石
 2153,1,ボクレーのえだ
-2153,5,Branche de Brocélôme
-2153,9,Phantump Twig
-2153,11,ボクレーのえだ
 2153,3,나목령의가지
 2153,4,小木靈的枝條
+2153,5,Branche de Brocélôme
 2153,6,Paragoni-Zweig
 2153,7,Rama de Phantump
 2153,8,Ramo di Phantump
+2153,9,Phantump Twig
+2153,11,ボクレーのえだ
 2153,12,小木灵的枝条
 2154,1,アゴジムシのいと
-2154,5,Fil de Larvibule
-2154,9,Grubbin Thread
-2154,11,アゴジムシのいと
 2154,3,턱지충이의실
 2154,4,強顎雞母蟲的絲
+2154,5,Fil de Larvibule
 2154,6,Mabula-Faden
 2154,7,Hilo de Grubbin
 2154,8,Filo di Grubbin
+2154,9,Grubbin Thread
+2154,11,アゴジムシのいと
 2154,12,强颚鸡母虫的丝
 2155,1,アブリーのこな
-2155,5,Poudre de Bombydou
-2155,9,Cutiefly Powder
-2155,11,アブリーのこな
 2155,3,에블리의가루
 2155,4,萌虻的粉
+2155,5,Poudre de Bombydou
 2155,6,Wommel-Puder
 2155,7,Polvo de Cutiefly
 2155,8,Polvere di Cutiefly
+2155,9,Cutiefly Powder
+2155,11,アブリーのこな
 2155,12,萌虻的粉
 2156,1,ジャラコのウロコ
-2156,5,Écaille de Bébécaille
-2156,9,Jangmo-o Scales
-2156,11,ジャラコのウロコ
 2156,3,짜랑꼬의비늘
 2156,4,心鱗寶的鱗片
+2156,5,Écaille de Bébécaille
 2156,6,Miniras-Schuppe
 2156,7,Escama de Jangmo-o
 2156,8,Squama di Jangmo-o
+2156,9,Jangmo-o Scales
+2156,11,ジャラコのウロコ
 2156,12,心鳞宝的鳞片
 2157,1,ウッウのうもう
-2157,5,Duvet de Nigosier
-2157,9,Cramorant Down
-2157,11,ウッウのうもう
 2157,3,윽우지의솜털
 2157,4,古月鳥的羽絨
+2157,5,Duvet de Nigosier
 2157,6,Urgl-Daune
 2157,7,Plumón de Cramorant
 2157,8,Piuma di Cramorant
+2157,9,Cramorant Down
+2157,11,ウッウのうもう
 2157,12,古月鸟的羽绒
 2158,1,モルペコのたね
-2158,5,Graine de Morpeko
-2158,9,Morpeko Snack
-2158,11,モルペコのたね
 2158,3,모르페코의씨앗
 2158,4,莫魯貝可的種子
+2158,5,Graine de Morpeko
 2158,6,Morpeko-Samen
 2158,7,Semilla de Morpeko
 2158,8,Seme di Morpeko
+2158,9,Morpeko Snack
+2158,11,モルペコのたね
 2158,12,莫鲁贝可的种子
 2159,1,チャデスのこな
-2159,5,Poudre de Poltchageist
-2159,9,Poltchageist Powder
-2159,11,チャデスのこな
 2159,3,차데스의가루
 2159,4,斯魔茶的粉
+2159,5,Poudre de Poltchageist
 2159,6,Mortcha-Puder
 2159,7,Polvo de Poltchageist
 2159,8,Polvere di Poltchageist
+2159,9,Poltchageist Powder
+2159,11,チャデスのこな
 2159,12,斯魔茶的粉
-2160,5,Fil de Liaison
-2160,9,Linking Cord
-2160,11, つながりのヒモ
 2160,3,연결의끈
 2160,4,聯繫繩
+2160,5,Fil de Liaison
 2160,6,Verbindungsschnur
 2160,7,Cordón Unión
 2160,8,Filo dell’unione
+2160,9,Linking Cord
+2160,11, つながりのヒモ
 2160,12,联系绳
-2161,5,CT172
-2161,9,TM172
-2161,11,わざマシン１７２
 2161,3,기술머신172
 2161,4,招式學習器１７２
+2161,5,CT172
 2161,6,TM172
 2161,7,MT172
 2161,8,MT172
+2161,9,TM172
+2161,11,わざマシン１７２
 2161,12,招式学习器１７２
-2162,5,CT173
-2162,9,TM173
-2162,11,わざマシン１７３
 2162,3,기술머신173
 2162,4,招式學習器１７３
+2162,5,CT173
 2162,6,TM173
 2162,7,MT173
 2162,8,MT173
+2162,9,TM173
+2162,11,わざマシン１７３
 2162,12,招式学习器１７３
-2163,5,CT174
-2163,9,TM174
-2163,11,わざマシン１７４
 2163,3,기술머신174
 2163,4,招式學習器１７４
+2163,5,CT174
 2163,6,TM174
 2163,7,MT174
 2163,8,MT174
+2163,9,TM174
+2163,11,わざマシン１７４
 2163,12,招式学习器１７４
-2164,5,CT175
-2164,9,TM175
-2164,11,わざマシン１７５
 2164,3,기술머신175
 2164,4,招式學習器１７５
+2164,5,CT175
 2164,6,TM175
 2164,7,MT175
 2164,8,MT175
+2164,9,TM175
+2164,11,わざマシン１７５
 2164,12,招式学习器１７５
-2165,5,CT176
-2165,9,TM176
-2165,11,わざマシン１７６
 2165,3,기술머신176
 2165,4,招式學習器１７６
+2165,5,CT176
 2165,6,TM176
 2165,7,MT176
 2165,8,MT176
+2165,9,TM176
+2165,11,わざマシン１７６
 2165,12,招式学习器１７６
-2166,5,CT177
-2166,9,TM177
-2166,11,わざマシン１７７
 2166,3,기술머신177
 2166,4,招式學習器１７７
+2166,5,CT177
 2166,6,TM177
 2166,7,MT177
 2166,8,MT177
+2166,9,TM177
+2166,11,わざマシン１７７
 2166,12,招式学习器１７７
-2167,5,CT178
-2167,9,TM178
-2167,11,わざマシン１７８
 2167,3,기술머신178
 2167,4,招式學習器１７８
+2167,5,CT178
 2167,6,TM178
 2167,7,MT178
 2167,8,MT178
+2167,9,TM178
+2167,11,わざマシン１７８
 2167,12,招式学习器１７８
-2168,5,CT179
-2168,9,TM179
-2168,11,わざマシン１７９
 2168,3,기술머신179
 2168,4,招式學習器１７９
+2168,5,CT179
 2168,6,TM179
 2168,7,MT179
 2168,8,MT179
+2168,9,TM179
+2168,11,わざマシン１７９
 2168,12,招式学习器１７９
-2169,5,CT180
-2169,9,TM180
-2169,11,わざマシン１８０
 2169,3,기술머신180
 2169,4,招式學習器１８０
+2169,5,CT180
 2169,6,TM180
 2169,7,MT180
 2169,8,MT180
+2169,9,TM180
+2169,11,わざマシン１８０
 2169,12,招式学习器１８０
-2170,5,CT181
-2170,9,TM181
-2170,11,わざマシン１８１
 2170,3,기술머신181
 2170,4,招式學習器１８１
+2170,5,CT181
 2170,6,TM181
 2170,7,MT181
 2170,8,MT181
+2170,9,TM181
+2170,11,わざマシン１８１
 2170,12,招式学习器１８１
-2171,5,CT182
-2171,9,TM182
-2171,11,わざマシン１８２
 2171,3,기술머신182
 2171,4,招式學習器１８２
+2171,5,CT182
 2171,6,TM182
 2171,7,MT182
 2171,8,MT182
+2171,9,TM182
+2171,11,わざマシン１８２
 2171,12,招式学习器１８２
-2172,5,CT183
-2172,9,TM183
-2172,11,わざマシン１８３
 2172,3,기술머신183
 2172,4,招式學習器１８３
+2172,5,CT183
 2172,6,TM183
 2172,7,MT183
 2172,8,MT183
+2172,9,TM183
+2172,11,わざマシン１８３
 2172,12,招式学习器１８３
-2173,5,CT184
-2173,9,TM184
-2173,11,わざマシン１８４
 2173,3,기술머신184
 2173,4,招式學習器１８４
+2173,5,CT184
 2173,6,TM184
 2173,7,MT184
 2173,8,MT184
+2173,9,TM184
+2173,11,わざマシン１８４
 2173,12,招式学习器１８４
-2174,5,CT185
-2174,9,TM185
-2174,11,わざマシン１８５
 2174,3,기술머신185
 2174,4,招式學習器１８５
+2174,5,CT185
 2174,6,TM185
 2174,7,MT185
 2174,8,MT185
+2174,9,TM185
+2174,11,わざマシン１８５
 2174,12,招式学习器１８５
-2175,5,CT186
-2175,9,TM186
-2175,11,わざマシン１８６
 2175,3,기술머신186
 2175,4,招式學習器１８６
+2175,5,CT186
 2175,6,TM186
 2175,7,MT186
 2175,8,MT186
+2175,9,TM186
+2175,11,わざマシン１８６
 2175,12,招式学习器１８６
-2176,5,CT187
-2176,9,TM187
-2176,11,わざマシン１８７
 2176,3,기술머신187
 2176,4,招式學習器１８７
+2176,5,CT187
 2176,6,TM187
 2176,7,MT187
 2176,8,MT187
+2176,9,TM187
+2176,11,わざマシン１８７
 2176,12,招式学习器１８７
-2177,5,CT188
-2177,9,TM188
-2177,11,わざマシン１８８
 2177,3,기술머신188
 2177,4,招式學習器１８８
+2177,5,CT188
 2177,6,TM188
 2177,7,MT188
 2177,8,MT188
+2177,9,TM188
+2177,11,わざマシン１８８
 2177,12,招式学习器１８８
-2178,5,CT189
-2178,9,TM189
-2178,11,わざマシン１８９
 2178,3,기술머신189
 2178,4,招式學習器１８９
+2178,5,CT189
 2178,6,TM189
 2178,7,MT189
 2178,8,MT189
+2178,9,TM189
+2178,11,わざマシン１８９
 2178,12,招式学习器１８９
-2179,5,CT190
-2179,9,TM190
-2179,11,わざマシン１９０
 2179,3,기술머신190
 2179,4,招式學習器１９０
+2179,5,CT190
 2179,6,TM190
 2179,7,MT190
 2179,8,MT190
+2179,9,TM190
+2179,11,わざマシン１９０
 2179,12,招式学习器１９０
-2180,5,CT191
-2180,9,TM191
-2180,11,わざマシン１９１
 2180,3,기술머신191
 2180,4,招式學習器１９１
+2180,5,CT191
 2180,6,TM191
 2180,7,MT191
 2180,8,MT191
+2180,9,TM191
+2180,11,わざマシン１９１
 2180,12,招式学习器１９１
-2181,5,CT192
-2181,9,TM192
-2181,11,わざマシン１９２
 2181,3,기술머신192
 2181,4,招式學習器１９２
+2181,5,CT192
 2181,6,TM192
 2181,7,MT192
 2181,8,MT192
+2181,9,TM192
+2181,11,わざマシン１９２
 2181,12,招式学习器１９２
-2182,5,CT193
-2182,9,TM193
-2182,11,わざマシン１９３
 2182,3,기술머신193
 2182,4,招式學習器１９３
+2182,5,CT193
 2182,6,TM193
 2182,7,MT193
 2182,8,MT193
+2182,9,TM193
+2182,11,わざマシン１９３
 2182,12,招式学习器１９３
-2183,5,CT194
-2183,9,TM194
-2183,11,わざマシン１９４
 2183,3,기술머신194
 2183,4,招式學習器１９４
+2183,5,CT194
 2183,6,TM194
 2183,7,MT194
 2183,8,MT194
+2183,9,TM194
+2183,11,わざマシン１９４
 2183,12,招式学习器１９４
-2184,5,CT195
-2184,9,TM195
-2184,11,わざマシン１９５
 2184,3,기술머신195
 2184,4,招式學習器１９５
+2184,5,CT195
 2184,6,TM195
 2184,7,MT195
 2184,8,MT195
+2184,9,TM195
+2184,11,わざマシン１９５
 2184,12,招式学习器１９５
-2185,5,CT196
-2185,9,TM196
-2185,11,わざマシン１９６
 2185,3,기술머신196
 2185,4,招式學習器１９６
+2185,5,CT196
 2185,6,TM196
 2185,7,MT196
 2185,8,MT196
+2185,9,TM196
+2185,11,わざマシン１９６
 2185,12,招式学习器１９６
-2186,5,CT197
-2186,9,TM197
-2186,11,わざマシン１９７
 2186,3,기술머신197
 2186,4,招式學習器１９７
+2186,5,CT197
 2186,6,TM197
 2186,7,MT197
 2186,8,MT197
+2186,9,TM197
+2186,11,わざマシン１９７
 2186,12,招式学习器１９７
-2187,5,CT198
-2187,9,TM198
-2187,11,わざマシン１９８
 2187,3,기술머신198
 2187,4,招式學習器１９８
+2187,5,CT198
 2187,6,TM198
 2187,7,MT198
 2187,8,MT198
+2187,9,TM198
+2187,11,わざマシン１９８
 2187,12,招式学习器１９８
-2188,5,CT199
-2188,9,TM199
-2188,11,わざマシン１９９
 2188,3,기술머신199
 2188,4,招式學習器１９９
+2188,5,CT199
 2188,6,TM199
 2188,7,MT199
 2188,8,MT199
+2188,9,TM199
+2188,11,わざマシン１９９
 2188,12,招式学习器１９９
-2189,5,CT200
-2189,9,TM200
-2189,11,わざマシン２００
 2189,3,기술머신200
 2189,4,招式學習器２００
+2189,5,CT200
 2189,6,TM200
 2189,7,MT200
 2189,8,MT200
+2189,9,TM200
+2189,11,わざマシン２００
 2189,12,招式学习器２００
-2190,5,CT201
-2190,9,TM201
-2190,11,わざマシン２０１
 2190,3,기술머신201
 2190,4,招式學習器２０１
+2190,5,CT201
 2190,6,TM201
 2190,7,MT201
 2190,8,MT201
+2190,9,TM201
+2190,11,わざマシン２０１
 2190,12,招式学习器２０１
-2191,5,CT202
-2191,9,TM202
-2191,11,わざマシン２０２
 2191,3,기술머신202
 2191,4,招式學習器２０２
+2191,5,CT202
 2191,6,TM202
 2191,7,MT202
 2191,8,MT202
+2191,9,TM202
+2191,11,わざマシン２０２
 2191,12,招式学习器２０２
-2192,5,CT203
-2192,9,TM203
-2192,11,わざマシン２０３
 2192,3,기술머신203
 2192,4,招式學習器２０３
+2192,5,CT203
 2192,6,TM203
 2192,7,MT203
 2192,8,MT203
+2192,9,TM203
+2192,11,わざマシン２０３
 2192,12,招式学习器２０３
-2193,5,CT204
-2193,9,TM204
-2193,11,わざマシン２０４
 2193,3,기술머신204
 2193,4,招式學習器２０４
+2193,5,CT204
 2193,6,TM204
 2193,7,MT204
 2193,8,MT204
+2193,9,TM204
+2193,11,わざマシン２０４
 2193,12,招式学习器２０４
-2194,5,CT205
-2194,9,TM205
-2194,11,わざマシン２０５
 2194,3,기술머신205
 2194,4,招式學習器２０５
+2194,5,CT205
 2194,6,TM205
 2194,7,MT205
 2194,8,MT205
+2194,9,TM205
+2194,11,わざマシン２０５
 2194,12,招式学习器２０５
-2195,5,CT206
-2195,9,TM206
-2195,11,わざマシン２０６
 2195,3,기술머신206
 2195,4,招式學習器２０６
+2195,5,CT206
 2195,6,TM206
 2195,7,MT206
 2195,8,MT206
+2195,9,TM206
+2195,11,わざマシン２０６
 2195,12,招式学习器２０６
-2196,5,CT207
-2196,9,TM207
-2196,11,わざマシン２０７
 2196,3,기술머신207
 2196,4,招式學習器２０７
+2196,5,CT207
 2196,6,TM207
 2196,7,MT207
 2196,8,MT207
+2196,9,TM207
+2196,11,わざマシン２０７
 2196,12,招式学习器２０７
-2197,5,CT208
-2197,9,TM208
-2197,11,わざマシン２０８
 2197,3,기술머신208
 2197,4,招式學習器２０８
+2197,5,CT208
 2197,6,TM208
 2197,7,MT208
 2197,8,MT208
+2197,9,TM208
+2197,11,わざマシン２０８
 2197,12,招式学习器２０８
-2198,5,CT209
-2198,9,TM209
-2198,11,わざマシン２０９
 2198,3,기술머신209
 2198,4,招式學習器２０９
+2198,5,CT209
 2198,6,TM209
 2198,7,MT209
 2198,8,MT209
+2198,9,TM209
+2198,11,わざマシン２０９
 2198,12,招式学习器２０９
-2199,5,CT210
-2199,9,TM210
-2199,11,わざマシン２１０
 2199,3,기술머신210
 2199,4,招式學習器２１０
+2199,5,CT210
 2199,6,TM210
 2199,7,MT210
 2199,8,MT210
+2199,9,TM210
+2199,11,わざマシン２１０
 2199,12,招式学习器２１０
-2200,5,CT211
-2200,9,TM211
-2200,11,わざマシン２１１
 2200,3,기술머신211
 2200,4,招式學習器２１１
+2200,5,CT211
 2200,6,TM211
 2200,7,MT211
 2200,8,MT211
+2200,9,TM211
+2200,11,わざマシン２１１
 2200,12,招式学习器２１１
-2201,5,CT212
-2201,9,TM212
-2201,11,わざマシン２１２
 2201,3,기술머신212
 2201,4,招式學習器２１２
+2201,5,CT212
 2201,6,TM212
 2201,7,MT212
 2201,8,MT212
+2201,9,TM212
+2201,11,わざマシン２１２
 2201,12,招式学习器２１２
-2202,5,CT213
-2202,9,TM213
-2202,11,わざマシン２１３
 2202,3,기술머신213
 2202,4,招式學習器２１３
+2202,5,CT213
 2202,6,TM213
 2202,7,MT213
 2202,8,MT213
+2202,9,TM213
+2202,11,わざマシン２１３
 2202,12,招式学习器２１３
-2203,5,CT214
-2203,9,TM214
-2203,11,わざマシン２１４
 2203,3,기술머신214
 2203,4,招式學習器２１４
+2203,5,CT214
 2203,6,TM214
 2203,7,MT214
 2203,8,MT214
+2203,9,TM214
+2203,11,わざマシン２１４
 2203,12,招式学习器２１４
-2204,5,CT215
-2204,9,TM215
-2204,11,わざマシン２１５
 2204,3,기술머신215
 2204,4,招式學習器２１５
+2204,5,CT215
 2204,6,TM215
 2204,7,MT215
 2204,8,MT215
+2204,9,TM215
+2204,11,わざマシン２１５
 2204,12,招式学习器２１５
-2205,5,CT216
-2205,9,TM216
-2205,11,わざマシン２１６
 2205,3,기술머신216
 2205,4,招式學習器２１６
+2205,5,CT216
 2205,6,TM216
 2205,7,MT216
 2205,8,MT216
+2205,9,TM216
+2205,11,わざマシン２１６
 2205,12,招式学习器２１６
-2206,5,CT217
-2206,9,TM217
-2206,11,わざマシン２１７
 2206,3,기술머신217
 2206,4,招式學習器２１７
+2206,5,CT217
 2206,6,TM217
 2206,7,MT217
 2206,8,MT217
+2206,9,TM217
+2206,11,わざマシン２１７
 2206,12,招式学习器２１７
-2207,5,CT218
-2207,9,TM218
-2207,11,わざマシン２１８
 2207,3,기술머신218
 2207,4,招式學習器２１８
+2207,5,CT218
 2207,6,TM218
 2207,7,MT218
 2207,8,MT218
+2207,9,TM218
+2207,11,わざマシン２１８
 2207,12,招式学习器２１８
-2208,5,CT219
-2208,9,TM219
-2208,11,わざマシン２１９
 2208,3,기술머신219
 2208,4,招式學習器２１９
+2208,5,CT219
 2208,6,TM219
 2208,7,MT219
 2208,8,MT219
+2208,9,TM219
+2208,11,わざマシン２１９
 2208,12,招式学习器２１９
-2209,5,CT220
-2209,9,TM220
-2209,11,わざマシン２２０
 2209,3,기술머신220
 2209,4,招式學習器２２０
+2209,5,CT220
 2209,6,TM220
 2209,7,MT220
 2209,8,MT220
+2209,9,TM220
+2209,11,わざマシン２２０
 2209,12,招式学习器２２０
-2210,5,CT221
-2210,9,TM221
-2210,11,わざマシン２２１
 2210,3,기술머신221
 2210,4,招式學習器２２１
+2210,5,CT221
 2210,6,TM221
 2210,7,MT221
 2210,8,MT221
+2210,9,TM221
+2210,11,わざマシン２２１
 2210,12,招式学习器２２１
-2211,5,CT222
-2211,9,TM222
-2211,11,わざマシン２２２
 2211,3,기술머신222
 2211,4,招式學習器２２２
+2211,5,CT222
 2211,6,TM222
 2211,7,MT222
 2211,8,MT222
+2211,9,TM222
+2211,11,わざマシン２２２
 2211,12,招式学习器２２２
-2212,5,CT223
-2212,9,TM223
-2212,11,わざマシン２２３
 2212,3,기술머신223
 2212,4,招式學習器２２３
+2212,5,CT223
 2212,6,TM223
 2212,7,MT223
 2212,8,MT223
+2212,9,TM223
+2212,11,わざマシン２２３
 2212,12,招式学习器２２３
-2213,5,CT224
-2213,9,TM224
-2213,11,わざマシン２２４
 2213,3,기술머신224
 2213,4,招式學習器２２４
+2213,5,CT224
 2213,6,TM224
 2213,7,MT224
 2213,8,MT224
+2213,9,TM224
+2213,11,わざマシン２２４
 2213,12,招式学习器２２４
-2214,5,CT225
-2214,9,TM225
-2214,11,わざマシン２２５
 2214,3,기술머신225
 2214,4,招式學習器２２５
+2214,5,CT225
 2214,6,TM225
 2214,7,MT225
 2214,8,MT225
+2214,9,TM225
+2214,11,わざマシン２２５
 2214,12,招式学习器２２５
-2215,5,CT226
-2215,9,TM226
-2215,11,わざマシン２２６
 2215,3,기술머신226
 2215,4,招式學習器２２６
+2215,5,CT226
 2215,6,TM226
 2215,7,MT226
 2215,8,MT226
+2215,9,TM226
+2215,11,わざマシン２２６
 2215,12,招式学习器２２６
-2216,5,CT227
-2216,9,TM227
-2216,11,わざマシン２２７
 2216,3,기술머신227
 2216,4,招式學習器２２７
+2216,5,CT227
 2216,6,TM227
 2216,7,MT227
 2216,8,MT227
+2216,9,TM227
+2216,11,わざマシン２２７
 2216,12,招式学习器２２７
-2217,5,CT228
-2217,9,TM228
-2217,11,わざマシン２２８
 2217,3,기술머신228
 2217,4,招式學習器２２８
+2217,5,CT228
 2217,6,TM228
 2217,7,MT228
 2217,8,MT228
+2217,9,TM228
+2217,11,わざマシン２２８
 2217,12,招式学习器２２８
-2218,5,CT229
-2218,9,TM229
-2218,11,わざマシン２２９
 2218,3,기술머신229
 2218,4,招式學習器２２９
+2218,5,CT229
 2218,6,TM229
 2218,7,MT229
 2218,8,MT229
+2218,9,TM229
+2218,11,わざマシン２２９
 2218,12,招式学习器２２９
-2219,5,Étrange Ball
-2219,9,Strange Ball
 2219,3,스트레인지볼
 2219,4,奇異球
+2219,5,Étrange Ball
 2219,6,Rätselball
 2219,7,Extraña Ball
 2219,8,Strange Ball
+2219,9,Strange Ball
 2219,11,ストレンジボール
 2219,12,奇异球
-2220,5,Poké Ball
-2220,9,Poké Ball
 2220,3,몬스터볼
 2220,4,精靈球
+2220,5,Poké Ball
 2220,6,Pokéball
 2220,7,Poké Ball
 2220,8,Poké Ball
+2220,9,Poké Ball
 2220,11,モンスターボール
 2220,12,精灵球
-2221,5,Super Ball
-2221,9,Great Ball
 2221,3,슈퍼볼
 2221,4,超級球
+2221,5,Super Ball
 2221,6,Superball
 2221,7,Super Ball
 2221,8,Mega Ball
+2221,9,Great Ball
 2221,11,スーパーボール
 2221,12,超级球
-2222,5,Hyper Ball
-2222,9,Ultra Ball
 2222,3,하이퍼볼
 2222,4,高級球
+2222,5,Hyper Ball
 2222,6,Hyperball
 2222,7,Ultra Ball
 2222,8,Ultra Ball
+2222,9,Ultra Ball
 2222,11,ハイパーボール
 2222,12,高级球
-2223,5,Masse Ball
-2223,9,Heavy Ball
 2223,3,헤비볼
 2223,4,沉重球
+2223,5,Masse Ball
 2223,6,Schwerball
 2223,7,Peso Ball
 2223,8,Peso Ball
+2223,9,Heavy Ball
 2223,11,ヘビーボール
 2223,12,沉重球
-2224,5,Mégamasse Ball
-2224,9,Leaden Ball
 2224,3,메가톤볼
 2224,4,超重球
+2224,5,Mégamasse Ball
 2224,6,Zentnerball
 2224,7,Kilo Ball
 2224,8,Megaton Ball
+2224,9,Leaden Ball
 2224,11,メガトンボール
 2224,12,超重球
-2225,5,Gigamasse Ball
-2225,9,Gigaton Ball
 2225,3,기가톤볼
 2225,4,巨重球
+2225,5,Gigamasse Ball
 2225,6,Tonnenball
 2225,7,Quintal Ball
 2225,8,Gigaton Ball
+2225,9,Gigaton Ball
 2225,11,ギガトンボール
 2225,12,巨重球
-2226,5,Plume Ball
-2226,9,Feather Ball
 2226,3,페더볼
 2226,4,飛羽球
+2226,5,Plume Ball
 2226,6,Federball
 2226,7,Pluma Ball
 2226,8,Piuma Ball
+2226,9,Feather Ball
 2226,11,フェザーボール
 2226,12,飞羽球
-2227,5,Envol Ball
-2227,9,Wing Ball
 2227,3,윙볼
 2227,4,飛翼球
+2227,5,Envol Ball
 2227,6,Flügelball
 2227,7,Ala Ball
 2227,8,Wing Ball
+2227,9,Wing Ball
 2227,11,ウイングボール
 2227,12,飞翼球
-2228,5,Propulse Ball
-2228,9,Jet Ball
 2228,3,제트볼
 2228,4,飛梭球
+2228,5,Propulse Ball
 2228,6,Düsenball
 2228,7,Aero Ball
 2228,8,Jet Ball
+2228,9,Jet Ball
 2228,11,ジェットボール
 2228,12,飞梭球
-2229,5,Origine Ball
-2229,9,Origin Ball
 2229,3,오리진볼
 2229,4,起源球
+2229,5,Origine Ball
 2229,6,Urball
 2229,7,Origen Ball
 2229,8,Origin Ball
+2229,9,Origin Ball
 2229,11,オリジンボール
 2229,12,起源球
-2230,6,Schwarzaugit
-2230,9,Black Augurite
 2230,3,검은휘석
 2230,4,黑奇石
 2230,5,Obsidienne
+2230,6,Schwarzaugit
 2230,7,Mineral Negro
 2230,8,Augite nera
+2230,9,Black Augurite
 2230,11,くろのきせき
 2230,12,黑奇石
-2231,6,Torfblock
-2231,9,Peat Block
 2231,3,피트블록
 2231,4,泥炭塊
 2231,5,Bloc de Tourbe
+2231,6,Torfblock
 2231,7,Bloque de Turba
 2231,8,Blocco di torba
+2231,9,Peat Block
 2231,11,ピートブロック
 2231,12,泥炭块
-2232,6,Legierungsmetall
-2232,9,Metal Alloy
 2232,3,복합금속
 2232,4,複合金屬
 2232,5,Métal Composite
+2232,6,Legierungsmetall
 2232,7,Metal Compuesto
 2232,8,Metallo composito
+2232,9,Metal Alloy
 2232,11,ふくごうきんぞく
 2232,12,复合金属

--- a/data/v2/csv/item_names.csv
+++ b/data/v2/csv/item_names.csv
@@ -9511,7 +9511,7 @@ item_id,local_language_id,name
 933,14,Ticket Barco
 934,1,ライブドレス
 934,3,라이브드레스
-934,4,演出禮裙
+934,4,演出禮服
 934,5,Robe Live
 934,6,Live-Kleid
 934,7,Vestido de Gala
@@ -17485,2185 +17485,4365 @@ item_id,local_language_id,name
 1658,12,牵绊缰绳
 1658,14,Riendas Unión
 1659,1,だいこんごうだま
-1659,4,大金刚宝玉
+1659,4,大金剛寶玉
 1659,5,Globe Adamant
 1659,9,Adamant Crystal
 1659,11,だいこんごうだま
+1659,3,큰금강옥
+1659,6,Adamantkristall
+1659,7,Gran Diamansfera
+1659,8,Adamasferoide
+1659,12,大金刚宝玉
 1660,1,だいしらたま
-1660,4,大白宝玉
+1660,4,大白寶玉
 1660,5,Globe Perlé
 1660,9,Lustrous Globe
 1660,11,だいしらたま
+1660,3,큰백옥
+1660,6,Weißkristall
+1660,7,Gran Lustresfera
+1660,8,Splendisferoide
+1660,12,大白宝玉
 1661,1,だいはっきんだま
-1661,4,大白金宝玉
+1661,4,大白金寶玉
 1661,5,Globe Platiné
 1661,9,Griseous Core
 1661,11,だいはっきんだま
+1661,3,큰백금옥
+1661,6,Platinumkristall
+1661,7,Gran Griseosfera
+1661,8,Grigiosferoide
+1661,12,大白金宝玉
 1662,1,まっさらプレート
-1662,4,净空石板
+1662,4,淨空石板
 1662,5,Plaque Renouveau
 1662,9,Blank Plate
 1662,11,まっさらプレート
+1662,3,순백플레이트
+1662,6,Neutraltafel
+1662,7,Tabla Neutra
+1662,8,Lastraripristino
+1662,12,净空石板
 1663,1,ストレンジボール
-1663,4,奇异球
+1663,4,奇異球
 1663,5,Étrange Ball
 1663,9,Strange Ball
 1663,11,ストレンジボール
+1663,3,스트레인지볼
+1663,6,Rätselball
+1663,7,Extraña Ball
+1663,8,Strange Ball
+1663,12,奇异球
 1664,1,レジェンドプレート
-1664,4,传说石板
+1664,4,傳說石板
 1664,5,Plaque Légende
 1664,9,Legend Plate
 1664,11,レジェンドプレート
+1664,3,레전드플레이트
+1664,6,Legendentafel
+1664,7,Tabla Legendaria
+1664,8,Lastraleggenda
+1664,12,传说石板
 1665,1,スマホロトム
-1665,4,手机洛托姆
+1665,4,手機洛托姆
 1665,5,Motismart
 1665,9,Rotom Phone
 1665,11,スマホロトム
+1665,3,스마트로토무
+1665,6,Smart-Rotom
+1665,7,SmartRotom
+1665,8,Smart Rotom
+1665,12,手机洛托姆
 1666,1,サンドウィッチ
 1666,4,三明治
 1666,5,Sandwich
 1666,9,Sandwich
 1666,11,サンドウィッチ
+1666,3,샌드위치
+1666,6,Sandwich
+1666,7,Bocadillo
+1666,8,Panino
+1666,12,三明治
 1667,1,コライドンのボール
-1667,4,故勒顿的球
+1667,4,故勒頓的球
 1667,5,Poké Ball de Koraidon
 1667,9,Koraidon’s Poké Ball
 1667,11,コライドンのボール
+1667,3,코라이돈의 볼
+1667,6,Koraidons Pokéball
+1667,7,Poké Ball de Koraidon
+1667,8,Poké Ball Koraidon
+1667,12,故勒顿的球
 1668,1,ミライドンのボール
-1668,4,密勒顿的球
+1668,4,密勒頓的球
 1668,5,Poké Ball de Miraidon
 1668,9,Miraidon’s Poké Ball
 1668,11,ミライドンのボール
+1668,3,미라이돈의 볼
+1668,6,Miraidons Pokéball
+1668,7,Poké Ball de Miraidon
+1668,8,Poké Ball Miraidon
+1668,12,密勒顿的球
 1669,1,テラスタルオーブ
 1669,4,太晶珠
 1669,5,Orbe Téracristal
 1669,9,Tera Orb
 1669,11,テラスタルオーブ
+1669,3,테라스탈오브
+1669,6,Terakristall-Orb
+1669,7,Orbe Teracristal
+1669,8,Terasfera
+1669,12,太晶珠
 1670,1,スカーレットブック
-1670,4,朱之书
+1670,4,朱之書
 1670,5,Livre Écarlate
 1670,9,Scarlet Book
 1670,11,スカーレットブック
+1670,3,스칼렛북
+1670,6,Karmesinbuch
+1670,7,Libro Escarlata
+1670,8,Libro scarlatto
+1670,12,朱之书
 1671,1,バイオレットブック
-1671,4,紫之书
+1671,4,紫之書
 1671,5,Livre Violet
 1671,9,Violet Book
 1671,11,バイオレットブック
+1671,3,바이올렛북
+1671,6,Purpurbuch
+1671,7,Libro Púrpura
+1671,8,Libro violetto
+1671,12,紫之书
 1672,1,ハイダイのサイフ
-1672,4,海岱的钱包
+1672,4,海岱的錢包
 1672,5,Portefeuille de Kombu
 1672,9,Kofu’s Wallet
 1672,11,ハイダイのサイフ
+1672,3,곤포의 지갑
+1672,6,Kombus Geldbörse
+1672,7,Cartera de Fuco
+1672,8,Portafogli di Algaro
+1672,12,海岱的钱包
 1673,1,ちいさなタケノコ
-1673,4,小竹笋
+1673,4,小竹筍
 1673,5,Petit Bambou
 1673,9,Tiny Bamboo Shoot
 1673,11,ちいさなタケノコ
+1673,3,작은죽순
+1673,6,Minibambusspross
+1673,7,Bambú Pequeño
+1673,8,Minibambù
+1673,12,小竹笋
 1674,1,おおきなタケノコ
-1674,4,大竹笋
+1674,4,大竹筍
 1674,5,Gros Bambou
 1674,9,Big Bamboo Shoot
 1674,11,おおきなタケノコ
+1674,3,큰죽순
+1674,6,Riesenbambusspross
+1674,7,Bambú Grande
+1674,8,Grande bambù
+1674,12,大竹笋
 1675,1,あくのかけじく
-1675,4,恶之挂轴
+1675,4,惡之掛軸
 1675,5,Rouleau des Ténèbres
 1675,9,Scroll of Darkness
 1675,11,あくのかけじく
+1675,3,악의 족자
+1675,6,Unlicht-Schriftrolle
+1675,7,Manuscrito Sombras
+1675,8,Rotolo del Buio
+1675,12,恶之挂轴
 1676,1,みずのかけじく
-1676,4,水之挂轴
+1676,4,水之掛軸
 1676,5,Rouleau de l'Eau
 1676,9,Scroll of Waters
 1676,11,みずのかけじく
+1676,3,물의 족자
+1676,6,Wasser-Schriftrolle
+1676,7,Manuscrito Aguas
+1676,8,Rotolo dell’Acqua
+1676,12,水之挂轴
 1677,1,ノロイノヨロイ
-1677,4,咒术之铠
+1677,4,詛咒之鎧
 1677,5,Armure de la Rancune
 1677,9,Malicious Armor
 1677,11,ノロイノヨロイ
+1677,3,저주받은갑옷
+1677,6,Fluchrüstung
+1677,7,Armadura Maldita
+1677,8,Armatura infausta
+1677,12,咒术之铠
 1678,1,テラピースノーマル
-1678,4,一般太晶碎块
+1678,4,一般太晶碎塊
 1678,5,Téra-Éclat Normal
 1678,9,Normal Tera Shard
 1678,11,テラピースノーマル
+1678,3,테라피스 노말
+1678,6,Tera-Stück (Normal)
+1678,7,Teralito Normal
+1678,8,Teralite Normale
+1678,12,一般太晶碎块
 1679,1,テラピースほのお
-1679,4,火太晶碎块
+1679,4,火太晶碎塊
 1679,5,Téra-Éclat Feu
 1679,9,Fire Tera Shard
 1679,11,テラピースほのお
+1679,3,테라피스 불꽃
+1679,6,Tera-Stück (Feuer)
+1679,7,Teralito Fuego
+1679,8,Teralite Fuoco
+1679,12,火太晶碎块
 1680,1,テラピースみず
-1680,4,水太晶碎块
+1680,4,水太晶碎塊
 1680,5,Téra-Éclat Eau
 1680,9,Water Tera Shard
 1680,11,テラピースみず
+1680,3,테라피스 물
+1680,6,Tera-Stück (Wasser)
+1680,7,Teralito Agua
+1680,8,Teralite Acqua
+1680,12,水太晶碎块
 1681,1,テラピースでんき
-1681,4,电太晶碎块
+1681,4,電太晶碎塊
 1681,5,Téra-Éclat Électrik
 1681,9,Electric Tera Shard
 1681,11,テラピースでんき
+1681,3,테라피스 전기
+1681,6,Tera-Stück (Elektro)
+1681,7,Teralito Eléctrico
+1681,8,Teralite Elettro
+1681,12,电太晶碎块
 1682,1,テラピースくさ
-1682,4,草太晶碎块
+1682,4,草太晶碎塊
 1682,5,Téra-Éclat Plante
 1682,9,Grass Tera Shard
 1682,11,テラピースくさ
+1682,3,테라피스 풀
+1682,6,Tera-Stück (Pflanze)
+1682,7,Teralito Planta
+1682,8,Teralite Erba
+1682,12,草太晶碎块
 1683,1,テラピースこおり
-1683,4,冰太晶碎块
+1683,4,冰太晶碎塊
 1683,5,Téra-Éclat Glace
 1683,9,Ice Tera Shard
 1683,11,テラピースこおり
+1683,3,테라피스 얼음
+1683,6,Tera-Stück (Eis)
+1683,7,Teralito Hielo
+1683,8,Teralite Ghiaccio
+1683,12,冰太晶碎块
 1684,1,テラピースかくとう
-1684,4,格斗太晶碎块
+1684,4,格鬥太晶碎塊
 1684,5,Téra-Éclat Combat
 1684,9,Fighting Tera Shard
 1684,11,テラピースかくとう
+1684,3,테라피스 격투
+1684,6,Tera-Stück (Kampf)
+1684,7,Teralito Lucha
+1684,8,Teralite Lotta
+1684,12,格斗太晶碎块
 1685,1,テラピースどく
-1685,4,毒太晶碎块
+1685,4,毒太晶碎塊
 1685,5,Téra-Éclat Poison
 1685,9,Poison Tera Shard
 1685,11,テラピースどく
+1685,3,테라피스 독
+1685,6,Tera-Stück (Gift)
+1685,7,Teralito Veneno
+1685,8,Teralite Veleno
+1685,12,毒太晶碎块
 1686,1,テラピースじめん
-1686,4,地面太晶碎块
+1686,4,地面太晶碎塊
 1686,5,Téra-Éclat Sol
 1686,9,Ground Tera Shard
 1686,11,テラピースじめん
+1686,3,테라피스 땅
+1686,6,Tera-Stück (Boden)
+1686,7,Teralito Tierra
+1686,8,Teralite Terra
+1686,12,地面太晶碎块
 1687,1,テラピースひこう
-1687,4,飞行太晶碎块
+1687,4,飛行太晶碎塊
 1687,5,Téra-Éclat Vol
 1687,9,Flying Tera Shard
 1687,11,テラピースひこう
+1687,3,테라피스 비행
+1687,6,Tera-Stück (Flug)
+1687,7,Teralito Volador
+1687,8,Teralite Volante
+1687,12,飞行太晶碎块
 1688,1,テラピースエスパー
-1688,4,超能力太晶碎块
+1688,4,超能力太晶碎塊
 1688,5,Téra-Éclat Psy
 1688,9,Psychic Tera Shard
 1688,11,テラピースエスパー
+1688,3,테라피스 에스퍼
+1688,6,Tera-Stück (Psycho)
+1688,7,Teralito Psíquico
+1688,8,Teralite Psico
+1688,12,超能力太晶碎块
 1689,1,テラピースむし
-1689,4,虫太晶碎块
+1689,4,蟲太晶碎塊
 1689,5,Téra-Éclat Insecte
 1689,9,Bug Tera Shard
 1689,11,テラピースむし
+1689,3,테라피스 벌레
+1689,6,Tera-Stück (Käfer)
+1689,7,Teralito Bicho
+1689,8,Teralite Coleottero
+1689,12,虫太晶碎块
 1690,1,テラピースいわ
-1690,4,岩石太晶碎块
+1690,4,岩石太晶碎塊
 1690,5,Téra-Éclat Roche
 1690,9,Rock Tera Shard
 1690,11,テラピースいわ
+1690,3,테라피스 바위
+1690,6,Tera-Stück (Gestein)
+1690,7,Teralito Roca
+1690,8,Teralite Roccia
+1690,12,岩石太晶碎块
 1691,1,テラピースゴースト
-1691,4,幽灵太晶碎块
+1691,4,幽靈太晶碎塊
 1691,5,Téra-Éclat Spectre
 1691,9,Ghost Tera Shard
 1691,11,テラピースゴースト
+1691,3,테라피스 고스트
+1691,6,Tera-Stück (Geist)
+1691,7,Teralito Fantasma
+1691,8,Teralite Spettro
+1691,12,幽灵太晶碎块
 1692,1,テラピースドラゴン
-1692,4,龙太晶碎块
+1692,4,龍太晶碎塊
 1692,5,Téra-Éclat Dragon
 1692,9,Dragon Tera Shard
 1692,11,テラピースドラゴン
+1692,3,테라피스 드래곤
+1692,6,Tera-Stück (Drache)
+1692,7,Teralito Dragón
+1692,8,Teralite Drago
+1692,12,龙太晶碎块
 1693,1,テラピースあく
-1693,4,恶太晶碎块
+1693,4,惡太晶碎塊
 1693,5,Téra-Éclat Ténèbres
 1693,9,Dark Tera Shard
 1693,11,テラピースあく
+1693,3,테라피스 악
+1693,6,Tera-Stück (Unlicht)
+1693,7,Teralito Siniestro
+1693,8,Teralite Buio
+1693,12,恶太晶碎块
 1694,1,テラピースはがね
-1694,4,钢太晶碎块
+1694,4,鋼太晶碎塊
 1694,5,Téra-Éclat Acier
 1694,9,Steel Tera Shard
 1694,11,テラピースはがね
+1694,3,테라피스 강철
+1694,6,Tera-Stück (Stahl)
+1694,7,Teralito Acero
+1694,8,Teralite Acciaio
+1694,12,钢太晶碎块
 1695,1,テラピースフェアリー
-1695,4,妖精太晶碎块
+1695,4,妖精太晶碎塊
 1695,5,Téra-Éclat Fée
 1695,9,Fairy Tera Shard
 1695,11,テラピースフェアリー
+1695,3,테라피스 페어리
+1695,6,Tera-Stück (Fee)
+1695,7,Teralito Hada
+1695,8,Teralite Folletto
+1695,12,妖精太晶碎块
 1696,1,ブーストエナジー
-1696,4,驱劲能量
+1696,4,驅勁能量
 1696,5,Énergie Booster
 1696,9,Booster Energy
 1696,11,ブーストエナジー
+1696,3,부스트에너지
+1696,6,Energiekapsel
+1696,7,Energía Potenciadora
+1696,8,Capsula energetica
+1696,12,驱劲能量
 1697,1,とくせいガード
-1697,4,特性护具
+1697,4,特性護具
 1697,5,Garde-Talent
 1697,9,Ability Shield
 1697,11,とくせいガード
+1697,3,특성가드
+1697,6,Fähigkeitenschild
+1697,7,Escudo Habilidad
+1697,8,Scudo abilità
+1697,12,特性护具
 1698,1,クリアチャーム
-1698,4,清净坠饰
+1698,4,清淨墜飾
 1698,5,Talisman Sain
 1698,9,Clear Amulet
 1698,11,クリアチャーム
+1698,3,클리어참
+1698,6,Neutralschmuck
+1698,7,Amuleto Puro
+1698,8,Ciondolochiaro
+1698,12,清净坠饰
 1699,1,ものまねハーブ
 1699,4,模仿香草
 1699,5,Feuille Copieuse
 1699,9,Mirror Herb
 1699,11,ものまねハーブ
+1699,3,흉내허브
+1699,6,Kopierkraut
+1699,7,Hierba Copia
+1699,8,Foglia carbone
+1699,12,模仿香草
 1700,1,パンチグローブ
-1700,4,拳击手套
+1700,4,拳擊手套
 1700,5,Gant de Boxe
 1700,9,Punching Glove
 1700,11,パンチグローブ
+1700,3,펀치글러브
+1700,6,Boxhandschuh
+1700,7,Guante de Boxeo
+1700,8,Guantone
+1700,12,拳击手套
 1701,1,おんみつマント
 1701,4,密探斗篷
 1701,5,Cape Obscure
 1701,9,Covert Cloak
 1701,11,おんみつマント
+1701,3,은밀망토
+1701,6,Tarnumhang
+1701,7,Capa Furtiva
+1701,8,Anonimanto
+1701,12,密探斗篷
 1702,1,いかさまダイス
-1702,4,机变骰子
+1702,4,老千骰子
 1702,5,Dé Pipé
 1702,9,Loaded Dice
 1702,11,いかさまダイス
+1702,3,속임수주사위
+1702,6,Gezinkter Würfel
+1702,7,Dado Trucado
+1702,8,Dado truccato
+1702,12,机变骰子
 1703,1,バケット
-1703,4,长棍面包
+1703,4,長棍麵包
 1703,5,Baguette
 1703,9,Baguette
 1703,11,バケット
+1703,3,바게트
+1703,6,Baguette
+1703,7,Barra de Pan
+1703,8,Filoncino
+1703,12,长棍面包
 1704,1,マヨネーズ
-1704,4,蛋黄酱
+1704,4,美乃滋
 1704,5,Mayonnaise
 1704,9,Mayonnaise
 1704,11,マヨネーズ
+1704,3,마요네즈
+1704,6,Mayonnaise
+1704,7,Mayonesa
+1704,8,Maionese
+1704,12,蛋黄酱
 1705,1,ケチャップ
-1705,4,番茄酱
+1705,4,番茄醬
 1705,5,Ketchup
 1705,9,Ketchup
 1705,11,ケチャップ
+1705,3,케첩
+1705,6,Ketchup
+1705,7,Kétchup
+1705,8,Ketchup
+1705,12,番茄酱
 1706,1,マスタード
-1706,4,黄芥末酱
+1706,4,黃芥末醬
 1706,5,Moutarde
 1706,9,Mustard
 1706,11,マスタード
+1706,3,머스터드
+1706,6,Senf
+1706,7,Mostaza
+1706,8,Senape
+1706,12,黄芥末酱
 1707,1,バター
-1707,4,黄油
+1707,4,奶油
 1707,5,Beurre
 1707,9,Butter
 1707,11,バター
+1707,3,버터
+1707,6,Butter
+1707,7,Mantequilla
+1707,8,Burro
+1707,12,黄油
 1708,1,ピーナッツバター
-1708,4,花生酱
+1708,4,花生醬
 1708,5,Beurre de Cacahuètes
 1708,9,Peanut Butter
 1708,11,ピーナッツバター
+1708,3,땅콩버터
+1708,6,Erdnussbutter
+1708,7,Crema de Cacahuete
+1708,8,Burro di arachidi
+1708,12,花生酱
 1709,1,チリソース
-1709,4,辣酱
+1709,4,辣醬
 1709,5,Sauce Piquante
 1709,9,Chili Sauce
 1709,11,チリソース
+1709,3,칠리소스
+1709,6,Chilisoße
+1709,7,Salsa Picante
+1709,8,Salsa piccante
+1709,12,辣酱
 1710,1,ソルト
-1710,4,盐
+1710,4,鹽
 1710,5,Sel
 1710,9,Salt
 1710,11,ソルト
+1710,3,소금
+1710,6,Salz
+1710,7,Sal
+1710,8,Sale
+1710,12,盐
 1711,1,ペッパー
 1711,4,胡椒
 1711,5,Poivre
 1711,9,Pepper
 1711,11,ペッパー
+1711,3,후추
+1711,6,Pfeffer
+1711,7,Pimienta
+1711,8,Pepe
+1711,12,胡椒
 1712,1,ヨーグルト
-1712,4,酸奶
+1712,4,優格
 1712,5,Yaourt
 1712,9,Yogurt
 1712,11,ヨーグルト
+1712,3,요구르트
+1712,6,Joghurt
+1712,7,Yogur
+1712,8,Yogurt
+1712,12,酸奶
 1713,1,ホイップクリーム
-1713,4,鲜奶油
+1713,4,鮮奶油
 1713,5,Creme Fouettée
 1713,9,Whipped Cream
 1713,11,ホイップクリーム
+1713,3,휘핑크림
+1713,6,Schlagsahne
+1713,7,Nata Montada
+1713,8,Panna montata
+1713,12,鲜奶油
 1714,1,クリームチーズ
-1714,4,奶油芝士
+1714,4,奶油起司
 1714,5,Fromage Frais
 1714,9,Cream Cheese
 1714,11,クリームチーズ
+1714,3,크림치즈
+1714,6,Frischkäse
+1714,7,Queso Crema
+1714,8,Formaggio cremoso
+1714,12,奶油芝士
 1715,1,ベリージャム
-1715,4,莓果酱
+1715,4,莓果醬
 1715,5,Confiture de Baies
 1715,9,Jam
 1715,11,ベリージャム
+1715,3,베리잼
+1715,6,Beerenkonfitüre
+1715,7,Confitura de Bayas
+1715,8,Confettura di bosco
+1715,12,莓果酱
 1716,1,マーマレード
-1716,4,橘子酱
+1716,4,橘子醬
 1716,5,Marmelade
 1716,9,Marmalade
 1716,11,マーマレード
+1716,3,마멀레이드
+1716,6,Marmelade
+1716,7,Mermelada
+1716,8,Marmellata
+1716,12,橘子酱
 1717,1,オリーブオイル
-1717,4,橄榄油
+1717,4,橄欖油
 1717,5,Huile d'Olive
 1717,9,Olive Oil
 1717,11,オリーブオイル
+1717,3,올리브오일
+1717,6,Olivenöl
+1717,7,Aceite de Oliva
+1717,8,Olio d’oliva
+1717,12,橄榄油
 1718,1,ビネガー
 1718,4,醋
 1718,5,Vinaigre
 1718,9,Vinegar
 1718,11,ビネガー
+1718,3,비니거
+1718,6,Essig
+1718,7,Vinagre
+1718,8,Aceto
+1718,12,醋
 1719,1,ひでん：あまスパイス
-1719,4,秘传：甜味料
+1719,4,秘傳：甜味料
 1719,5,Épice Secrète Sucrée
 1719,9,Sweet Herba Mystica
 1719,11,ひでん：あまスパイス
+1719,3,비전 달콤스파이스
+1719,6,Süßes Geheimgewürz
+1719,7,Especia Oculta Dulce
+1719,8,Spezia nascosta dolce
+1719,12,秘传：甜味料
 1720,1,ひでん：しおスパイス
-1720,4,秘传：咸味料
+1720,4,秘傳：鹹味料
 1720,5,Épice Secrète Salée
 1720,9,Salty Herba Mystica
 1720,11,ひでん：しおスパイス
+1720,3,비전 짭짤스파이스
+1720,6,Salziges Geheimgewürz
+1720,7,Especia Oculta Salada
+1720,8,Spezia nascosta salata
+1720,12,秘传：咸味料
 1721,1,ひでん：すぱスパイス
-1721,4,秘传：酸味料
+1721,4,秘傳：酸味料
 1721,5,Épice Secrète Acide
 1721,9,Sour Herba Mystica
 1721,11,ひでん：すぱスパイス
+1721,3,비전 새콤스파이스
+1721,6,Saures Geheimgewürz
+1721,7,Especia Oculta Ácida
+1721,8,Spezia nascosta aspra
+1721,12,秘传：酸味料
 1722,1,ひでん：にがスパイス
-1722,4,秘传：苦味料
+1722,4,秘傳：苦味料
 1722,5,Épice Secrète Amère
 1722,9,Bitter Herba Mystica
 1722,11,ひでん：にがスパイス
+1722,3,비전 쌉쌀스파이스
+1722,6,Bitteres Geheimgewürz
+1722,7,Especia Oculta Amarga
+1722,8,Spezia nascosta amara
+1722,12,秘传：苦味料
 1723,1,ひでん：からスパイス
-1723,4,秘传：辣味料
+1723,4,秘傳：辣味料
 1723,5,Épice Secrète Corsée
 1723,9,Spicy Herba Mystica
 1723,11,ひでん：からスパイス
+1723,3,비전 매콤스파이스
+1723,6,Scharfes Geheimgewürz
+1723,7,Especia Oculta Picante
+1723,8,Spezia nascosta pepata
+1723,12,秘传：辣味料
 1724,1,レタス
 1724,4,生菜
 1724,5,Laitue
 1724,9,Lettuce
 1724,11,レタス
+1724,3,양상추
+1724,6,Salat
+1724,7,Lechuga
+1724,8,Lattuga
+1724,12,生菜
 1725,1,トマトスライス
-1725,4,西红柿片
+1725,4,番茄片
 1725,5,Tomate
 1725,9,Tomato
 1725,11,トマトスライス
+1725,3,토마토슬라이스
+1725,6,Tomate
+1725,7,Tomate
+1725,8,Pomodoro
+1725,12,番茄片
 1726,1,カットミニトマト
-1726,4,小西红柿块
+1726,4,小番茄塊
 1726,5,Tomate Cerise
 1726,9,Cherry Tomatoes
 1726,11,カットミニトマト
+1726,3,방울토마토슬라이스
+1726,6,Mini-Tomate
+1726,7,Tomate Cherri
+1726,8,Pomodorino
+1726,12,小番茄块
 1727,1,キュウリスライス
-1727,4,小黄瓜片
+1727,4,小黃瓜片
 1727,5,Concombre
 1727,9,Cucumber
 1727,11,キュウリスライス
+1727,3,오이슬라이스
+1727,6,Gurke
+1727,7,Pepino
+1727,8,Cetriolo
+1727,12,小黄瓜片
 1728,1,ピクルススライス
-1728,4,酸黄瓜片
+1728,4,酸黃瓜片
 1728,5,Cornichon
 1728,9,Pickle
 1728,11,ピクルススライス
+1728,3,피클슬라이스
+1728,6,Gewürzgurke
+1728,7,Pepinillo
+1728,8,Sottaceto
+1728,12,酸黄瓜片
 1729,1,たまねぎスライス
-1729,4,洋葱片
+1729,4,洋蔥片
 1729,5,Oignon
 1729,9,Onion
 1729,11,たまねぎスライス
+1729,3,양파슬라이스
+1729,6,Zwiebel
+1729,7,Cebolla
+1729,8,Cipolla
+1729,12,洋葱片
 1730,1,アーリーレッド
-1730,4,红洋葱
+1730,4,紅洋蔥
 1730,5,Oignon Rouge
 1730,9,Red Onion
 1730,11,アーリーレッド
+1730,3,적양파
+1730,6,Rote Zwiebel
+1730,7,Cebolla Roja
+1730,8,Cipolla rossa
+1730,12,红洋葱
 1731,1,ピーマンスライス
 1731,4,青椒片
 1731,5,Poivron Vert
 1731,9,Green Bell Pepper
 1731,11,ピーマンスライス
+1731,3,피망슬라이스
+1731,6,Grüne Paprika
+1731,7,Pimiento Verde
+1731,8,Peperone verde
+1731,12,青椒片
 1732,1,あかパプリカスライス
-1732,4,红椒片
+1732,4,紅椒片
 1732,5,Poivron Rouge
 1732,9,Red Bell Pepper
 1732,11,あかパプリカスライス
+1732,3,빨간파프리카슬라이스
+1732,6,Rote Paprika
+1732,7,Pimiento Rojo
+1732,8,Peperone rosso
+1732,12,红椒片
 1733,1,きパプリカスライス
-1733,4,黄椒片
+1733,4,黃椒片
 1733,5,Poivron Jaune
 1733,9,Yellow Bell Pepper
 1733,11,きパプリカスライス
+1733,3,노란파프리카슬라이스
+1733,6,Gelbe Paprika
+1733,7,Pimiento Amarillo
+1733,8,Peperone giallo
+1733,12,黄椒片
 1734,1,アボカド
-1734,4,牛油果
+1734,4,酪梨
 1734,5,Avocat
 1734,9,Avocado
 1734,11,アボカド
+1734,3,아보카도
+1734,6,Avocado
+1734,7,Aguacate
+1734,8,Avocado
+1734,12,牛油果
 1735,1,やきベーコン
 1735,4,煎培根
 1735,5,Bacon
 1735,9,Bacon
 1735,11,やきベーコン
+1735,3,구운베이컨
+1735,6,Gebratener Speck
+1735,7,Panceta
+1735,8,Pancetta rosolata
+1735,12,煎培根
 1736,1,ハムスライス
 1736,4,火腿片
 1736,5,Jambon Blanc
 1736,9,Ham
 1736,11,ハムスライス
+1736,3,슬라이스햄
+1736,6,Kochschinken
+1736,7,Jamón Cocido
+1736,8,Prosciutto cotto
+1736,12,火腿片
 1737,1,なまハム
 1737,4,生火腿
 1737,5,Jambon Cru
 1737,9,Prosciutto
 1737,11,なまハム
+1737,3,생햄
+1737,6,Roher Schinken
+1737,7,Jamón Serrano
+1737,8,Prosciutto crudo
+1737,12,生火腿
 1738,1,やきチョリソー
-1738,4,煎辣香肠
+1738,4,煎辣香腸
 1738,5,Chorizo Grillé
 1738,9,Chorizo
 1738,11,やきチョリソー
+1738,3,구운초리조
+1738,6,Chorizo
+1738,7,Chorizo
+1738,8,Chorizo rosolato
+1738,12,煎辣香肠
 1739,1,ハーブソーセージ
-1739,4,香草香肠
+1739,4,香草香腸
 1739,5,Saucisse aux Herbes
 1739,9,Herbed Sausage
 1739,11,ハーブソーセージ
+1739,3,허브소시지
+1739,6,Kräuterwurst
+1739,7,Butifarra
+1739,8,Salsiccia alle erbe
+1739,12,香草香肠
 1740,1,ハンバーグ
-1740,4,汉堡排
+1740,4,漢堡排
 1740,5,Steak Haché
 1740,9,Hamburger
 1740,11,ハンバーグ
+1740,3,햄버그
+1740,6,Frikadelle
+1740,7,Hamburguesa
+1740,8,Hamburger grigliato
+1740,12,汉堡排
 1741,1,ガケガニスティック
 1741,4,毛崖蟹棒
 1741,5,Bâtonnet de Craparoi
 1741,9,Klawf Stick
 1741,11,ガケガニスティック
+1741,3,절벼게맛살
+1741,6,Klibbe-Stick
+1741,7,Surimi de Klawf
+1741,8,Surimi di Klawf
+1741,12,毛崖蟹棒
 1742,1,スモークきりみ
-1742,4,烟熏鱼片
+1742,4,煙燻魚片
 1742,5,Filet Fumé
 1742,9,Smoked Fillet
 1742,11,スモークきりみ
+1742,3,훈제토막
+1742,6,Räucherfilet
+1742,7,Filete Ahumado
+1742,8,Filetto affumicato
+1742,12,烟熏鱼片
 1743,1,きりみフライ
-1743,4,炸鱼片
+1743,4,炸魚片
 1743,5,Filet Frit
 1743,9,Fried Fillet
 1743,11,きりみフライ
+1743,3,튀긴토막
+1743,6,Frittierfilet
+1743,7,Filete Frito
+1743,8,Filetto impanato
+1743,12,炸鱼片
 1744,1,スライスエッグ
 1744,4,水煮蛋片
 1744,5,Œuf
 1744,9,Egg
 1744,11,スライスエッグ
+1744,3,에그슬라이스
+1744,6,Ei
+1744,7,Huevo Cocido
+1744,8,Uovo bollito
+1744,12,水煮蛋片
 1745,1,トルティージャ
 1745,4,烘蛋
 1745,5,Tortilla
 1745,9,Potato Tortilla
 1745,11,トルティージャ
+1745,3,토르티야
+1745,6,Tortilla
+1745,7,Tortilla
+1745,8,Tortilla
+1745,12,烘蛋
 1746,1,トーフ
 1746,4,豆腐
 1746,5,Tofu
 1746,9,Tofu
 1746,11,トーフ
+1746,3,두부
+1746,6,Tofu
+1746,7,Tofu
+1746,8,Tofu
+1746,12,豆腐
 1747,1,ライス
-1747,4,米饭
+1747,4,米飯
 1747,5,Riz
 1747,9,Rice
 1747,11,ライス
+1747,3,라이스
+1747,6,Reis
+1747,7,Arroz
+1747,8,Riso
+1747,12,米饭
 1748,1,ヌードル
-1748,4,面条
+1748,4,麵條
 1748,5,Nouilles
 1748,9,Noodles
 1748,11,ヌードル
+1748,3,누들
+1748,6,Nudeln
+1748,7,Fideos
+1748,8,Noodle
+1748,12,面条
 1749,1,ポテトサラダ
-1749,4,土豆色拉
+1749,4,馬鈴薯沙拉
 1749,5,Salade de Patates
 1749,9,Potato Salad
 1749,11,ポテトサラダ
+1749,3,감자샐러드
+1749,6,Kartoffelsalat
+1749,7,Ensaladilla
+1749,8,Insalata di patate
+1749,12,土豆沙拉
 1750,1,スライスチーズ
-1750,4,芝士片
+1750,4,起司片
 1750,5,Fromage
 1750,9,Cheese
 1750,11,スライスチーズ
+1750,3,슬라이스치즈
+1750,6,Scheibenkäse
+1750,7,Queso
+1750,8,Formaggio
+1750,12,芝士片
 1751,1,バナナスライス
 1751,4,香蕉片
 1751,5,Banane
 1751,9,Banana
 1751,11,バナナスライス
+1751,3,바나나슬라이스
+1751,6,Banane
+1751,7,Plátano
+1751,8,Banana
+1751,12,香蕉片
 1752,1,いちごスライス
 1752,4,草莓片
 1752,5,Fraise
 1752,9,Strawberry
 1752,11,いちごスライス
+1752,3,딸기슬라이스
+1752,6,Erdbeere
+1752,7,Fresa
+1752,8,Fragola
+1752,12,草莓片
 1753,1,わぎりリンゴ
-1753,4,苹果片
+1753,4,蘋果片
 1753,5,Pomme
 1753,9,Apple
 1753,11,わぎりリンゴ
+1753,3,사과슬라이스
+1753,6,Apfel
+1753,7,Manzana
+1753,8,Mela
+1753,12,苹果片
 1754,1,わぎりキウイ
-1754,4,奇异果片
+1754,4,奇異果片
 1754,5,Kiwi
 1754,9,Kiwi
 1754,11,わぎりキウイ
+1754,3,키위슬라이스
+1754,6,Kiwi
+1754,7,Kiwi
+1754,8,Kiwi
+1754,12,奇异果片
 1755,1,カットパイン
-1755,4,凤梨片
+1755,4,鳳梨片
 1755,5,Ananas
 1755,9,Pineapple
 1755,11,カットパイン
+1755,3,파인애플슬라이스
+1755,6,Ananas
+1755,7,Piña
+1755,8,Ananas
+1755,12,凤梨片
 1756,1,バラペーニョ
 1756,4,小辣椒
 1756,5,Piment
 1756,9,Jalapeño
 1756,11,バラペーニョ
+1756,3,할라페뇨
+1756,6,Jalapeño
+1756,7,Jalapeño
+1756,8,Jalapeño
+1756,12,小辣椒
 1757,1,ホースラディッシュ
 1757,4,辣根
 1757,5,Raifort
 1757,9,Horseradish
 1757,11,ホースラディッシュ
+1757,3,호스래디시
+1757,6,Meerrettich
+1757,7,Rábano Picante
+1757,8,Rafano
+1757,12,辣根
 1758,1,カレーパウダー
-1758,4,咖喱粉
+1758,4,咖哩粉
 1758,5,Curry en Poudre
 1758,9,Curry Powder
 1758,11,カレーパウダー
+1758,3,카레파우더
+1758,6,Currypulver
+1758,7,Curri en Polvo
+1758,8,Curry in polvere
+1758,12,咖喱粉
 1759,1,ワサビソース
-1759,4,芥末酱
+1759,4,芥末醬
 1759,5,Sauce au Wasabi
 1759,9,Wasabi
 1759,11,ワサビソース
+1759,3,와사비소스
+1759,6,Wasabi
+1759,7,Wasabi
+1759,8,Wasabi
+1759,12,芥末酱
 1760,1,クレソン
 1760,4,豆瓣菜
 1760,5,Cresson
 1760,9,Watercress
 1760,11,クレソン
+1760,3,물냉이
+1760,6,Kresse
+1760,7,Berros
+1760,8,Crescione
+1760,12,豆瓣菜
 1761,1,バジル
-1761,4,罗勒
+1761,4,羅勒
 1761,5,Basilic
 1761,9,Basil
 1761,11,バジル
+1761,3,바질
+1761,6,Basilikum
+1761,7,Albahaca
+1761,8,Basilico
+1761,12,罗勒
 1762,1,コンパンのキバ
 1762,4,毛球的牙
 1762,5,Croc de Mimitoss
 1762,9,Venonat Fang
 1762,11,コンパンのキバ
+1762,3,콘팡의이빨
+1762,6,Bluzuk-Zahn
+1762,7,Colmillo de Venonat
+1762,8,Zanna di Venonat
+1762,12,毛球的牙
 1763,1,ディグダのつち
 1763,4,地鼠的土
 1763,5,Terre de Taupiqueur
 1763,9,Diglett Dirt
 1763,11,ディグダのつち
+1763,3,디그다의흙
+1763,6,Digda-Erde
+1763,7,Tierra de Diglett
+1763,8,Terra di Diglett
+1763,12,地鼠的土
 1764,1,ニャースのけ
 1764,4,喵喵的毛
 1764,5,Poils de Miaouss
 1764,9,Meowth Fur
 1764,11,ニャースのけ
+1764,3,나옹의털
+1764,6,Mauzi-Haar
+1764,7,Pelo de Meowth
+1764,8,Pelo di Meowth
+1764,12,喵喵的毛
 1765,1,コダックのうもう
-1765,4,可达鸭的羽绒
+1765,4,可達鴨的羽絨
 1765,5,Duvet de Psykokwak
 1765,9,Psyduck Down
 1765,11,コダックのうもう
+1765,3,고라파덕의솜털
+1765,6,Enton-Daune
+1765,7,Plumón de Psyduck
+1765,8,Piuma di Psyduck
+1765,12,可达鸭的羽绒
 1766,1,マンキーのけ
 1766,4,猴怪的毛
 1766,5,Poils de Férosinge
 1766,9,Mankey Fur
 1766,11,マンキーのけ
+1766,3,망키의털
+1766,6,Menki-Haar
+1766,7,Pelo de Mankey
+1766,8,Pelo di Mankey
+1766,12,猴怪的毛
 1767,1,ガーディのけ
 1767,4,卡蒂狗的毛
 1767,5,Poils de Caninos
 1767,9,Growlithe Fur
 1767,11,ガーディのけ
+1767,3,가디의털
+1767,6,Fukano-Haar
+1767,7,Pelo de Growlithe
+1767,8,Pelo di Growlithe
+1767,12,卡蒂狗的毛
 1768,1,ヤドンのツメ
-1768,4,呆呆兽的爪子
+1768,4,呆呆獸的爪子
 1768,5,Griffe de Ramoloss
 1768,9,Slowpoke Claw
 1768,11,ヤドンのツメ
+1768,3,야돈의발톱
+1768,6,Flegmon-Kralle
+1768,7,Garra de Slowpoke
+1768,8,Artiglio di Slowpoke
+1768,12,呆呆兽的爪子
 1769,1,コイルのねじ
-1769,4,小磁怪的螺丝
+1769,4,小磁怪的螺絲
 1769,5,Vis de Magnéti
 1769,9,Magnemite Screw
 1769,11,コイルのねじ
+1769,3,코일의나사
+1769,6,Magnetilo-Schraube
+1769,7,Tornillo de Magnemite
+1769,8,Vite di Magnemite
+1769,12,小磁怪的螺丝
 1770,1,ベトベターのどくそ
 1770,4,臭泥的毒素
 1770,5,Poison de Tadmorv
 1770,9,Grimer Toxin
 1770,11,ベトベターのどくそ
+1770,3,질퍽이의독소
+1770,6,Sleima-Toxin
+1770,7,Toxinas de Grimer
+1770,8,Tossine di Grimer
+1770,12,臭泥的毒素
 1771,1,シェルダーのしんじゅ
-1771,4,大舌贝的珍珠
+1771,4,大舌貝的珍珠
 1771,5,Perle de Kokiyas
 1771,9,Shellder Pearl
 1771,11,シェルダーのしんじゅ
+1771,3,셀러의진주
+1771,6,Muschas-Perle
+1771,7,Perla de Shellder
+1771,8,Perla di Shellder
+1771,12,大舌贝的珍珠
 1772,1,ゴースのガス
-1772,4,鬼斯的气体
+1772,4,鬼斯的氣體
 1772,5,Gaz de Fantominus
 1772,9,Gastly Gas
 1772,11,ゴースのガス
+1772,3,고오스의가스
+1772,6,Nebulak-Gas
+1772,7,Gas de Gastly
+1772,8,Gas di Gastly
+1772,12,鬼斯的气体
 1773,1,スリープのけ
 1773,4,催眠貘的毛
 1773,5,Poils de Soporifik
 1773,9,Drowzee Fur
 1773,11,スリープのけ
+1773,3,슬리프의털
+1773,6,Traumato-Haar
+1773,7,Pelo de Drowzee
+1773,8,Pelo di Drowzee
+1773,12,催眠貘的毛
 1774,1,ビリリダマのでんき
-1774,4,霹雳电球的电力
+1774,4,霹靂電球的電力
 1774,5,Électricité de Voltorbe
 1774,9,Voltorb Sparks
 1774,11,ビリリダマのでんき
+1774,3,찌리리공의전기
+1774,6,Voltobal-Strom
+1774,7,Electricidad de Voltorb
+1774,8,Elettricità di Voltorb
+1774,12,霹雳电球的电力
 1775,1,ストライクのツメ
-1775,4,飞天螳螂的爪子
+1775,4,飛天螳螂的爪子
 1775,5,Griffe d'Insécateur
 1775,9,Scyther Claw
 1775,11,ストライクのツメ
+1775,3,스라크의발톱
+1775,6,Sichlor-Kralle
+1775,7,Garra de Scyther
+1775,8,Artiglio di Scyther
+1775,12,飞天螳螂的爪子
 1776,1,ケンタロスのけ
-1776,4,肯泰罗的毛
+1776,4,肯泰羅的毛
 1776,5,Poils de Tauros
 1776,9,Tauros Hair
 1776,11,ケンタロスのけ
+1776,3,켄타로스의털
+1776,6,Tauros-Haar
+1776,7,Pelo de Tauros
+1776,8,Pelo di Tauros
+1776,12,肯泰罗的毛
 1777,1,コイキングのウロコ
-1777,4,鲤鱼王的鳞片
+1777,4,鯉魚王的鱗片
 1777,5,Écaille de Magicarpe
 1777,9,Magikarp Scales
 1777,11,コイキングのウロコ
+1777,3,잉어킹의비늘
+1777,6,Karpador-Schuppe
+1777,7,Escama de Magikarp
+1777,8,Squama di Magikarp
+1777,12,鲤鱼王的鳞片
 1778,1,メタモンのべたべた
-1778,4,百变怪的黏糊
+1778,4,百變怪的黏糊
 1778,5,Substance de Métamorph
 1778,9,Ditto Goo
 1778,11,メタモンのべたべた
+1778,3,메타몽의끈끈이
+1778,6,Ditto-Glibber
+1778,7,Pegote de Ditto
+1778,8,Appiccicume di Ditto
+1778,12,百变怪的黏糊
 1779,1,イーブイのけ
 1779,4,伊布的毛
 1779,5,Poils d’Évoli
 1779,9,Eevee Fur
 1779,11,イーブイのけ
+1779,3,이브이의털
+1779,6,Evoli-Haar
+1779,7,Pelo de Eevee
+1779,8,Pelo di Eevee
+1779,12,伊布的毛
 1780,1,ミニリュウのウロコ
-1780,4,迷你龙的鳞片
+1780,4,迷你龍的鱗片
 1780,5,Écaille de Minidraco
 1780,9,Dratini Scales
 1780,11,ミニリュウのウロコ
+1780,3,미뇽의비늘
+1780,6,Dratini-Schuppe
+1780,7,Escama de Dratini
+1780,8,Squama di Dratini
+1780,12,迷你龙的鳞片
 1781,1,ピチューのけ
 1781,4,皮丘的毛
 1781,5,Poils de Pichu
 1781,9,Pichu Fur
 1781,11,ピチューのけ
+1781,3,피츄의털
+1781,6,Pichu-Haar
+1781,7,Pelo de Pichu
+1781,8,Pelo di Pichu
+1781,12,皮丘的毛
 1782,1,ププリンのけ
-1782,4,宝宝丁的毛
+1782,4,寶寶丁的毛
 1782,5,Poils de Toudoudou
 1782,9,Igglybuff Fluff
 1782,11,ププリンのけ
+1782,3,푸푸린의털
+1782,6,Fluffeluff-Haar
+1782,7,Pelo de Igglybuff
+1782,8,Pelo di Igglybuff
+1782,12,宝宝丁的毛
 1783,1,メリープのけだま
 1783,4,咩利羊的毛球
 1783,5,Laine de Wattouat
 1783,9,Mareep Wool
 1783,11,メリープのけだま
+1783,3,메리프의털뭉치
+1783,6,Voltilamm-Wolle
+1783,7,Lana de Mareep
+1783,8,Lana di Mareep
+1783,12,咩利羊的毛球
 1784,1,ハネッコのはっぱ
-1784,4,毽子草的叶片
+1784,4,毽子草的葉片
 1784,5,Feuille de Granivol
 1784,9,Hoppip Leaf
 1784,11,ハネッコのはっぱ
+1784,3,통통코의잎
+1784,6,Hoppspross-Blatt
+1784,7,Hoja de Hoppip
+1784,8,Foglia di Hoppip
+1784,12,毽子草的叶片
 1785,1,ヒマナッツのはっぱ
-1785,4,向日种子的叶片
+1785,4,向日種子的葉片
 1785,5,Feuille de Tournegrin
 1785,9,Sunkern Leaf
 1785,11,ヒマナッツのはっぱ
+1785,3,해너츠의잎
+1785,6,Sonnkern-Blatt
+1785,7,Hoja de Sunkern
+1785,8,Foglia di Sunkern
+1785,12,向日种子的叶片
 1786,1,ヤミカラスのおたから
-1786,4,黑暗鸦的宝物
+1786,4,黑暗鴉的寶物
 1786,5,Trésor de Cornèbre
 1786,9,Murkrow Bauble
 1786,11,ヤミカラスのおたから
+1786,3,니로우의보물
+1786,6,Kramurx-Schatz
+1786,7,Tesoro de Murkrow
+1786,8,Tesoro di Murkrow
+1786,12,黑暗鸦的宝物
 1787,1,ムウマのなみだ
-1787,4,梦妖的眼泪
+1787,4,夢妖的眼淚
 1787,5,Larme de Feuforêve
 1787,9,Misdreavus Tears
 1787,11,ムウマのなみだ
+1787,3,무우마의눈물
+1787,6,Traunfugil-Träne
+1787,7,Lágrima de Misdreavus
+1787,8,Lacrime di Misdreavus
+1787,12,梦妖的眼泪
 1788,1,キリンリキのけ
 1788,4,麒麟奇的毛
 1788,5,Poils de Girafarig
 1788,9,Girafarig Fur
 1788,11,キリンリキのけ
+1788,3,키링키의털
+1788,6,Girafarig-Haar
+1788,7,Pelo de Girafarig
+1788,8,Pelo di Girafarig
+1788,12,麒麟奇的毛
 1789,1,クヌギダマのから
-1789,4,榛果球的壳
+1789,4,榛果球的殼
 1789,5,Écorce de Pomdepik
 1789,9,Pineco Husk
 1789,11,クヌギダマのから
+1789,3,피콘의껍데기
+1789,6,Tannza-Schale
+1789,7,Corteza de Pineco
+1789,8,Guscio di Pineco
+1789,12,榛果球的壳
 1790,1,ノコッチのウロコ
-1790,4,土龙弟弟的鳞片
+1790,4,土龍弟弟的鱗片
 1790,5,Écaille d'Insolourdo
 1790,9,Dunsparce Scales
 1790,11,ノコッチのウロコ
+1790,3,노고치의비늘
+1790,6,Dummisel-Schuppe
+1790,7,Escama de Dunsparce
+1790,8,Squama di Dunsparce
+1790,12,土龙弟弟的鳞片
 1791,1,ハリーセンのトゲ
-1791,4,千针鱼的刺
+1791,4,千針魚的刺
 1791,5,Épine de Qwilfish
 1791,9,Qwilfish Spines
 1791,11,ハリーセンのトゲ
+1791,3,침바루의가시
+1791,6,Baldorfish-Stachel
+1791,7,Púa de Qwilfish
+1791,8,Aculeo di Qwilfish
+1791,12,千针鱼的刺
 1792,1,ヘラクロスのツメ
-1792,4,赫拉克罗斯的爪子
+1792,4,赫拉克羅斯的爪子
 1792,5,Griffe de Scarhino
 1792,9,Heracross Claw
 1792,11,ヘラクロスのツメ
+1792,3,헤라크로스의발톱
+1792,6,Skaraborn-Kralle
+1792,7,Garra de Heracross
+1792,8,Artiglio di Heracross
+1792,12,赫拉克罗斯的爪子
 1793,1,ニューラのツメ
 1793,4,狃拉的爪子
 1793,5,Griffe de Farfuret
 1793,9,Sneasel Claw
 1793,11,ニューラのツメ
+1793,3,포푸니의손톱
+1793,6,Sniebel-Kralle
+1793,7,Garra de Sneasel
+1793,8,Artiglio di Sneasel
+1793,12,狃拉的爪子
 1794,1,ヒメグマのツメ
-1794,4,熊宝宝的爪子
+1794,4,熊寶寶的爪子
 1794,5,Griffe de Teddiursa
 1794,9,Teddiursa Claw
 1794,11,ヒメグマのツメ
+1794,3,깜지곰의손톱
+1794,6,Teddiursa-Kralle
+1794,7,Garra de Teddiursa
+1794,8,Artiglio di Teddiursa
+1794,12,熊宝宝的爪子
 1795,1,デリバードのにもつ
-1795,4,信使鸟的行李
+1795,4,信使鳥的行李
 1795,5,Provisions de Cadoizo
 1795,9,Delibird Parcel
 1795,11,デリバードのにもつ
+1795,3,딜리버드의짐
+1795,6,Botogel-Päckchen
+1795,7,Paquete de Delibird
+1795,8,Scorte di Delibird
+1795,12,信使鸟的行李
 1796,1,デルビルのキバ
-1796,4,戴鲁比的牙
+1796,4,戴魯比的牙
 1796,5,Croc de Malosse
 1796,9,Houndour Fang
 1796,11,デルビルのキバ
+1796,3,델빌의이빨
+1796,6,Hunduster-Zahn
+1796,7,Colmillo de Houndour
+1796,8,Zanna di Houndour
+1796,12,戴鲁比的牙
 1797,1,ゴマゾウのツメ
 1797,4,小小象的爪子
 1797,5,Ongle de Phanpy
 1797,9,Phanpy Nail
 1797,11,ゴマゾウのツメ
+1797,3,코코리의발톱
+1797,6,Phanpy-Kralle
+1797,7,Uña de Phanpy
+1797,8,Unghia di Phanpy
+1797,12,小小象的爪子
 1798,1,オドシシのけ
-1798,4,惊角鹿的毛
+1798,4,驚角鹿的毛
 1798,5,Poils de Cerfrousse
 1798,9,Stantler Hair
 1798,11,オドシシのけ
+1798,3,노라키의털
+1798,6,Damhirplex-Haar
+1798,7,Pelo de Stantler
+1798,8,Pelo di Stantler
+1798,12,惊角鹿的毛
 1799,1,ヨーギラスのツメ
 1799,4,幼基拉斯的爪子
 1799,5,Griffe d'Embrylex
 1799,9,Larvitar Claw
 1799,11,ヨーギラスのツメ
+1799,3,애버라스의발톱
+1799,6,Larvitar-Kralle
+1799,7,Garra de Larvitar
+1799,8,Artiglio di Larvitar
+1799,12,幼基拉斯的爪子
 1800,1,キャモメのはね
-1800,4,长翅鸥的羽毛
+1800,4,長翅鷗的羽毛
 1800,5,Plume de Goélise
 1800,9,Wingull Feather
 1800,11,キャモメのはね
+1800,3,갈모매의깃털
+1800,6,Wingull-Feder
+1800,7,Pluma de Wingull
+1800,8,Penna di Wingull
+1800,12,长翅鸥的羽毛
 1801,1,ラルトスのおとしもの
-1801,4,拉鲁拉丝的掉落物
+1801,4,拉魯拉絲的掉落物
 1801,5,Babiole de Tarsal
 1801,9,Ralts Dust
 1801,11,ラルトスのおとしもの
+1801,3,랄토스의유실물
+1801,6,Trasla-Material
+1801,7,Pertenencia de Ralts
+1801,8,Oggetto di Ralts
+1801,12,拉鲁拉丝的掉落物
 1802,1,アメタマのミツ
 1802,4,溜溜糖球的蜜
 1802,5,Nectar d'Arakdo
 1802,9,Surskit Syrup
 1802,11,アメタマのミツ
+1802,3,비구술의꿀
+1802,6,Gehweiher-Nektar
+1802,7,Néctar de Surskit
+1802,8,Sciroppo di Surskit
+1802,12,溜溜糖球的蜜
 1803,1,キノココのほうし
 1803,4,蘑蘑菇的孢子
 1803,5,Spores de Balignon
 1803,9,Shroomish Spores
 1803,11,キノココのほうし
+1803,3,버섯꼬의포자
+1803,6,Knilz-Spore
+1803,7,Esporas de Shroomish
+1803,8,Spore di Shroomish
+1803,12,蘑蘑菇的孢子
 1804,1,ナマケロのけ
-1804,4,懒人獭的毛
+1804,4,懶人獺的毛
 1804,5,Poils de Parecool
 1804,9,Slakoth Fur
 1804,11,ナマケロのけ
+1804,3,게을로의털
+1804,6,Bummelz-Haar
+1804,7,Pelo de Slakoth
+1804,8,Pelo di Slakoth
+1804,12,懒人獭的毛
 1805,1,マクノシタのあせ
 1805,4,幕下力士的汗
 1805,5,Sueur de Makuhita
 1805,9,Makuhita Sweat
 1805,11,マクノシタのあせ
+1805,3,마크탕의땀
+1805,6,Makuhita-Schweiß
+1805,7,Sudor de Makuhita
+1805,8,Sudore di Makuhita
+1805,12,幕下力士的汗
 1806,1,ルリリのけ
-1806,4,露力丽的毛
+1806,4,露力麗的毛
 1806,5,Poils d'Azurill
 1806,9,Azurill Fur
 1806,11,ルリリのけ
+1806,3,루리리의털
+1806,6,Azurill-Haar
+1806,7,Pelo de Azurill
+1806,8,Pelo di Azurill
+1806,12,露力丽的毛
 1807,1,ヤミラミのほうせき
-1807,4,勾魂眼的宝石
+1807,4,勾魂眼的寶石
 1807,5,Joyau de Ténéfix
 1807,9,Sableye Gem
 1807,11,ヤミラミのほうせき
+1807,3,깜까미의보석
+1807,6,Zobiris-Edelstein
+1807,7,Gema de Sableye
+1807,8,Gemma di Sableye
+1807,12,勾魂眼的宝石
 1808,1,アサナンのあせ
-1808,4,玛沙那的汗
+1808,4,瑪沙那的汗
 1808,5,Sueur de Méditikka
 1808,9,Meditite Sweat
 1808,11,アサナンのあせ
+1808,3,요가랑의땀
+1808,6,Meditie-Schweiß
+1808,7,Sudor de Meditite
+1808,8,Sudore di Meditite
+1808,12,玛沙那的汗
 1809,1,ゴクリンのねんえき
-1809,4,溶食兽的黏液
+1809,4,溶食獸的黏液
 1809,5,Mucus de Gloupti
 1809,9,Gulpin Mucus
 1809,11,ゴクリンのねんえき
+1809,3,꼴깍몬의점액
+1809,6,Schluppuck-Schleim
+1809,7,Secreción de Gulpin
+1809,8,Muco di Gulpin
+1809,12,溶食兽的黏液
 1810,1,ドンメルのようがん
-1810,4,呆火驼的熔岩
+1810,4,呆火駝的熔岩
 1810,5,Lave de Chamallot
 1810,9,Numel Lava
 1810,11,ドンメルのようがん
+1810,3,둔타의용암
+1810,6,Camaub-Lava
+1810,7,Lava de Numel
+1810,8,Lava di Numel
+1810,12,呆火驼的熔岩
 1811,1,コータスのせきたん
-1811,4,煤炭龟的煤炭
+1811,4,煤炭龜的煤炭
 1811,5,Charbon de Chartor
 1811,9,Torkoal Coal
 1811,11,コータスのせきたん
+1811,3,코터스의석탄
+1811,6,Qurtel-Kohle
+1811,7,Carbón de Torkoal
+1811,8,Carbone di Torkoal
+1811,12,煤炭龟的煤炭
 1812,1,バネブーのしんじゅ
-1812,4,跳跳猪的珍珠
+1812,4,跳跳豬的珍珠
 1812,5,Perle de Spoink
 1812,9,Spoink Pearl
 1812,11,バネブーのしんじゅ
+1812,3,피그점프의진주
+1812,6,Spoink-Perle
+1812,7,Perla de Spoink
+1812,8,Perla di Spoink
+1812,12,跳跳猪的珍珠
 1813,1,サボネアのトゲ
 1813,4,刺球仙人掌的刺
 1813,5,Épine de Cacnea
 1813,9,Cacnea Needle
 1813,11,サボネアのトゲ
+1813,3,선인왕의가시
+1813,6,Tuska-Stachel
+1813,7,Espina de Cacnea
+1813,8,Spina di Cacnea
+1813,12,刺球仙人掌的刺
 1814,1,チルットのはね
-1814,4,青绵鸟的羽毛
+1814,4,青綿鳥的羽毛
 1814,5,Plume de Tylton
 1814,9,Swablu Fluff
 1814,11,チルットのはね
+1814,3,파비코의깃털
+1814,6,Wablu-Feder
+1814,7,Pluma de Swablu
+1814,8,Piuma di Swablu
+1814,12,青绵鸟的羽毛
 1815,1,ザングースのツメ
-1815,4,猫鼬斩的爪子
+1815,4,貓鼬斬的爪子
 1815,5,Griffe de Mangriff
 1815,9,Zangoose Claw
 1815,11,ザングースのツメ
+1815,3,쟝고의발톱
+1815,6,Sengo-Kralle
+1815,7,Garra de Zangoose
+1815,8,Artiglio di Zangoose
+1815,12,猫鼬斩的爪子
 1816,1,ハブネークのキバ
-1816,4,饭匙蛇的牙
+1816,4,飯匙蛇的牙
 1816,5,Croc de Séviper
 1816,9,Seviper Fang
 1816,11,ハブネークのキバ
+1816,3,세비퍼의이빨
+1816,6,Vipitis-Zahn
+1816,7,Colmillo de Seviper
+1816,8,Zanna di Seviper
+1816,12,饭匙蛇的牙
 1817,1,ドジョッチのねんえき
-1817,4,泥泥鳅的黏液
+1817,4,泥泥鰍的黏液
 1817,5,Mucus de Barloche
 1817,9,Barboach Slime
 1817,11,ドジョッチのねんえき
+1817,3,미꾸리의점액
+1817,6,Schmerbe-Schleim
+1817,7,Secreción de Barboach
+1817,8,Muco di Barboach
+1817,12,泥泥鳅的黏液
 1818,1,カゲボウズのきれはし
-1818,4,怨影娃娃的残片
+1818,4,怨影娃娃的殘片
 1818,5,Tissu de Polichombr
 1818,9,Shuppet Scrap
 1818,11,カゲボウズのきれはし
+1818,3,어둠대신의천조각
+1818,6,Shuppet-Fetzen
+1818,7,Retal de Shuppet
+1818,8,Brandello di Shuppet
+1818,12,怨影娃娃的残片
 1819,1,トロピウスのはっぱ
-1819,4,热带龙的叶片
+1819,4,熱帶龍的葉片
 1819,5,Feuille de Tropius
 1819,9,Tropius Leaf
 1819,11,トロピウスのはっぱ
+1819,3,트로피우스의잎
+1819,6,Tropius-Blatt
+1819,7,Hoja de Tropius
+1819,8,Foglia di Tropius
+1819,12,热带龙的叶片
 1820,1,ユキワラシのけ
 1820,4,雪童子的毛
 1820,5,Poils de Stalgamin
 1820,9,Snorunt Fur
 1820,11,ユキワラシのけ
+1820,3,눈꼬마의털
+1820,6,Schneppke-Haar
+1820,7,Pelo de Snorunt
+1820,8,Pelo di Snorunt
+1820,12,雪童子的毛
 1821,1,ラブカスのウロコ
-1821,4,爱心鱼的鳞片
+1821,4,愛心魚的鱗片
 1821,5,Écaille de Lovdisc
 1821,9,Luvdisc Scales
 1821,11,ラブカスのウロコ
+1821,3,사랑동이의비늘
+1821,6,Liebiskus-Schuppe
+1821,7,Escama de Luvdisc
+1821,8,Squama di Luvdisc
+1821,12,爱心鱼的鳞片
 1822,1,タツベイのウロコ
-1822,4,宝贝龙的鳞片
+1822,4,寶貝龍的鱗片
 1822,5,Écaille de Draby
 1822,9,Bagon Scales
 1822,11,タツベイのウロコ
+1822,3,아공이의비늘
+1822,6,Kindwurm-Schuppe
+1822,7,Escama de Bagon
+1822,8,Squama di Bagon
+1822,12,宝贝龙的鳞片
 1823,1,ムックルのはね
-1823,4,姆克儿的羽毛
+1823,4,姆克兒的羽毛
 1823,5,Plume d’Étourmi
 1823,9,Starly Feather
 1823,11,ムックルのはね
+1823,3,찌르꼬의깃털
+1823,6,Staralili-Feder
+1823,7,Pluma de Starly
+1823,8,Penna di Starly
+1823,12,姆克儿的羽毛
 1824,1,コロボーシのぬけがら
-1824,4,圆法师的蜕壳
+1824,4,圓法師的蛻殼
 1824,5,Mue de Crikzik
 1824,9,Kricketot Shell
 1824,11,コロボーシのぬけがら
+1824,3,귀뚤뚜기의허물
+1824,6,Zirpurze-Häutungsrest
+1824,7,Muda de Kricketot
+1824,8,Esuvia di Kricketot
+1824,12,圆法师的蜕壳
 1825,1,コリンクのキバ
-1825,4,小猫怪的牙
+1825,4,小貓怪的牙
 1825,5,Croc de Lixy
 1825,9,Shinx Fang
 1825,11,コリンクのキバ
+1825,3,꼬링크의이빨
+1825,6,Sheinux-Zahn
+1825,7,Colmillo de Shinx
+1825,8,Zanna di Shinx
+1825,12,小猫怪的牙
 1826,1,ミツハニーのミツ
 1826,4,三蜜蜂的蜜
 1826,5,Nectar d'Apitrini
 1826,9,Combee Honey
 1826,11,ミツハニーのミツ
+1826,3,세꿀버리의꿀
+1826,6,Wadribie-Honig
+1826,7,Miel de Combee
+1826,8,Nettare di Combee
+1826,12,三蜜蜂的蜜
 1827,1,パチリスのけ
-1827,4,帕奇利兹的毛
+1827,4,帕奇利茲的毛
 1827,5,Poils de Pachirisu
 1827,9,Pachirisu Fur
 1827,11,パチリスのけ
+1827,3,파치리스의털
+1827,6,Pachirisu-Haar
+1827,7,Pelo de Pachirisu
+1827,8,Pelo di Pachirisu
+1827,12,帕奇利兹的毛
 1828,1,ブイゼルのけ
 1828,4,泳圈鼬的毛
 1828,5,Poils de Mustébouée
 1828,9,Buizel Fur
 1828,11,ブイゼルのけ
+1828,3,브이젤의털
+1828,6,Bamelin-Haar
+1828,7,Pelo de Buizel
+1828,8,Pelo di Buizel
+1828,12,泳圈鼬的毛
 1829,1,カラナクシのねんえき
-1829,4,无壳海兔的黏液
+1829,4,無殼海兔的黏液
 1829,5,Mucus de Sancoki
 1829,9,Shellos Mucus
 1829,11,カラナクシのねんえき
+1829,3,깝질무의점액
+1829,6,Schalellos-Schleim
+1829,7,Secreción de Shellos
+1829,8,Bava di Shellos
+1829,12,无壳海兔的黏液
 1830,1,フワンテのガス
-1830,4,飘飘球的气体
+1830,4,飄飄球的氣體
 1830,5,Gaz de Baudrive
 1830,9,Drifloon Gas
 1830,11,フワンテのガス
+1830,3,흔들풍손의가스
+1830,6,Driftlon-Gas
+1830,7,Gas de Drifloon
+1830,8,Gas di Drifloon
+1830,12,飘飘球的气体
 1831,1,スカンプーのけ
 1831,4,臭鼬噗的毛
 1831,5,Poils de Moufouette
 1831,9,Stunky Fur
 1831,11,スカンプーのけ
+1831,3,스컹뿡의털
+1831,6,Skunkapuh-Haar
+1831,7,Pelo de Stunky
+1831,8,Pelo di Stunky
+1831,12,臭鼬噗的毛
 1832,1,ドーミラーのかけら
-1832,4,铜镜怪的碎片
+1832,4,銅鏡怪的碎片
 1832,5,Fragment d'Archéomire
 1832,9,Bronzor Fragment
 1832,11,ドーミラーのかけら
+1832,3,동미러의조각
+1832,6,Bronzel-Splitter
+1832,7,Fragmento de Bronzor
+1832,8,Frammento di Bronzor
+1832,12,铜镜怪的碎片
 1833,1,ウソハチのなみだ
-1833,4,盆才怪的眼泪
+1833,4,盆才怪的眼淚
 1833,5,Larme de Manzaï
 1833,9,Bonsly Tears
 1833,11,ウソハチのなみだ
+1833,3,꼬지지의눈물
+1833,6,Mobai-Träne
+1833,7,Lágrima de Bonsly
+1833,8,Lacrime di Bonsly
+1833,12,盆才怪的眼泪
 1834,1,ピンプクのおとしもの
 1834,4,小福蛋的掉落物
 1834,5,Babiole de Ptiravi
 1834,9,Happiny Dust
 1834,11,ピンプクのおとしもの
+1834,3,핑복의유실물
+1834,6,Wonneira-Material
+1834,7,Pertenencia de Happiny
+1834,8,Oggetto di Happiny
+1834,12,小福蛋的掉落物
 1835,1,ミカルゲのかけら
 1835,4,花岩怪的碎片
 1835,5,Fragment de Spiritomb
 1835,9,Spiritomb Fragment
 1835,11,ミカルゲのかけら
+1835,3,화강돌의조각
+1835,6,Kryppuk-Splitter
+1835,7,Fragmento de Spiritomb
+1835,8,Frammento di Spiritomb
+1835,12,花岩怪的碎片
 1836,1,フカマルのウロコ
-1836,4,圆陆鲨的鳞片
+1836,4,圓陸鯊的鱗片
 1836,5,Écaille de Griknot
 1836,9,Gible Scales
 1836,11,フカマルのウロコ
+1836,3,딥상어동의비늘
+1836,6,Kaumalat-Schuppe
+1836,7,Escama de Gible
+1836,8,Squama di Gible
+1836,12,圆陆鲨的鳞片
 1837,1,リオルのけ
-1837,4,利欧路的毛
+1837,4,利歐路的毛
 1837,5,Poils de Riolu
 1837,9,Riolu Fur
 1837,11,リオルのけ
+1837,3,리오르의털
+1837,6,Riolu-Haar
+1837,7,Pelo de Riolu
+1837,8,Pelo di Riolu
+1837,12,利欧路的毛
 1838,1,ヒポポタスのすな
-1838,4,沙河马的沙
+1838,4,沙河馬的沙
 1838,5,Sable d'Hippopotas
 1838,9,Hippopotas Sand
 1838,11,ヒポポタスのすな
+1838,3,히포포타스의모래
+1838,6,Hippopotas-Sand
+1838,7,Arena de Hippopotas
+1838,8,Sabbia di Hippopotas
+1838,12,沙河马的沙
 1839,1,グレッグルのどくそ
 1839,4,不良蛙的毒素
 1839,5,Poison de Cradopaud
 1839,9,Croagunk Poison
 1839,11,グレッグルのどくそ
+1839,3,삐딱구리의독소
+1839,6,Glibunkel-Toxin
+1839,7,Toxinas de Croagunk
+1839,8,Tossine di Croagunk
+1839,12,不良蛙的毒素
 1840,1,ケイコウオのウロコ
-1840,4,荧光鱼的鳞片
+1840,4,螢光魚的鱗片
 1840,5,Écaille d’Écayon
 1840,9,Finneon Scales
 1840,11,ケイコウオのウロコ
+1840,3,형광어의비늘
+1840,6,Finneon-Schuppe
+1840,7,Escama de Finneon
+1840,8,Squama di Finneon
+1840,12,荧光鱼的鳞片
 1841,1,ユキカブリのみ
-1841,4,雪笠怪的果实
+1841,4,雪笠怪的果實
 1841,5,Baie de Blizzi
 1841,9,Snover Berries
 1841,11,ユキカブリのみ
+1841,3,눈쓰개의열매
+1841,6,Shnebedeck-Beere
+1841,7,Baya de Snover
+1841,8,Bacca di Snover
+1841,12,雪笠怪的果实
 1842,1,ロトムのでんき
-1842,4,洛托姆的电力
+1842,4,洛托姆的電力
 1842,5,Électricité de Motisma
 1842,9,Rotom Sparks
 1842,11,ロトムのでんき
+1842,3,로토무의전기
+1842,6,Rotom-Strom
+1842,7,Electricidad de Rotom
+1842,8,Elettricità di Rotom
+1842,12,洛托姆的电力
 1843,1,チュリネのはっぱ
-1843,4,百合根娃娃的叶片
+1843,4,百合根娃娃的葉片
 1843,5,Feuille de Chlorobule
 1843,9,Petilil Leaf
 1843,11,チュリネのはっぱ
+1843,3,치릴리의잎
+1843,6,Lilminip-Blatt
+1843,7,Hoja de Petilil
+1843,8,Foglia di Petilil
+1843,12,百合根娃娃的叶片
 1844,1,バスラオのキバ
-1844,4,野蛮鲈鱼的牙
+1844,4,野蠻鱸魚的牙
 1844,5,Croc de Bargantua
 1844,9,Basculin Fang
 1844,11,バスラオのキバ
+1844,3,배쓰나이의이빨
+1844,6,Barschuft-Zahn
+1844,7,Colmillo de Basculin
+1844,8,Dente di Basculin
+1844,12,野蛮鲈鱼的牙
 1845,1,メグロコのツメ
-1845,4,黑眼鳄的爪子
+1845,4,黑眼鱷的爪子
 1845,5,Griffe de Mascaïman
 1845,9,Sandile Claw
 1845,11,メグロコのツメ
+1845,3,깜눈크의발톱
+1845,6,Ganovil-Kralle
+1845,7,Garra de Sandile
+1845,8,Artiglio di Sandile
+1845,12,黑眼鳄的爪子
 1846,1,ゾロアのけ
-1846,4,索罗亚的毛
+1846,4,索羅亞的毛
 1846,5,Poils de Zorua
 1846,9,Zorua Fur
 1846,11,ゾロアのけ
+1846,3,조로아의털
+1846,6,Zorua-Haar
+1846,7,Pelo de Zorua
+1846,8,Pelo di Zorua
+1846,12,索罗亚的毛
 1847,1,ゴチムのまつげ
-1847,4,哥德宝宝的睫毛
+1847,4,哥德寶寶的睫毛
 1847,5,Cils de Scrutella
 1847,9,Gothita Eyelash
 1847,11,ゴチムのまつげ
+1847,3,고디탱의속눈썹
+1847,6,Mollimorba-Wimper
+1847,7,Pestaña de Gothita
+1847,8,Ciglia di Gothita
+1847,12,哥德宝宝的睫毛
 1848,1,シキジカのけ
 1848,4,四季鹿的毛
 1848,5,Poils de Vivaldaim
 1848,9,Deerling Hair
 1848,11,シキジカのけ
+1848,3,사철록의털
+1848,6,Sesokitz-Haar
+1848,7,Pelo de Deerling
+1848,8,Pelo di Deerling
+1848,12,四季鹿的毛
 1849,1,タマゲタケのほうし
 1849,4,哎呀球菇的孢子
 1849,5,Spores de Trompignon
 1849,9,Foongus Spores
 1849,11,タマゲタケのほうし
+1849,3,깜놀버슬의포자
+1849,6,Tarnpignon-Spore
+1849,7,Esporas de Foongus
+1849,8,Spore di Foongus
+1849,12,哎呀球菇的孢子
 1850,1,ママンボウのねんえき
-1850,4,保姆曼波的黏液
+1850,4,保母曼波的黏液
 1850,5,Mucus de Mamanbo
 1850,9,Alomomola Mucus
 1850,11,ママンボウのねんえき
+1850,3,맘복치의점액
+1850,6,Mamolida-Schleim
+1850,7,Secreción de Alomomola
+1850,8,Muco di Alomomola
+1850,12,保姆曼波的黏液
 1851,1,シビシラスのねんえき
-1851,4,麻麻小鱼的黏液
+1851,4,麻麻小魚的黏液
 1851,5,Mucus d'Anchwatt
 1851,9,Tynamo Slime
 1851,11,シビシラスのねんえき
+1851,3,저리어의점액
+1851,6,Zapplardin-Schleim
+1851,7,Secreción de Tynamo
+1851,8,Muco di Tynamo
+1851,12,麻麻小鱼的黏液
 1852,1,キバゴのウロコ
-1852,4,牙牙的鳞片
+1852,4,牙牙的鱗片
 1852,5,Écaille de Coupenotte
 1852,9,Axew Scales
 1852,11,キバゴのウロコ
+1852,3,터검니의비늘
+1852,6,Milza-Schuppe
+1852,7,Escama de Axew
+1852,8,Squama di Axew
+1852,12,牙牙的鳞片
 1853,1,クマシュンのけ
-1853,4,喷嚏熊的毛
+1853,4,噴嚏熊的毛
 1853,5,Poils de Polarhume
 1853,9,Cubchoo Fur
 1853,11,クマシュンのけ
+1853,3,코고미의털
+1853,6,Petznief-Haar
+1853,7,Pelo de Cubchoo
+1853,8,Pelo di Cubchoo
+1853,12,喷嚏熊的毛
 1854,1,フリージオのこおり
-1854,4,几何雪花的冰
+1854,4,幾何雪花的冰
 1854,5,Glace d'Hexagel
 1854,9,Cryogonal Ice
 1854,11,フリージオのこおり
+1854,3,프리지오의얼음
+1854,6,Frigometri-Eis
+1854,7,Hielo de Cryogonal
+1854,8,Ghiaccio di Cryogonal
+1854,12,几何雪花的冰
 1855,1,コマタナのやいば
-1855,4,驹刀小兵的刀
+1855,4,駒刀小兵的刀
 1855,5,Lame de Scalpion
 1855,9,Pawniard Blade
 1855,11,コマタナのやいば
+1855,3,자망칼의칼날
+1855,6,Gladiantri-Klinge
+1855,7,Cuchilla de Pawniard
+1855,8,Lama di Pawniard
+1855,12,驹刀小兵的刀
 1856,1,ワシボンのはね
-1856,4,毛头小鹰的羽毛
+1856,4,毛頭小鷹的羽毛
 1856,5,Plume de Furaiglon
 1856,9,Rufflet Feather
 1856,11,ワシボンのはね
+1856,3,수리둥보의깃털
+1856,6,Geronimatz-Feder
+1856,7,Pluma de Rufflet
+1856,8,Penna di Rufflet
+1856,12,毛头小鹰的羽毛
 1857,1,モノズのウロコ
-1857,4,单首龙的鳞片
+1857,4,單首龍的鱗片
 1857,5,Écaille de Solochi
 1857,9,Deino Scales
 1857,11,モノズのウロコ
+1857,3,모노두의비늘
+1857,6,Kapuno-Schuppe
+1857,7,Escama de Deino
+1857,8,Squama di Deino
+1857,12,单首龙的鳞片
 1858,1,メラルバのけ
-1858,4,燃烧虫的毛
+1858,4,燃燒蟲的毛
 1858,5,Poils de Pyronille
 1858,9,Larvesta Fuzz
 1858,11,メラルバのけ
+1858,3,활화르바의털
+1858,6,Ignivor-Haar
+1858,7,Pelo de Larvesta
+1858,8,Pelo di Larvesta
+1858,12,燃烧虫的毛
 1859,1,ヤヤコマのはね
 1859,4,小箭雀的羽毛
 1859,5,Plume de Passerouge
 1859,9,Fletchling Feather
 1859,11,ヤヤコマのはね
+1859,3,화살꼬빈의깃털
+1859,6,Dartiri-Feder
+1859,7,Pluma de Fletchling
+1859,8,Penna di Fletchling
+1859,12,小箭雀的羽毛
 1860,1,コフキムシのこな
-1860,4,粉蝶虫的粉
+1860,4,粉蝶蟲的粉
 1860,5,Poudre de Lépidonille
 1860,9,Scatterbug Powder
 1860,11,コフキムシのこな
+1860,3,분이벌레의가루
+1860,6,Purmel-Puder
+1860,7,Polvo de Scatterbug
+1860,8,Polvere di Scatterbug
+1860,12,粉蝶虫的粉
 1861,1,シシコのたてがみ
-1861,4,小狮狮的鬃毛
+1861,4,小獅獅的鬃毛
 1861,5,Crinière d'Hélionceau
 1861,9,Litleo Tuft
 1861,11,シシコのたてがみ
+1861,3,레오꼬의갈기
+1861,6,Leufeo-Mähnenhaar
+1861,7,Mechón de Litleo
+1861,8,Crine di Litleo
+1861,12,小狮狮的鬃毛
 1862,1,フラベベのかふん
 1862,4,花蓓蓓的花粉
 1862,5,Pollen de Flabébé
 1862,9,Flabébé Pollen
 1862,11,フラベベのかふん
+1862,3,플라베베의꽃가루
+1862,6,Flabébé-Pollen
+1862,7,Polen de Flabébé
+1862,8,Polline di Flabébé
+1862,12,花蓓蓓的花粉
 1863,1,メェークルのはっぱ
-1863,4,坐骑小羊的叶片
+1863,4,坐騎小羊的葉片
 1863,5,Feuille de Cabriolaine
 1863,9,Skiddo Leaf
 1863,11,メェークルのはっぱ
+1863,3,메이클의잎
+1863,6,Mähikel-Blatt
+1863,7,Hoja de Skiddo
+1863,8,Foglia di Skiddo
+1863,12,坐骑小羊的叶片
 1864,1,クズモーのもくず
 1864,4,垃垃藻的碎藻
 1864,5,Algue de Venalgue
 1864,9,Skrelp Kelp
 1864,11,クズモーのもくず
+1864,3,수레기의해초
+1864,6,Algitt-Alge
+1864,7,Alga de Skrelp
+1864,8,Alga di Skrelp
+1864,12,垃垃藻的碎藻
 1865,1,ウデッポウのハサミ
-1865,4,铁臂枪虾的钳子
+1865,4,鐵臂槍蝦的鉗子
 1865,5,Pince de Flingouste
 1865,9,Clauncher Claw
 1865,11,ウデッポウのハサミ
+1865,3,완철포의집게
+1865,6,Scampisto-Schere
+1865,7,Pinza de Clauncher
+1865,8,Chela di Clauncher
+1865,12,铁臂枪虾的钳子
 1866,1,ルチャブルのうもう
-1866,4,摔角鹰人的羽绒
+1866,4,摔角鷹人的羽絨
 1866,5,Duvet de Brutalibré
 1866,9,Hawlucha Down
 1866,11,ルチャブルのうもう
+1866,3,루차불의솜털
+1866,6,Resladero-Daune
+1866,7,Plumón de Hawlucha
+1866,8,Piuma di Hawlucha
+1866,12,摔角鹰人的羽绒
 1867,1,デデンネのけ
 1867,4,咚咚鼠的毛
 1867,5,Poils de Dedenne
 1867,9,Dedenne Fur
 1867,11,デデンネのけ
+1867,3,데덴네의털
+1867,6,Dedenne-Haar
+1867,7,Pelo de Dedenne
+1867,8,Pelo di Dedenne
+1867,12,咚咚鼠的毛
 1868,1,ヌメラのねんえき
-1868,4,黏黏宝的黏液
+1868,4,黏黏寶的黏液
 1868,5,Mucus de Mucuscule
 1868,9,Goomy Goo
 1868,11,ヌメラのねんえき
+1868,3,미끄메라의점액
+1868,6,Viscora-Schleim
+1868,7,Secreción de Goomy
+1868,8,Bava di Goomy
+1868,12,黏黏宝的黏液
 1869,1,クレッフィのかぎ
-1869,4,钥圈儿的钥匙
+1869,4,鑰圈兒的鑰匙
 1869,5,Clé de Trousselin
 1869,9,Klefki Key
 1869,11,クレッフィのかぎ
+1869,3,클레피의열쇠
+1869,6,Clavion-Schlüssel
+1869,7,Llave de Klefki
+1869,8,Chiave di Klefki
+1869,12,钥圈儿的钥匙
 1870,1,カチコールのこおり
-1870,4,冰宝的冰
+1870,4,冰寶的冰
 1870,5,Glace de Grelaçon
 1870,9,Bergmite Ice
 1870,11,カチコールのこおり
+1870,3,꽁어름의얼음
+1870,6,Arktip-Eis
+1870,7,Hielo de Bergmite
+1870,8,Ghiaccio di Bergmite
+1870,12,冰宝的冰
 1871,1,オンバットのけ
 1871,4,嗡蝠的毛
 1871,5,Poils de Sonistrelle
 1871,9,Noibat Fur
 1871,11,オンバットのけ
+1871,3,음뱃의털
+1871,6,eF-eM-Haar
+1871,7,Pelo de Noibat
+1871,8,Pelo di Noibat
+1871,12,嗡蝠的毛
 1872,1,ヤングースのけ
-1872,4,猫鼬少的毛
+1872,4,貓鼬少的毛
 1872,5,Poils de Manglouton
 1872,9,Yungoos Fur
 1872,11,ヤングースのけ
+1872,3,영구스의털
+1872,6,Mangunior-Haar
+1872,7,Pelo de Yungoos
+1872,8,Pelo di Yungoos
+1872,12,猫鼬少的毛
 1873,1,マケンカニのから
-1873,4,好胜蟹的壳
+1873,4,好勝蟹的殼
 1873,5,Carapace de Crabagarre
 1873,9,Crabrawler Shell
 1873,11,マケンカニのから
+1873,3,오기지게의껍데기
+1873,6,Krabbox-Schale
+1873,7,Cáscara de Crabrawler
+1873,8,Carapace di Crabrawler
+1873,12,好胜蟹的壳
 1874,1,オドリドリのはね
-1874,4,花舞鸟的羽毛
+1874,4,花舞鳥的羽毛
 1874,5,Plume de Plumeline
 1874,9,Oricorio Feather
 1874,11,オドリドリのはね
+1874,3,춤추새의깃털
+1874,6,Choreogel-Feder
+1874,7,Pluma de Oricorio
+1874,8,Penna di Oricorio
+1874,12,花舞鸟的羽毛
 1875,1,イワンコのいわ
 1875,4,岩狗狗的岩石
 1875,5,Roche de Rocabot
 1875,9,Rockruff Rock
 1875,11,イワンコのいわ
+1875,3,암멍이의바위
+1875,6,Wuffels-Stein
+1875,7,Roca de Rockruff
+1875,8,Roccia di Rockruff
+1875,12,岩狗狗的岩石
 1876,1,ヒドイデのトゲ
-1876,4,好坏星的刺
+1876,4,好壞星的刺
 1876,5,Épine de Vorastérie
 1876,9,Mareanie Spike
 1876,11,ヒドイデのトゲ
+1876,3,시마사리의가시
+1876,6,Garstella-Stachel
+1876,7,Aguijón de Mareanie
+1876,8,Aculeo di Mareanie
+1876,12,好坏星的刺
 1877,1,ドロバンコのどろ
-1877,4,泥驴仔的泥巴
+1877,4,泥驢仔的泥巴
 1877,5,Boue de Tiboudet
 1877,9,Mudbray Mud
 1877,11,ドロバンコのどろ
+1877,3,머드나기의진흙
+1877,6,Pampuli-Schlamm
+1877,7,Lodo de Mudbray
+1877,8,Fango di Mudbray
+1877,12,泥驴仔的泥巴
 1878,1,カリキリのはっぱ
-1878,4,伪螳草的叶片
+1878,4,偽螳草的葉片
 1878,5,Feuille de Mimantis
 1878,9,Fomantis Leaf
 1878,11,カリキリのはっぱ
+1878,3,짜랑랑의잎
+1878,6,Imantis-Blatt
+1878,7,Hoja de Fomantis
+1878,8,Foglia di Fomantis
+1878,12,伪螳草的叶片
 1879,1,ヤトウモリのガス
-1879,4,夜盗火蜥的气体
+1879,4,夜盜火蜥的氣體
 1879,5,Gaz de Tritox
 1879,9,Salandit Gas
 1879,11,ヤトウモリのガス
+1879,3,야도뇽의가스
+1879,6,Molunk-Gas
+1879,7,Gas de Salandit
+1879,8,Gas di Salandit
+1879,12,夜盗火蜥的气体
 1880,1,アマカジのあせ
 1880,4,甜竹竹的汗
 1880,5,Sueur de Croquine
 1880,9,Bounsweet Sweat
 1880,11,アマカジのあせ
+1880,3,달콤아의땀
+1880,6,Frubberl-Schweiß
+1880,7,Sudor de Bounsweet
+1880,8,Sudore di Bounsweet
+1880,12,甜竹竹的汗
 1881,1,ヤレユータンのけ
-1881,4,智挥猩的毛
+1881,4,智揮猩的毛
 1881,5,Poils de Gouroutan
 1881,9,Oranguru Fur
 1881,11,ヤレユータンのけ
+1881,3,하랑우탄의털
+1881,6,Kommandutan-Haar
+1881,7,Pelo de Oranguru
+1881,8,Pelo di Oranguru
+1881,12,智挥猩的毛
 1882,1,ナゲツケサルのけ
-1882,4,投掷猴的毛
+1882,4,投擲猴的毛
 1882,5,Poils de Quartermac
 1882,9,Passimian Fur
 1882,11,ナゲツケサルのけ
+1882,3,내던숭이의털
+1882,6,Quartermak-Haar
+1882,7,Pelo de Passimian
+1882,8,Pelo di Passimian
+1882,12,投掷猴的毛
 1883,1,スナバァのすな
 1883,4,沙丘娃的沙
 1883,5,Sable de Bacabouh
 1883,9,Sandygast Sand
 1883,11,スナバァのすな
+1883,3,모래꿍의모래
+1883,6,Sankabuh-Sand
+1883,7,Arena de Sandygast
+1883,8,Sabbia di Sandygast
+1883,12,沙丘娃的沙
 1884,1,ネッコアラのツメ
-1884,4,树枕尾熊的爪子
+1884,4,樹枕尾熊的爪子
 1884,5,Griffe de Dodoala
 1884,9,Komala Claw
 1884,11,ネッコアラのツメ
+1884,3,자말라의발톱
+1884,6,Koalelu-Kralle
+1884,7,Garra de Komala
+1884,8,Artiglio di Komala
+1884,12,树枕尾熊的爪子
 1885,1,ミミッキュのきれはし
-1885,4,谜拟丘的残片
+1885,4,謎擬Ｑ的殘片
 1885,5,Tissu de Mimiqui
 1885,9,Mimikyu Scrap
 1885,11,ミミッキュのきれはし
+1885,3,따라큐의천조각
+1885,6,Mimigma-Fetzen
+1885,7,Retal de Mimikyu
+1885,8,Brandello di Mimikyu
+1885,12,谜拟丘的残片
 1886,1,ハギギシリのは
-1886,4,磨牙彩皮鱼的牙齿
+1886,4,磨牙彩皮魚的牙齒
 1886,5,Dent de Denticrisse
 1886,9,Bruxish Tooth
 1886,11,ハギギシリのは
+1886,3,치갈기의이빨
+1886,6,Knirfish-Zahn
+1886,7,Diente de Bruxish
+1886,8,Dente di Bruxish
+1886,12,磨牙彩皮鱼的牙齿
 1887,1,カムカメのツメ
-1887,4,咬咬龟的爪子
+1887,4,咬咬龜的爪子
 1887,5,Griffe de Khélocrok
 1887,9,Chewtle Claw
 1887,11,カムカメのツメ
+1887,3,깨물부기의발톱
+1887,6,Kamehaps-Kralle
+1887,7,Garra de Chewtle
+1887,8,Unghia di Chewtle
+1887,12,咬咬龟的爪子
 1888,1,ホシガリスのけ
-1888,4,贪心栗鼠的毛
+1888,4,貪心栗鼠的毛
 1888,5,Poils de Rongourmand
 1888,9,Skwovet Fur
 1888,11,ホシガリスのけ
+1888,3,탐리스의털
+1888,6,Raffel-Haar
+1888,7,Pelo de Skwovet
+1888,8,Pelo di Skwovet
+1888,12,贪心栗鼠的毛
 1889,1,サシカマスのウロコ
-1889,4,刺梭鱼的鳞片
+1889,4,刺梭魚的鱗片
 1889,5,Écaille d'Embrochet
 1889,9,Arrokuda Scales
 1889,11,サシカマスのウロコ
+1889,3,찌로꼬치의비늘
+1889,6,Pikuda-Schuppe
+1889,7,Escama de Arrokuda
+1889,8,Squama di Arrokuda
+1889,12,刺梭鱼的鳞片
 1890,1,ココガラのはね
 1890,4,稚山雀的羽毛
 1890,5,Plume de Minisange
 1890,9,Rookidee Feather
 1890,11,ココガラのはね
+1890,3,파라꼬의깃털
+1890,6,Meikro-Feder
+1890,7,Pluma de Rookidee
+1890,8,Penna di Rookidee
+1890,12,稚山雀的羽毛
 1891,1,エレズンのでんき
-1891,4,电音婴的电力
+1891,4,毒電嬰的電力
 1891,5,Électricité de Toxizap
 1891,9,Toxel Sparks
 1891,11,エレズンのでんき
+1891,3,일레즌의전기
+1891,6,Toxel-Strom
+1891,7,Electricidad de Toxel
+1891,8,Elettricità di Toxel
+1891,12,电音婴的电力
 1892,1,タイレーツのあせ
-1892,4,列阵兵的汗
+1892,4,列陣兵的汗
 1892,5,Sueur d'Hexadron
 1892,9,Falinks Sweat
 1892,11,タイレーツのあせ
+1892,3,대여르의땀
+1892,6,Legios-Schweiß
+1892,7,Sudor de Falinks
+1892,8,Sudore di Falinks
+1892,12,列阵兵的汗
 1893,1,ゾウドウのさび
-1893,4,铜象的锈
+1893,4,銅象的鏽
 1893,5,Rouille de Charibari
 1893,9,Cufant Tarnish
 1893,11,ゾウドウのさび
+1893,3,끼리동의녹
+1893,6,Kupfanti-Patina
+1893,7,Óxido de Cufant
+1893,8,Ruggine di Cufant
+1893,12,铜象的锈
 1894,1,タンドンのせきたん
 1894,4,小炭仔的煤炭
 1894,5,Charbon de Charbi
 1894,9,Rolycoly Coal
 1894,11,タンドンのせきたん
+1894,3,탄동의석탄
+1894,6,Klonkett-Kohle
+1894,7,Carbón de Rolycoly
+1894,8,Carbone di Rolycoly
+1894,12,小炭仔的煤炭
 1895,1,スナヘビのすな
 1895,4,沙包蛇的沙
 1895,5,Sable de Dunaja
 1895,9,Silicobra Sand
 1895,11,スナヘビのすな
+1895,3,모래뱀의모래
+1895,6,Salanga-Sand
+1895,7,Arena de Silicobra
+1895,8,Sabbia di Silicobra
+1895,12,沙包蛇的沙
 1896,1,イエッサンのけ
-1896,4,爱管侍的毛
+1896,4,愛管侍的毛
 1896,5,Poils de Wimessir
 1896,9,Indeedee Fur
 1896,11,イエッサンのけ
+1896,3,에써르의털
+1896,6,Servol-Haar
+1896,7,Pelo de Indeedee
+1896,8,Pelo di Indeedee
+1896,12,爱管侍的毛
 1897,1,バチンウニのはり
-1897,4,啪嚓海胆的针
+1897,4,啪嚓海膽的針
 1897,5,Épine de Wattapik
 1897,9,Pincurchin Spines
 1897,11,バチンウニのはり
+1897,3,찌르성게의가시
+1897,6,Britzigel-Stachel
+1897,7,Púa de Pincurchin
+1897,8,Aculeo di Pincurchin
+1897,12,啪嚓海胆的针
 1898,1,ユキハミのいと
-1898,4,雪吞虫的丝
+1898,4,雪吞蟲的絲
 1898,5,Fil de Frissonille
 1898,9,Snom Thread
 1898,11,ユキハミのいと
+1898,3,누니머기의실
+1898,6,Snomnom-Faden
+1898,7,Hilo de Snom
+1898,8,Filo di Snom
+1898,12,雪吞虫的丝
 1899,1,ベロバーのけ
-1899,4,捣蛋小妖的毛
+1899,4,搗蛋小妖的毛
 1899,5,Poils de Grimalin
 1899,9,Impidimp Hair
 1899,11,ベロバーのけ
+1899,3,메롱꿍의털
+1899,6,Bähmon-Haar
+1899,7,Pelo de Impidimp
+1899,8,Pelo di Impidimp
+1899,12,捣蛋小妖的毛
 1900,1,カジッチュのかじゅう
-1900,4,啃果虫的果汁
+1900,4,啃果蟲的果汁
 1900,5,Jus de Verpom
 1900,9,Applin Juice
 1900,11,カジッチュのかじゅう
+1900,3,과사삭벌레의과즙
+1900,6,Knapfel-Fruchtsaft
+1900,7,Zumo de Applin
+1900,8,Succo di Applin
+1900,12,啃果虫的果汁
 1901,1,ヤバチャのかけら
-1901,4,来悲茶的碎片
+1901,4,來悲茶的碎片
 1901,5,Fragment de Théffroi
 1901,9,Sinistea Chip
 1901,11,ヤバチャのかけら
+1901,3,데인차의조각
+1901,6,Fatalitee-Splitter
+1901,7,Fragmento de Sinistea
+1901,8,Coccio di Sinistea
+1901,12,来悲茶的碎片
 1902,1,ミブリムのおとしもの
 1902,4,迷布莉姆的掉落物
 1902,5,Babiole de Bibichut
 1902,9,Hatenna Dust
 1902,11,ミブリムのおとしもの
+1902,3,몸지브림의유실물
+1902,6,Brimova-Material
+1902,7,Pertenencia de Hatenna
+1902,8,Oggetto di Hatenna
+1902,12,迷布莉姆的掉落物
 1903,1,イシヘンジンのいわ
 1903,4,巨石丁的岩石
 1903,5,Roche de Dolman
 1903,9,Stonjourner Stone
 1903,11,イシヘンジンのいわ
+1903,3,돌헨진의바위
+1903,6,Humanolith-Stein
+1903,7,Roca de Stonjourner
+1903,8,Roccia di Stonjourner
+1903,12,巨石丁的岩石
 1904,1,コオリッポのうもう
-1904,4,冰砌鹅的羽绒
+1904,4,冰砌鵝的羽絨
 1904,5,Duvet de Bekaglaçon
 1904,9,Eiscue Down
 1904,11,コオリッポのうもう
+1904,3,빙큐보의솜털
+1904,6,Kubuin-Daune
+1904,7,Plumón de Eiscue
+1904,8,Piuma di Eiscue
+1904,12,冰砌鹅的羽绒
 1905,1,ドラメシヤのこな
-1905,4,多龙梅西亚的粉
+1905,4,多龍梅西亞的粉
 1905,5,Poudre de Fantyrm
 1905,9,Dreepy Powder
 1905,11,ドラメシヤのこな
+1905,3,드라꼰의가루
+1905,6,Grolldra-Puder
+1905,7,Polvo de Dreepy
+1905,8,Polvere di Dreepy
+1905,12,多龙梅西亚的粉
 1906,1,グルトンのけ
-1906,4,爱吃豚的毛
+1906,4,愛吃豚的毛
 1906,5,Poils de Gourmelet
 1906,9,Lechonk Hair
 1906,11,グルトンのけ
+1906,3,맛보돈의털
+1906,6,Ferkuli-Haar
+1906,7,Pelo de Lechonk
+1906,8,Pelo di Lechonk
+1906,12,爱吃豚的毛
 1907,1,タマンチュラのいと
-1907,4,团珠蛛的丝
+1907,4,團珠蛛的絲
 1907,5,Fil de Tissenboule
 1907,9,Tarountula Thread
 1907,11,タマンチュラのいと
+1907,3,타랜툴라의실
+1907,6,Tarundel-Faden
+1907,7,Hilo de Tarountula
+1907,8,Filo di Tarountula
+1907,12,团珠蛛的丝
 1908,1,マメバッタのツメ
 1908,4,豆蟋蟀的爪子
 1908,5,Griffe de Lilliterelle
 1908,9,Nymble Claw
 1908,11,マメバッタのツメ
+1908,3,콩알뚜기의발톱
+1908,6,Micrick-Kralle
+1908,7,Garra de Nymble
+1908,8,Artiglio di Nymble
+1908,12,豆蟋蟀的爪子
 1909,1,シガロコのどろ
-1909,4,虫滚泥的泥巴
+1909,4,蟲滾泥的泥巴
 1909,5,Boue de Léboulérou
 1909,9,Rellor Mud
 1909,11,シガロコのどろ
+1909,3,구르데의진흙
+1909,6,Relluk-Schlamm
+1909,7,Barro de Rellor
+1909,8,Fango di Rellor
+1909,12,虫滚泥的泥巴
 1910,1,ボチのろう
-1910,4,墓仔狗的蜡
+1910,4,墓仔狗的蠟
 1910,5,Cire de Toutombe
 1910,9,Greavard Wax
 1910,11,ボチのろう
+1910,3,망망이의촛농
+1910,6,Gruff-Wachs
+1910,7,Cera de Greavard
+1910,8,Cera di Greavard
+1910,12,墓仔狗的蜡
 1911,1,ヒラヒナのうもう
-1911,4,飘飘雏的羽绒
+1911,4,飄飄雛的羽絨
 1911,5,Duvet de Flotillon
 1911,9,Flittle Down
 1911,11,ヒラヒナのうもう
+1911,3,하느라기의솜털
+1911,6,Flattutu-Daune
+1911,7,Plumón de Flittle
+1911,8,Piuma di Flittle
+1911,12,飘飘雏的羽绒
 1912,1,ウミディグダのすな
 1912,4,海地鼠的沙
 1912,5,Sable de Taupikeau
 1912,9,Wiglett Sand
 1912,11,ウミディグダのすな
+1912,3,바다그다의모래
+1912,6,Schligda-Sand
+1912,7,Arena de Wiglett
+1912,8,Sabbia di Wiglett
+1912,12,海地鼠的沙
 1913,1,ヘイラッシャのヒゲ
-1913,4,吃吼霸的胡须
+1913,4,吃吼霸的鬍鬚
 1913,5,Barbillon d'Oyacata
 1913,9,Dondozo Whisker
 1913,11,ヘイラッシャのヒゲ
+1913,3,어써러셔의수염
+1913,6,Heerashai-Bartel
+1913,7,Bigote de Dondozo
+1913,8,Barbiglio di Dondozo
+1913,12,吃吼霸的胡须
 1914,1,ミガルーサのきりみ
-1914,4,轻身鳕的鱼片
+1914,4,輕身鱈的魚片
 1914,5,Chair de Délestin
 1914,9,Veluza Fillet
 1914,11,ミガルーサのきりみ
+1914,3,가비루사의토막
+1914,6,Agiluza-Filet
+1914,7,Carne de Veluza
+1914,8,Filetto di Veluza
+1914,12,轻身鳕的鱼片
 1915,1,ナミイルカのねんえき
 1915,4,波普海豚的黏液
 1915,5,Mucus de Dofin
 1915,9,Finizen Mucus
 1915,11,ナミイルカのねんえき
+1915,3,맨돌핀의점액
+1915,6,Normifin-Schleim
+1915,7,Secreción de Finizen
+1915,8,Muco di Finizen
+1915,12,波普海豚的黏液
 1916,1,ミニーブのオイル
 1916,4,迷你芙的油
 1916,5,Huile d'Olivini
 1916,9,Smoliv Oil
 1916,11,ミニーブのオイル
+1916,3,미니브의오일
+1916,6,Olini-Öl
+1916,7,Aceite de Smoliv
+1916,8,Olio di Smoliv
+1916,12,迷你芙的油
 1917,1,カプサイジのたね
-1917,4,热辣娃的种子
+1917,4,熱辣娃的種子
 1917,5,Graine de Pimito
 1917,9,Capsakid Seed
 1917,11,カプサイジのたね
+1917,3,캡싸이의씨앗
+1917,6,Chilingel-Samen
+1917,7,Semilla de Capsakid
+1917,8,Seme di Capsakid
+1917,12,热辣娃的种子
 1918,1,ズピカのねんえき
 1918,4,光蚪仔的黏液
 1918,5,Mucus de Têtampoule
 1918,9,Tadbulb Mucus
 1918,11,ズピカのねんえき
+1918,3,빈나두의점액
+1918,6,Blipp-Schleim
+1918,7,Secreción de Tadbulb
+1918,8,Muco di Tadbulb
+1918,12,光蚪仔的黏液
 1919,1,ブロロンのガス
-1919,4,噗隆隆的气体
+1919,4,噗隆隆的氣體
 1919,5,Gaz de Vrombi
 1919,9,Varoom Fume
 1919,11,ブロロンのガス
+1919,3,부르롱의가스
+1919,6,Knattox-Gas
+1919,7,Gas de Varoom
+1919,8,Gas di Varoom
+1919,12,噗隆隆的气体
 1920,1,ミミズズのさび
-1920,4,拖拖蚓的锈
+1920,4,拖拖蚓的鏽
 1920,5,Rouille de Ferdeter
 1920,9,Orthworm Tarnish
 1920,11,ミミズズのさび
+1920,3,꿈트렁의녹
+1920,6,Schlurm-Patina
+1920,7,Óxido de Orthworm
+1920,8,Ruggine di Orthworm
+1920,12,拖拖蚓的锈
 1921,1,ワッカネズミのけ
-1921,4,一对鼠的毛
+1921,4,一對鼠的毛
 1921,5,Poils de Compagnol
 1921,9,Tandemaus Fur
 1921,11,ワッカネズミのけ
+1921,3,두리쥐의털
+1921,6,Zwieps-Haar
+1921,7,Pelo de Tandemaus
+1921,8,Pelo di Tandemaus
+1921,12,一对鼠的毛
 1922,1,アルクジラのあぶら
-1922,4,走鲸的油脂
+1922,4,走鯨的油脂
 1922,5,Graisse de Piétacé
 1922,9,Cetoddle Grease
 1922,11,アルクジラのあぶら
+1922,3,터벅고래의기름
+1922,6,Flaniwal-Fett
+1922,7,Grasa de Cetoddle
+1922,8,Grasso di Cetoddle
+1922,12,走鲸的油脂
 1923,1,セビエのウロコ
-1923,4,凉脊龙的鳞片
+1923,4,涼脊龍的鱗片
 1923,5,Écaille de Frigodo
 1923,9,Frigibax Scales
 1923,11,セビエのウロコ
+1923,3,드니차의비늘
+1923,6,Frospino-Schuppe
+1923,7,Escama de Frigibax
+1923,8,Squama di Frigibax
+1923,12,凉脊龙的鳞片
 1924,1,シャリタツのウロコ
-1924,4,米立龙的鳞片
+1924,4,米立龍的鱗片
 1924,5,Écaille de Nigirigon
 1924,9,Tatsugiri Scales
 1924,11,シャリタツのウロコ
+1924,3,싸리용의비늘
+1924,6,Nigiragi-Schuppe
+1924,7,Escama de Tatsugiri
+1924,8,Squama di Tatsugiri
+1924,12,米立龙的鳞片
 1925,1,モトトカゲのウロコ
-1925,4,摩托蜥的鳞片
+1925,4,摩托蜥的鱗片
 1925,5,Écaille de Motorizard
 1925,9,Cyclizar Scales
 1925,11,モトトカゲのウロコ
+1925,3,모토마의비늘
+1925,6,Mopex-Schuppe
+1925,7,Escama de Cyclizar
+1925,8,Squama di Cyclizar
+1925,12,摩托蜥的鳞片
 1926,1,パモのけ
-1926,4,布拨的毛
+1926,4,布撥的毛
 1926,5,Poils de Pohm
 1926,9,Pawmi Fur
 1926,11,パモのけ
+1926,3,빠모의털
+1926,6,Pamo-Haar
+1926,7,Pelo de Pawmi
+1926,8,Pelo di Pawmi
+1926,12,布拨的毛
 1927,1,カイデンのはね
-1927,4,电海燕的羽毛
+1927,4,電海燕的羽毛
 1927,5,Plume de Zapétrel
 1927,9,Wattrel Feather
 1927,11,カイデンのはね
+1927,3,찌리비의깃털
+1927,6,Voltrel-Feder
+1927,7,Pluma de Wattrel
+1927,8,Penna di Wattrel
+1927,12,电海燕的羽毛
 1928,1,オトシドリのはね
-1928,4,下石鸟的羽毛
+1928,4,下石鳥的羽毛
 1928,5,Plume de Lestombaile
 1928,9,Bombirdier Feather
 1928,11,オトシドリのはね
+1928,3,떨구새의깃털
+1928,6,Adebom-Feder
+1928,7,Pluma de Bombirdier
+1928,8,Penna di Bombirdier
+1928,12,下石鸟的羽毛
 1929,1,イキリンコのはね
-1929,4,怒鹦哥的羽毛
+1929,4,怒鸚哥的羽毛
 1929,5,Plume de Tapatoès
 1929,9,Squawkabilly Feather
 1929,11,イキリンコのはね
+1929,3,시비꼬의깃털
+1929,6,Krawalloro-Feder
+1929,7,Pluma de Squawkabilly
+1929,8,Penna di Squawkabilly
+1929,12,怒鹦哥的羽毛
 1930,1,カラミンゴのうもう
-1930,4,缠红鹤的羽绒
+1930,4,纏紅鶴的羽絨
 1930,5,Duvet de Flamenroule
 1930,9,Flamigo Down
 1930,11,カラミンゴのうもう
+1930,3,꼬이밍고의솜털
+1930,6,Flaminkno-Daune
+1930,7,Plumón de Flamigo
+1930,8,Piuma di Flamigo
+1930,12,缠红鹤的羽绒
 1931,1,ガケガニのハサミ
-1931,4,毛崖蟹的钳子
+1931,4,毛崖蟹的鉗子
 1931,5,Pince de Craparoi
 1931,9,Klawf Claw
 1931,11,ガケガニのハサミ
+1931,3,절벼게의집게
+1931,6,Klibbe-Schere
+1931,7,Pinza de Klawf
+1931,8,Chela di Klawf
+1931,12,毛崖蟹的钳子
 1932,1,コジオのしお
-1932,4,盐石宝的盐
+1932,4,鹽石寶的鹽
 1932,5,Sel de Selutin
 1932,9,Nacli Salt
 1932,11,コジオのしお
+1932,3,베베솔트의소금
+1932,6,Geosali-Salz
+1932,7,Sal de Nacli
+1932,8,Sale di Nacli
+1932,12,盐石宝的盐
 1933,1,キラーメのけっしょう
-1933,4,晶光芽的结晶
+1933,4,晶光芽的結晶
 1933,5,Cristal de Germéclat
 1933,9,Glimmet Crystal
 1933,11,キラーメのけっしょう
+1933,3,초롱순의결정
+1933,6,Lumispross-Kristall
+1933,7,Cristal de Glimmet
+1933,8,Cristallo di Glimmet
+1933,12,晶光芽的结晶
 1934,1,シルシュルーのインク
-1934,4,滋汁鼹的墨汁
+1934,4,滋汁鼴的墨汁
 1934,5,Encre de Gribouraigne
 1934,9,Shroodle Ink
 1934,11,シルシュルーのインク
+1934,3,땃쭈르의잉크
+1934,6,Sproxi-Tinte
+1934,7,Tinta de Shroodle
+1934,8,Inchiostro di Shroodle
+1934,12,滋汁鼹的墨汁
 1935,1,パピモッチのけ
 1935,4,狗仔包的毛
 1935,5,Poils de Pâtachiot
 1935,9,Fidough Fur
 1935,11,パピモッチのけ
+1935,3,쫀도기의털
+1935,6,Hefel-Haar
+1935,7,Pelo de Fidough
+1935,8,Pelo di Fidough
+1935,12,狗仔包的毛
 1936,1,オラチフのキバ
 1936,4,偶叫獒的牙
 1936,5,Croc de Grondogue
 1936,9,Maschiff Fang
 1936,11,オラチフのキバ
+1936,3,오라티프의이빨
+1936,6,Mobtiff-Zahn
+1936,7,Colmillo de Maschiff
+1936,8,Zanna di Maschiff
+1936,12,偶叫獒的牙
 1937,1,アノクサのえだ
-1937,4,纳噬草的枝条
+1937,4,納噬草的枝條
 1937,5,Branche de Virovent
 1937,9,Bramblin Twig
 1937,11,アノクサのえだ
+1937,3,그푸리의가지
+1937,6,Weherba-Zweig
+1937,7,Rama de Bramblin
+1937,8,Ramoscello di Bramblin
+1937,12,纳噬草的枝条
 1938,1,コレクレーのコイン
-1938,4,索财灵的硬币
+1938,4,索財靈的硬幣
 1938,5,Pièce de Mordudor
 1938,9,Gimmighoul Coin
 1938,11,コレクレーのコイン
+1938,3,모으령의코인
+1938,6,Gierspenst-Münze
+1938,7,Moneda de Gimmighoul
+1938,8,Moneta di Gimmighoul
+1938,12,索财灵的硬币
 1939,1,カヌチャンのけ
-1939,4,小锻匠的毛
+1939,4,小鍛匠的毛
 1939,5,Poils de Forgerette
 1939,9,Tinkatink Hair
 1939,11,カヌチャンのけ
+1939,3,어리짱의털
+1939,6,Forgita-Haar
+1939,7,Pelo de Tinkatink
+1939,8,Pelo di Tinkatink
+1939,12,小锻匠的毛
 1940,1,カルボウのすす
 1940,4,炭小侍的煤灰
 1940,5,Suie de Charbambin
 1940,9,Charcadet Soot
 1940,11,カルボウのすす
+1940,3,카르본의검댕
+1940,6,Knarbon-Ruß
+1940,7,Hollín de Charcadet
+1940,8,Fuliggine di Charcadet
+1940,12,炭小侍的煤灰
 1941,1,ノノクラゲのヒラヒラ
 1941,4,原野水母的薄片
 1941,5,Membrane de Tentacool
 1941,9,Toedscool Flaps
 1941,11,ノノクラゲのヒラヒラ
+1941,3,들눈해의갓
+1941,6,Tentagra-Lamelle
+1941,7,Pliegue de Toedscool
+1941,8,Pieghe di Toedscool
+1941,12,原野水母的薄片
 1942,1,ウパーのねんえき
-1942,4,乌波的黏液
+1942,4,烏波的黏液
 1942,5,Mucus d'Axoloto
 1942,9,Wooper Slime
 1942,11,ウパーのねんえき
+1942,3,우파의점액
+1942,6,Felino-Schleim
+1942,7,Secreción de Wooper
+1942,8,Muco di Wooper
+1942,12,乌波的黏液
 1944,1,わざマシン１０１
-1944,4,招式学习器１０１
+1944,4,招式學習器１０１
 1944,5,CT101
 1944,9,TM101
 1944,11,わざマシン１０１
+1944,3,기술머신101
+1944,6,TM101
+1944,7,MT101
+1944,8,MT101
+1944,12,招式学习器１０１
 1945,1,わざマシン１０２
-1945,4,招式学习器１０２
+1945,4,招式學習器１０２
 1945,5,CT102
 1945,9,TM102
 1945,11,わざマシン１０２
+1945,3,기술머신102
+1945,6,TM102
+1945,7,MT102
+1945,8,MT102
+1945,12,招式学习器１０２
 1946,1,わざマシン１０３
-1946,4,招式学习器１０３
+1946,4,招式學習器１０３
 1946,5,CT103
 1946,9,TM103
 1946,11,わざマシン１０３
+1946,3,기술머신103
+1946,6,TM103
+1946,7,MT103
+1946,8,MT103
+1946,12,招式学习器１０３
 1947,1,わざマシン１０４
-1947,4,招式学习器１０４
+1947,4,招式學習器１０４
 1947,5,CT104
 1947,9,TM104
 1947,11,わざマシン１０４
+1947,3,기술머신104
+1947,6,TM104
+1947,7,MT104
+1947,8,MT104
+1947,12,招式学习器１０４
 1948,1,わざマシン１０５
-1948,4,招式学习器１０５
+1948,4,招式學習器１０５
 1948,5,CT105
 1948,9,TM105
 1948,11,わざマシン１０５
+1948,3,기술머신105
+1948,6,TM105
+1948,7,MT105
+1948,8,MT105
+1948,12,招式学习器１０５
 1949,1,わざマシン１０６
-1949,4,招式学习器１０６
+1949,4,招式學習器１０６
 1949,5,CT106
 1949,9,TM106
 1949,11,わざマシン１０６
+1949,3,기술머신106
+1949,6,TM106
+1949,7,MT106
+1949,8,MT106
+1949,12,招式学习器１０６
 1950,1,わざマシン１０７
-1950,4,招式学习器１０７
+1950,4,招式學習器１０７
 1950,5,CT107
 1950,9,TM107
 1950,11,わざマシン１０７
+1950,3,기술머신107
+1950,6,TM107
+1950,7,MT107
+1950,8,MT107
+1950,12,招式学习器１０７
 1951,1,わざマシン１０８
-1951,4,招式学习器１０８
+1951,4,招式學習器１０８
 1951,5,CT108
 1951,9,TM108
 1951,11,わざマシン１０８
+1951,3,기술머신108
+1951,6,TM108
+1951,7,MT108
+1951,8,MT108
+1951,12,招式学习器１０８
 1952,1,わざマシン１０９
-1952,4,招式学习器１０９
+1952,4,招式學習器１０９
 1952,5,CT109
 1952,9,TM109
 1952,11,わざマシン１０９
+1952,3,기술머신109
+1952,6,TM109
+1952,7,MT109
+1952,8,MT109
+1952,12,招式学习器１０９
 1953,1,わざマシン１１０
-1953,4,招式学习器１１０
+1953,4,招式學習器１１０
 1953,5,CT110
 1953,9,TM110
 1953,11,わざマシン１１０
+1953,3,기술머신110
+1953,6,TM110
+1953,7,MT110
+1953,8,MT110
+1953,12,招式学习器１１０
 1954,1,わざマシン１１１
-1954,4,招式学习器１１１
+1954,4,招式學習器１１１
 1954,5,CT111
 1954,9,TM111
 1954,11,わざマシン１１１
+1954,3,기술머신111
+1954,6,TM111
+1954,7,MT111
+1954,8,MT111
+1954,12,招式学习器１１１
 1955,1,わざマシン１１２
-1955,4,招式学习器１１２
+1955,4,招式學習器１１２
 1955,5,CT112
 1955,9,TM112
 1955,11,わざマシン１１２
+1955,3,기술머신112
+1955,6,TM112
+1955,7,MT112
+1955,8,MT112
+1955,12,招式学习器１１２
 1956,1,わざマシン１１３
-1956,4,招式学习器１１３
+1956,4,招式學習器１１３
 1956,5,CT113
 1956,9,TM113
 1956,11,わざマシン１１３
+1956,3,기술머신113
+1956,6,TM113
+1956,7,MT113
+1956,8,MT113
+1956,12,招式学习器１１３
 1957,1,わざマシン１１４
-1957,4,招式学习器１１４
+1957,4,招式學習器１１４
 1957,5,CT114
 1957,9,TM114
 1957,11,わざマシン１１４
+1957,3,기술머신114
+1957,6,TM114
+1957,7,MT114
+1957,8,MT114
+1957,12,招式学习器１１４
 1958,1,わざマシン１１５
-1958,4,招式学习器１１５
+1958,4,招式學習器１１５
 1958,5,CT115
 1958,9,TM115
 1958,11,わざマシン１１５
+1958,3,기술머신115
+1958,6,TM115
+1958,7,MT115
+1958,8,MT115
+1958,12,招式学习器１１５
 1959,1,わざマシン１１６
-1959,4,招式学习器１１６
+1959,4,招式學習器１１６
 1959,5,CT116
 1959,9,TM116
 1959,11,わざマシン１１６
+1959,3,기술머신116
+1959,6,TM116
+1959,7,MT116
+1959,8,MT116
+1959,12,招式学习器１１６
 1960,1,わざマシン１１７
-1960,4,招式学习器１１７
+1960,4,招式學習器１１７
 1960,5,CT117
 1960,9,TM117
 1960,11,わざマシン１１７
+1960,3,기술머신117
+1960,6,TM117
+1960,7,MT117
+1960,8,MT117
+1960,12,招式学习器１１７
 1961,1,わざマシン１１８
-1961,4,招式学习器１１８
+1961,4,招式學習器１１８
 1961,5,CT118
 1961,9,TM118
 1961,11,わざマシン１１８
+1961,3,기술머신118
+1961,6,TM118
+1961,7,MT118
+1961,8,MT118
+1961,12,招式学习器１１８
 1962,1,わざマシン１１９
-1962,4,招式学习器１１９
+1962,4,招式學習器１１９
 1962,5,CT119
 1962,9,TM119
 1962,11,わざマシン１１９
+1962,3,기술머신119
+1962,6,TM119
+1962,7,MT119
+1962,8,MT119
+1962,12,招式学习器１１９
 1963,1,わざマシン１２０
-1963,4,招式学习器１２０
+1963,4,招式學習器１２０
 1963,5,CT120
 1963,9,TM120
 1963,11,わざマシン１２０
+1963,3,기술머신120
+1963,6,TM120
+1963,7,MT120
+1963,8,MT120
+1963,12,招式学习器１２０
 1964,1,わざマシン１２１
-1964,4,招式学习器１２１
+1964,4,招式學習器１２１
 1964,5,CT121
 1964,9,TM121
 1964,11,わざマシン１２１
+1964,3,기술머신121
+1964,6,TM121
+1964,7,MT121
+1964,8,MT121
+1964,12,招式学习器１２１
 1965,1,わざマシン１２２
-1965,4,招式学习器１２２
+1965,4,招式學習器１２２
 1965,5,CT122
 1965,9,TM122
 1965,11,わざマシン１２２
+1965,3,기술머신122
+1965,6,TM122
+1965,7,MT122
+1965,8,MT122
+1965,12,招式学习器１２２
 1966,1,わざマシン１２３
-1966,4,招式学习器１２３
+1966,4,招式學習器１２３
 1966,5,CT123
 1966,9,TM123
 1966,11,わざマシン１２３
+1966,3,기술머신123
+1966,6,TM123
+1966,7,MT123
+1966,8,MT123
+1966,12,招式学习器１２３
 1967,1,わざマシン１２４
-1967,4,招式学习器１２４
+1967,4,招式學習器１２４
 1967,5,CT124
 1967,9,TM124
 1967,11,わざマシン１２４
+1967,3,기술머신124
+1967,6,TM124
+1967,7,MT124
+1967,8,MT124
+1967,12,招式学习器１２４
 1968,1,わざマシン１２５
-1968,4,招式学习器１２５
+1968,4,招式學習器１２５
 1968,5,CT125
 1968,9,TM125
 1968,11,わざマシン１２５
+1968,3,기술머신125
+1968,6,TM125
+1968,7,MT125
+1968,8,MT125
+1968,12,招式学习器１２５
 1969,1,わざマシン１２６
-1969,4,招式学习器１２６
+1969,4,招式學習器１２６
 1969,5,CT126
 1969,9,TM126
 1969,11,わざマシン１２６
+1969,3,기술머신126
+1969,6,TM126
+1969,7,MT126
+1969,8,MT126
+1969,12,招式学习器１２６
 1970,1,わざマシン１２７
-1970,4,招式学习器１２７
+1970,4,招式學習器１２７
 1970,5,CT127
 1970,9,TM127
 1970,11,わざマシン１２７
+1970,3,기술머신127
+1970,6,TM127
+1970,7,MT127
+1970,8,MT127
+1970,12,招式学习器１２７
 1971,1,わざマシン１２８
-1971,4,招式学习器１２８
+1971,4,招式學習器１２８
 1971,5,CT128
 1971,9,TM128
 1971,11,わざマシン１２８
+1971,3,기술머신128
+1971,6,TM128
+1971,7,MT128
+1971,8,MT128
+1971,12,招式学习器１２８
 1972,1,わざマシン１２９
-1972,4,招式学习器１２９
+1972,4,招式學習器１２９
 1972,5,CT129
 1972,9,TM129
 1972,11,わざマシン１２９
+1972,3,기술머신129
+1972,6,TM129
+1972,7,MT129
+1972,8,MT129
+1972,12,招式学习器１２９
 1973,1,わざマシン１３０
-1973,4,招式学习器１３０
+1973,4,招式學習器１３０
 1973,5,CT130
 1973,9,TM130
 1973,11,わざマシン１３０
+1973,3,기술머신130
+1973,6,TM130
+1973,7,MT130
+1973,8,MT130
+1973,12,招式学习器１３０
 1974,1,わざマシン１３１
-1974,4,招式学习器１３１
+1974,4,招式學習器１３１
 1974,5,CT131
 1974,9,TM131
 1974,11,わざマシン１３１
+1974,3,기술머신131
+1974,6,TM131
+1974,7,MT131
+1974,8,MT131
+1974,12,招式学习器１３１
 1975,1,わざマシン１３２
-1975,4,招式学习器１３２
+1975,4,招式學習器１３２
 1975,5,CT132
 1975,9,TM132
 1975,11,わざマシン１３２
+1975,3,기술머신132
+1975,6,TM132
+1975,7,MT132
+1975,8,MT132
+1975,12,招式学习器１３２
 1976,1,わざマシン１３３
-1976,4,招式学习器１３３
+1976,4,招式學習器１３３
 1976,5,CT133
 1976,9,TM133
 1976,11,わざマシン１３３
+1976,3,기술머신133
+1976,6,TM133
+1976,7,MT133
+1976,8,MT133
+1976,12,招式学习器１３３
 1977,1,わざマシン１３４
-1977,4,招式学习器１３４
+1977,4,招式學習器１３４
 1977,5,CT134
 1977,9,TM134
 1977,11,わざマシン１３４
+1977,3,기술머신134
+1977,6,TM134
+1977,7,MT134
+1977,8,MT134
+1977,12,招式学习器１３４
 1978,1,わざマシン１３５
-1978,4,招式学习器１３５
+1978,4,招式學習器１３５
 1978,5,CT135
 1978,9,TM135
 1978,11,わざマシン１３５
+1978,3,기술머신135
+1978,6,TM135
+1978,7,MT135
+1978,8,MT135
+1978,12,招式学习器１３５
 1979,1,わざマシン１３６
-1979,4,招式学习器１３６
+1979,4,招式學習器１３６
 1979,5,CT136
 1979,9,TM136
 1979,11,わざマシン１３６
+1979,3,기술머신136
+1979,6,TM136
+1979,7,MT136
+1979,8,MT136
+1979,12,招式学习器１３６
 1980,1,わざマシン１３７
-1980,4,招式学习器１３７
+1980,4,招式學習器１３７
 1980,5,CT137
 1980,9,TM137
 1980,11,わざマシン１３７
+1980,3,기술머신137
+1980,6,TM137
+1980,7,MT137
+1980,8,MT137
+1980,12,招式学习器１３７
 1981,1,わざマシン１３８
-1981,4,招式学习器１３８
+1981,4,招式學習器１３８
 1981,5,CT138
 1981,9,TM138
 1981,11,わざマシン１３８
+1981,3,기술머신138
+1981,6,TM138
+1981,7,MT138
+1981,8,MT138
+1981,12,招式学习器１３８
 1982,1,わざマシン１３９
-1982,4,招式学习器１３９
+1982,4,招式學習器１３９
 1982,5,CT139
 1982,9,TM139
 1982,11,わざマシン１３９
+1982,3,기술머신139
+1982,6,TM139
+1982,7,MT139
+1982,8,MT139
+1982,12,招式学习器１３９
 1983,1,わざマシン１４０
-1983,4,招式学习器１４０
+1983,4,招式學習器１４０
 1983,5,CT140
 1983,9,TM140
 1983,11,わざマシン１４０
+1983,3,기술머신140
+1983,6,TM140
+1983,7,MT140
+1983,8,MT140
+1983,12,招式学习器１４０
 1984,1,わざマシン１４１
-1984,4,招式学习器１４１
+1984,4,招式學習器１４１
 1984,5,CT141
 1984,9,TM141
 1984,11,わざマシン１４１
+1984,3,기술머신141
+1984,6,TM141
+1984,7,MT141
+1984,8,MT141
+1984,12,招式学习器１４１
 1985,1,わざマシン１４２
-1985,4,招式学习器１４２
+1985,4,招式學習器１４２
 1985,5,CT142
 1985,9,TM142
 1985,11,わざマシン１４２
+1985,3,기술머신142
+1985,6,TM142
+1985,7,MT142
+1985,8,MT142
+1985,12,招式学习器１４２
 1986,1,わざマシン１４３
-1986,4,招式学习器１４３
+1986,4,招式學習器１４３
 1986,5,CT143
 1986,9,TM143
 1986,11,わざマシン１４３
+1986,3,기술머신143
+1986,6,TM143
+1986,7,MT143
+1986,8,MT143
+1986,12,招式学习器１４３
 1987,1,わざマシン１４４
-1987,4,招式学习器１４４
+1987,4,招式學習器１４４
 1987,5,CT144
 1987,9,TM144
 1987,11,わざマシン１４４
+1987,3,기술머신144
+1987,6,TM144
+1987,7,MT144
+1987,8,MT144
+1987,12,招式学习器１４４
 1988,1,わざマシン１４５
-1988,4,招式学习器１４５
+1988,4,招式學習器１４５
 1988,5,CT145
 1988,9,TM145
 1988,11,わざマシン１４５
+1988,3,기술머신145
+1988,6,TM145
+1988,7,MT145
+1988,8,MT145
+1988,12,招式学习器１４５
 1989,1,わざマシン１４６
-1989,4,招式学习器１４６
+1989,4,招式學習器１４６
 1989,5,CT146
 1989,9,TM146
 1989,11,わざマシン１４６
+1989,3,기술머신146
+1989,6,TM146
+1989,7,MT146
+1989,8,MT146
+1989,12,招式学习器１４６
 1990,1,わざマシン１４７
-1990,4,招式学习器１４７
+1990,4,招式學習器１４７
 1990,5,CT147
 1990,9,TM147
 1990,11,わざマシン１４７
+1990,3,기술머신147
+1990,6,TM147
+1990,7,MT147
+1990,8,MT147
+1990,12,招式学习器１４７
 1991,1,わざマシン１４８
-1991,4,招式学习器１４８
+1991,4,招式學習器１４８
 1991,5,CT148
 1991,9,TM148
 1991,11,わざマシン１４８
+1991,3,기술머신148
+1991,6,TM148
+1991,7,MT148
+1991,8,MT148
+1991,12,招式学习器１４８
 1992,1,わざマシン１４９
-1992,4,招式学习器１４９
+1992,4,招式學習器１４９
 1992,5,CT149
 1992,9,TM149
 1992,11,わざマシン１４９
+1992,3,기술머신149
+1992,6,TM149
+1992,7,MT149
+1992,8,MT149
+1992,12,招式学习器１４９
 1993,1,わざマシン１５０
-1993,4,招式学习器１５０
+1993,4,招式學習器１５０
 1993,5,CT150
 1993,9,TM150
 1993,11,わざマシン１５０
+1993,3,기술머신150
+1993,6,TM150
+1993,7,MT150
+1993,8,MT150
+1993,12,招式学习器１５０
 1994,1,わざマシン１５１
-1994,4,招式学习器１５１
+1994,4,招式學習器１５１
 1994,5,CT151
 1994,9,TM151
 1994,11,わざマシン１５１
+1994,3,기술머신151
+1994,6,TM151
+1994,7,MT151
+1994,8,MT151
+1994,12,招式学习器１５１
 1995,1,わざマシン１５２
-1995,4,招式学习器１５２
+1995,4,招式學習器１５２
 1995,5,CT152
 1995,9,TM152
 1995,11,わざマシン１５２
+1995,3,기술머신152
+1995,6,TM152
+1995,7,MT152
+1995,8,MT152
+1995,12,招式学习器１５２
 1996,1,わざマシン１５３
-1996,4,招式学习器１５３
+1996,4,招式學習器１５３
 1996,5,CT153
 1996,9,TM153
 1996,11,わざマシン１５３
+1996,3,기술머신153
+1996,6,TM153
+1996,7,MT153
+1996,8,MT153
+1996,12,招式学习器１５３
 1997,1,わざマシン１５４
-1997,4,招式学习器１５４
+1997,4,招式學習器１５４
 1997,5,CT154
 1997,9,TM154
 1997,11,わざマシン１５４
+1997,3,기술머신154
+1997,6,TM154
+1997,7,MT154
+1997,8,MT154
+1997,12,招式学习器１５４
 1998,1,わざマシン１５５
-1998,4,招式学习器１５５
+1998,4,招式學習器１５５
 1998,5,CT155
 1998,9,TM155
 1998,11,わざマシン１５５
+1998,3,기술머신155
+1998,6,TM155
+1998,7,MT155
+1998,8,MT155
+1998,12,招式学习器１５５
 1999,1,わざマシン１５６
-1999,4,招式学习器１５６
+1999,4,招式學習器１５６
 1999,5,CT156
 1999,9,TM156
 1999,11,わざマシン１５６
+1999,3,기술머신156
+1999,6,TM156
+1999,7,MT156
+1999,8,MT156
+1999,12,招式学习器１５６
 2000,1,わざマシン１５７
-2000,4,招式学习器１５７
+2000,4,招式學習器１５７
 2000,5,CT157
 2000,9,TM157
 2000,11,わざマシン１５７
+2000,3,기술머신157
+2000,6,TM157
+2000,7,MT157
+2000,8,MT157
+2000,12,招式学习器１５７
 2001,1,わざマシン１５８
-2001,4,招式学习器１５８
+2001,4,招式學習器１５８
 2001,5,CT158
 2001,9,TM158
 2001,11,わざマシン１５８
+2001,3,기술머신158
+2001,6,TM158
+2001,7,MT158
+2001,8,MT158
+2001,12,招式学习器１５８
 2002,1,わざマシン１５９
-2002,4,招式学习器１５９
+2002,4,招式學習器１５９
 2002,5,CT159
 2002,9,TM159
 2002,11,わざマシン１５９
+2002,3,기술머신159
+2002,6,TM159
+2002,7,MT159
+2002,8,MT159
+2002,12,招式学习器１５９
 2003,1,わざマシン１６０
-2003,4,招式学习器１６０
+2003,4,招式學習器１６０
 2003,5,CT160
 2003,9,TM160
 2003,11,わざマシン１６０
+2003,3,기술머신160
+2003,6,TM160
+2003,7,MT160
+2003,8,MT160
+2003,12,招式学习器１６０
 2004,1,わざマシン１６１
-2004,4,招式学习器１６１
+2004,4,招式學習器１６１
 2004,5,CT161
 2004,9,TM161
 2004,11,わざマシン１６１
+2004,3,기술머신161
+2004,6,TM161
+2004,7,MT161
+2004,8,MT161
+2004,12,招式学习器１６１
 2005,1,わざマシン１６２
-2005,4,招式学习器１６２
+2005,4,招式學習器１６２
 2005,5,CT162
 2005,9,TM162
 2005,11,わざマシン１６２
+2005,3,기술머신162
+2005,6,TM162
+2005,7,MT162
+2005,8,MT162
+2005,12,招式学习器１６２
 2006,1,わざマシン１６３
-2006,4,招式学习器１６３
+2006,4,招式學習器１６３
 2006,5,CT163
 2006,9,TM163
 2006,11,わざマシン１６３
+2006,3,기술머신163
+2006,6,TM163
+2006,7,MT163
+2006,8,MT163
+2006,12,招式学习器１６３
 2007,1,わざマシン１６４
-2007,4,招式学习器１６４
+2007,4,招式學習器１６４
 2007,5,CT164
 2007,9,TM164
 2007,11,わざマシン１６４
+2007,3,기술머신164
+2007,6,TM164
+2007,7,MT164
+2007,8,MT164
+2007,12,招式学习器１６４
 2008,1,わざマシン１６５
-2008,4,招式学习器１６５
+2008,4,招式學習器１６５
 2008,5,CT165
 2008,9,TM165
 2008,11,わざマシン１６５
+2008,3,기술머신165
+2008,6,TM165
+2008,7,MT165
+2008,8,MT165
+2008,12,招式学习器１６５
 2009,1,わざマシン１６６
-2009,4,招式学习器１６６
+2009,4,招式學習器１６６
 2009,5,CT166
 2009,9,TM166
 2009,11,わざマシン１６６
+2009,3,기술머신166
+2009,6,TM166
+2009,7,MT166
+2009,8,MT166
+2009,12,招式学习器１６６
 2010,1,わざマシン１６７
-2010,4,招式学习器１６７
+2010,4,招式學習器１６７
 2010,5,CT167
 2010,9,TM167
 2010,11,わざマシン１６７
+2010,3,기술머신167
+2010,6,TM167
+2010,7,MT167
+2010,8,MT167
+2010,12,招式学习器１６７
 2011,1,わざマシン１６８
-2011,4,招式学习器１６８
+2011,4,招式學習器１６８
 2011,5,CT168
 2011,9,TM168
 2011,11,わざマシン１６８
+2011,3,기술머신168
+2011,6,TM168
+2011,7,MT168
+2011,8,MT168
+2011,12,招式学习器１６８
 2012,1,わざマシン１６９
-2012,4,招式学习器１６９
+2012,4,招式學習器１６９
 2012,5,CT169
 2012,9,TM169
 2012,11,わざマシン１６９
+2012,3,기술머신169
+2012,6,TM169
+2012,7,MT169
+2012,8,MT169
+2012,12,招式学习器１６９
 2013,1,わざマシン１７０
-2013,4,招式学习器１７０
+2013,4,招式學習器１７０
 2013,5,CT170
 2013,9,TM170
 2013,11,わざマシン１７０
+2013,3,기술머신170
+2013,6,TM170
+2013,7,MT170
+2013,8,MT170
+2013,12,招式学习器１７０
 2014,1,わざマシン１７１
-2014,4,招式学习器１７１
+2014,4,招式學習器１７１
 2014,5,CT171
 2014,9,TM171
 2014,11,わざマシン１７１
+2014,3,기술머신171
+2014,6,TM171
+2014,7,MT171
+2014,8,MT171
+2014,12,招式学习器１７１
 2015,1,ピクニックセット
-2015,4,野餐组合
+2015,4,野餐組合
 2015,5,Set de Pique-Nique
 2015,9,Picnic Set
 2015,11,ピクニックセット
+2015,3,피크닉세트
+2015,6,Picknick-Set
+2015,7,Kit de Pícnic
+2015,8,Set da picnic
+2015,12,野餐组合
 2016,1,スクールボトル
-2016,4,校园水壶
+2016,4,校園水壺
 2016,5,Gourde de l'Académie
 2016,9,Academy Bottle
 2016,11,スクールボトル
+2016,3,스쿨 보틀
+2016,6,Akademie-Flasche
+2016,7,Termo Academia
+2016,8,Borraccia accademia
+2016,12,校园水壶
 2018,1,みずたまボトル
-2018,4,圆点水壶
+2018,4,圓點水壺
 2018,5,Gourde à Pois
 2018,9,Polka-Dot Bottle
 2018,11,みずたまボトル
+2018,3,물방울 보틀
+2018,6,Punkte-Flasche
+2018,7,Termo Lunares
+2018,8,Borraccia a pois
+2018,12,圆点水壶
 2019,1,ストライプボトル
-2019,4,条纹水壶
+2019,4,條紋水壺
 2019,5,Gourde à Rayures
 2019,9,Striped Bottle
 2019,11,ストライプボトル
+2019,3,줄무늬 보틀
+2019,6,Streifen-Flasche
+2019,7,Termo Rayas
+2019,8,Borraccia a righe
+2019,12,条纹水壶
 2020,1,ダイヤボトル
-2020,4,菱纹水壶
+2020,4,菱紋水壺
 2020,5,Gourde à Losanges
 2020,9,Diamond Bottle
 2020,11,ダイヤボトル
+2020,3,다이아 보틀
+2020,6,Rauten-Flasche
+2020,7,Termo Rombos
+2020,8,Borraccia a rombi
+2020,12,菱纹水壶
 2021,1,スクールカップ
-2021,4,校园水杯
+2021,4,校園水杯
 2021,5,Tasse de l'Académie
 2021,9,Academy Cup
 2021,11,スクールカップ
+2021,3,스쿨 컵
+2021,6,Akademie-Tasse
+2021,7,Taza Academia
+2021,8,Tazza accademia
+2021,12,校园水杯
 2023,1,たてストライプカップ
-2023,4,直条纹水杯
+2023,4,直條紋水杯
 2023,5,Tasse à Rayures Jaunes
 2023,9,Striped Cup
 2023,11,たてストライプカップ
+2023,3,세로 줄무늬 컵
+2023,6,Längsstreifen-Tasse
+2023,7,Taza Raya Vertical
+2023,8,Tazza a righe verticali
+2023,12,直条纹水杯
 2024,1,みずたまカップ
-2024,4,圆点水杯
+2024,4,圓點水杯
 2024,5,Tasse à Pois
 2024,9,Polka-Dot Cup
 2024,11,みずたまカップ
+2024,3,물방울 컵
+2024,6,Punkte-Tasse
+2024,7,Taza Lunares
+2024,8,Tazza a pois
+2024,12,圆点水杯
 2025,1,フラワーカップ
 2025,4,花朵水杯
 2025,5,Tasse à Fleurs
 2025,9,Flower Pattern Cup
 2025,11,フラワーカップ
+2025,3,플라워 컵
+2025,6,Blümchen-Tasse
+2025,7,Taza Flores
+2025,8,Tazza a fiori
+2025,12,花朵水杯
 2026,1,スクールクロス
-2026,4,校园桌巾
+2026,4,校園桌巾
 2026,5,Nappe de l'Académie
 2026,9,Academy Tablecloth
 2026,11,スクールクロス
+2026,3,스쿨 테이블보
+2026,6,Akademie-Tischtuch
+2026,7,Mantel Academia
+2026,8,Tovaglia accademia
+2026,12,校园桌巾
 2028,1,ファンシークロス
 2028,4,幻彩桌巾
 2028,5,Nappe Fantaisie
 2028,9,Whimsical Tablecloth
 2028,11,ファンシークロス
+2028,3,팬시 테이블보
+2028,6,Zauber-Tischtuch
+2028,7,Mantel Cuco
+2028,8,Tovaglia carina
+2028,12,幻彩桌巾
 2029,1,ネイチャークロス
 2029,4,大自然桌巾
 2029,5,Nappe Verdoyante
 2029,9,Leafy Tablecloth
 2029,11,ネイチャークロス
+2029,3,네이처 테이블보
+2029,6,Natur-Tischtuch
+2029,7,Mantel Naturaleza
+2029,8,Tovaglia natura
+2029,12,大自然桌巾
 2030,1,うらめしクロス
 2030,4,鬼祟桌巾
 2030,5,Nappe Hantée
 2030,9,Spooky Tablecloth
 2030,11,うらめしクロス
+2030,3,원망 테이블보
+2030,6,Groll-Tischtuch
+2030,7,Mantel Espectral
+2030,8,Tovaglia dispetto
+2030,12,鬼祟桌巾
 2031,1,スクールボール
-2031,4,校园球
+2031,4,校園球
 2031,5,Ballon de l'Académie
 2031,9,Academy Ball
 2031,11,スクールボール
+2031,3,스쿨볼
+2031,6,Akademie-Ball
+2031,7,Pelota Academia
+2031,8,Palla accademia
+2031,12,校园球
 2033,1,マリルボール
-2033,4,玛力露球
+2033,4,瑪力露球
 2033,5,Ballon Marill
 2033,9,Marill Ball
 2033,11,マリルボール
+2033,3,마릴볼
+2033,6,Marill-Ball
+2033,7,Pelota Marill
+2033,8,Palla Marill
+2033,12,玛力露球
 2034,1,けいとボール
-2034,4,毛线球
+2034,4,毛線球
 2034,5,Pelote de Laine
 2034,9,Yarn Ball
 2034,11,けいとボール
+2034,3,털실볼
+2034,6,Woll-Ball
+2034,7,Pelota Ovillo
+2034,8,Palla gomitolo
+2034,12,毛线球
 2035,1,ゲーミングボール
-2035,4,电竞球
+2035,4,電競球
 2035,5,Ballon Gaming
 2035,9,Cyber Ball
 2035,11,ゲーミングボール
+2035,3,게이밍볼
+2035,6,Cyber-Ball
+2035,7,Pelota Cibernética
+2035,8,Palla gaming
+2035,12,电竞球
 2036,1,ゴールドピック
-2036,4,金色三明治签
+2036,4,金色三明治籤
 2036,5,Pique Dorée
 2036,9,Gold Pick
 2036,11,ゴールドピック
+2036,3,골드 픽
+2036,6,Gold-Pikser
+2036,7,Palillo Dorado
+2036,8,Stecchino oro
+2036,12,金色三明治签
 2037,1,シルバーピック
-2037,4,银色三明治签
+2037,4,銀色三明治籤
 2037,5,Pique Argentée
 2037,9,Silver Pick
 2037,11,シルバーピック
+2037,3,실버 픽
+2037,6,Silber-Pikser
+2037,7,Palillo Plateado
+2037,8,Stecchino argento
+2037,12,银色三明治签
 2038,1,あかいはたピック
-2038,4,红旗子三明治签
+2038,4,紅旗子三明治籤
 2038,5,Pique à Fanion Rouge
 2038,9,Red-Flag Pick
 2038,11,あかいはたピック
+2038,3,빨강 깃발 픽
+2038,6,Rotfahnen-Pikser
+2038,7,Palillo Bandera Roja
+2038,8,Bandierina rossa
+2038,12,红旗子三明治签
 2039,1,あおいはたピック
-2039,4,蓝旗子三明治签
+2039,4,藍旗子三明治籤
 2039,5,Pique à Fanion Bleu
 2039,9,Blue-Flag Pick
 2039,11,あおいはたピック
+2039,3,파랑 깃발 픽
+2039,6,Blaufahnen-Pikser
+2039,7,Palillo Bandera Azul
+2039,8,Bandierina blu
+2039,12,蓝旗子三明治签
 2040,1,ピカピカピック
-2040,4,皮卡丘三明治签
+2040,4,皮卡丘三明治籤
 2040,5,Pique Pikapika
 2040,9,Pika-Pika Pick
 2040,11,ピカピカピック
+2040,3,피카피카 픽
+2040,6,Pikapika-Pikser
+2040,7,Palillo Pikachu
+2040,8,Stecchino Pikachu
+2040,12,皮卡丘三明治签
 2041,1,パチピカピック
-2041,4,眨眼皮卡丘三明治签
+2041,4,眨眼皮卡丘三明治籤
 2041,5,Pique à Chu Fripon
 2041,9,Winking Pika Pick
 2041,11,パチピカピック
+2041,3,윙크피카 픽
+2041,6,Zwinker-Pika-Pikser
+2041,7,Palillo Pikaguiño
+2041,8,Stecchino pikapika
+2041,12,眨眼皮卡丘三明治签
 2042,1,ブイブイピック
-2042,4,伊布三明治签
+2042,4,伊布三明治籤
 2042,5,Pique Volivoli
 2042,9,Vee-Vee Pick
 2042,11,ブイブイピック
+2042,3,브이브이 픽
+2042,6,Volivoli-Pikser
+2042,7,Palillo Eevee
+2042,8,Stecchino Eevee
+2042,12,伊布三明治签
 2043,1,ニコブイピック
-2043,4,笑脸伊布三明治签
+2043,4,笑臉伊布三明治籤
 2043,5,Pique Évo Rit
 2043,9,Smiling Vee Pick
 2043,11,ニコブイピック
+2043,3,방긋브이 픽
+2043,6,Kicher-Voli-Pikser
+2043,7,Palillo Eevee Feliz
+2043,8,Stecchino veevee
+2043,12,笑脸伊布三明治签
 2044,1,あおボールピック
-2044,4,蓝珠珠三明治签
+2044,4,藍珠珠三明治籤
 2044,5,Pique à Ball Bleue
 2044,9,Blue Poké Ball Pick
 2044,11,あおボールピック
+2044,3,파랑 볼 픽
+2044,6,Blauball-Pikser
+2044,7,Palillo Ball Azul
+2044,8,Stecchino Ball blu
+2044,12,蓝珠珠三明治签
 2045,1,イワイノヨロイ
-2045,4,庆祝之铠
+2045,4,慶祝之鎧
 2045,5,Armure de la Fortune
 2045,9,Auspicious Armor
 2045,11,イワイノヨロイ
+2045,3,축복받은갑옷
+2045,6,Glorienrüstung
+2045,7,Armadura Auspiciosa
+2045,8,Armatura fausta
+2045,12,庆祝之铠
 2046,1,かしらのしるし
-2046,4,头领凭证
+2046,4,頭領憑證
 2046,5,Emblème du Général
 2046,9,Leader’s Crest
 2046,11,かしらのしるし
+2046,3,대장의징표
+2046,6,Anführersymbol
+2046,7,Distintivo de Líder
+2046,8,Simbolo del capo
+2046,12,头领凭证
 2047,1,ピンクボトル
-2047,4,粉红水壶
+2047,4,粉紅水壺
 2047,5,Gourde Rose
 2047,9,Pink Bottle
 2047,11,ピンクボトル
+2047,3,핑크 보틀
+2047,6,Pinke Flasche
+2047,7,Termo Rosa
+2047,8,Borraccia rosa
+2047,12,粉红水壶
 2048,1,ブルーボトル
-2048,4,蓝色水壶
+2048,4,藍色水壺
 2048,5,Gourde Bleue
 2048,9,Blue Bottle
 2048,11,ブルーボトル
+2048,3,블루 보틀
+2048,6,Blaue Flasche
+2048,7,Termo Azul
+2048,8,Borraccia celeste
+2048,12,蓝色水壶
 2049,1,イエローボトル
-2049,4,黄色水壶
+2049,4,黃色水壺
 2049,5,Gourde Jaune
 2049,9,Yellow Bottle
 2049,11,イエローボトル
+2049,3,옐로 보틀
+2049,6,Gelbe Flasche
+2049,7,Termo Amarillo
+2049,8,Borraccia gialla
+2049,12,黄色水壶
 2050,1,Rステンレスボトル
-2050,4,红纹不锈钢水壶
+2050,4,紅紋不鏽鋼水壺
 2050,5,Gourde Inox (Rouge)
 2050,9,Steel Bottle (R)
 2050,11,Rステンレスボトル
+2050,3,R 스테인리스 보틀
+2050,6,Edelstahlflasche (R)
+2050,7,Termo Metal Rojo
+2050,8,Borraccia inox R
+2050,12,红纹不锈钢水壶
 2051,1,Yステンレスボトル
-2051,4,黄纹不锈钢水壶
+2051,4,黃紋不鏽鋼水壺
 2051,5,Gourde Inox (Jaune)
 2051,9,Steel Bottle (Y)
 2051,11,Yステンレスボトル
+2051,3,Y 스테인리스 보틀
+2051,6,Edelstahlflasche (G)
+2051,7,Termo Metal Amarillo
+2051,8,Borraccia inox G
+2051,12,黄纹不锈钢水壶
 2052,1,Bステンレスボトル
-2052,4,蓝纹不锈钢水壶
+2052,4,藍紋不鏽鋼水壺
 2052,5,Gourde Inox (Bleue)
 2052,9,Steel Bottle (B)
 2052,11,Bステンレスボトル
+2052,3,B 스테인리스 보틀
+2052,6,Edelstahlflasche (B)
+2052,7,Termo Metal Azul
+2052,8,Borraccia inox B
+2052,12,蓝纹不锈钢水壶
 2053,1,シルバーチタンボトル
-2053,4,银钛水壶
+2053,4,銀鈦水壺
 2053,5,Gourde Titane (Argent)
 2053,9,Silver Bottle
 2053,11,シルバーチタンボトル
+2053,3,실버 티탄 보틀
+2053,6,Silber-Titanflasche
+2053,7,Termo Plateado
+2053,8,Borraccia argento
+2053,12,银钛水壶
 2054,1,よこストライプカップ
-2054,4,横条纹水杯
+2054,4,橫條紋水杯
 2054,5,Tasse à Rayures Bleues
 2054,9,Barred Cup
 2054,11,よこストライプカップ
+2054,3,가로 줄무늬 컵
+2054,6,Querstreifen-Tasse
+2054,7,Taza Raya Horizontal
+2054,8,Tazza a righe orizzontali
+2054,12,横条纹水杯
 2055,1,ダイヤカップ
-2055,4,菱纹水杯
+2055,4,菱紋水杯
 2055,5,Tasse à Losanges
 2055,9,Diamond Pattern Cup
 2055,11,ダイヤカップ
+2055,3,다이아 컵
+2055,6,Rauten-Tasse
+2055,7,Taza Rombos
+2055,8,Tazza a rombi
+2055,12,菱纹水杯
 2056,1,ファイヤーカップ
 2056,4,火焰水杯
 2056,5,Tasse à Flammes
 2056,9,Fire Pattern Cup
 2056,11,ファイヤーカップ
+2056,3,파이어 컵
+2056,6,Flammen-Tasse
+2056,7,Taza Llamas
+2056,8,Tazza con fiamme
+2056,12,火焰水杯
 2057,1,ピンクカップ
-2057,4,粉红水杯
+2057,4,粉紅水杯
 2057,5,Tasse Rose
 2057,9,Pink Cup
 2057,11,ピンクカップ
+2057,3,핑크 컵
+2057,6,Pinke Tasse
+2057,7,Taza Rosa
+2057,8,Tazza rosa
+2057,12,粉红水杯
 2058,1,ブルーカップ
-2058,4,蓝色水杯
+2058,4,藍色水杯
 2058,5,Tasse Bleue
 2058,9,Blue Cup
 2058,11,ブルーカップ
+2058,3,블루 컵
+2058,6,Blaue Tasse
+2058,7,Taza Azul
+2058,8,Tazza celeste
+2058,12,蓝色水杯
 2059,1,イエローカップ
-2059,4,黄色水杯
+2059,4,黃色水杯
 2059,5,Tasse Jaune
 2059,9,Yellow Cup
 2059,11,イエローカップ
+2059,3,옐로 컵
+2059,6,Gelbe Tasse
+2059,7,Taza Amarilla
+2059,8,Tazza gialla
+2059,12,黄色水杯
 2060,1,ピカチュウカップ
 2060,4,皮卡丘水杯
 2060,5,Tasse Pikachu
 2060,9,Pikachu Cup
 2060,11,ピカチュウカップ
+2060,3,피카츄 컵
+2060,6,Pikachu-Tasse
+2060,7,Taza Pikachu
+2060,8,Tazza Pikachu
+2060,12,皮卡丘水杯
 2061,1,イーブイカップ
 2061,4,伊布水杯
 2061,5,Tasse Évoli
 2061,9,Eevee Cup
 2061,11,イーブイカップ
+2061,3,이브이 컵
+2061,6,Evoli-Tasse
+2061,7,Taza Eevee
+2061,8,Tazza Eevee
+2061,12,伊布水杯
 2062,1,ヤドンカップ
-2062,4,呆呆兽水杯
+2062,4,呆呆獸水杯
 2062,5,Tasse Ramoloss
 2062,9,Slowpoke Cup
 2062,11,ヤドンカップ
+2062,3,야돈 컵
+2062,6,Flegmon-Tasse
+2062,7,Taza Slowpoke
+2062,8,Tazza Slowpoke
+2062,12,呆呆兽水杯
 2063,1,シルバーチタンカップ
-2063,4,银钛水杯
+2063,4,銀鈦水杯
 2063,5,Tasse Titane (Argent)
 2063,9,Silver Cup
 2063,11,シルバーチタンカップ
+2063,3,실버 티탄 컵
+2063,6,Silber-Titantasse
+2063,7,Taza Plateada
+2063,8,Tazza argento
+2063,12,银钛水杯
 2064,1,バランスボール
 2064,4,瑜珈球
 2064,5,Ballon d'Exercice
 2064,9,Exercise Ball
 2064,11,バランスボール
+2064,3,밸런스볼
+2064,6,Gymnastik-Ball
+2064,7,Pelota Pilates
+2064,8,Palla fitness
+2064,12,瑜珈球
 2065,1,きいろチェッククロス
-2065,4,黄色格子桌巾
+2065,4,黃色格子桌巾
 2065,5,Nappe Tartan Jaune
 2065,9,Plaid Tablecloth (Y)
 2065,11,きいろチェッククロス
+2065,3,옐로 체크 테이블보
+2065,6,Gelbkaro-Tischtuch
+2065,7,Mantel Cuadros Ámbar
+2065,8,Tovaglia a quadri gialla
+2065,12,黄色格子桌巾
 2066,1,あおチェッククロス
-2066,4,蓝色格子桌巾
+2066,4,藍色格子桌巾
 2066,5,Nappe Tartan Bleue
 2066,9,Plaid Tablecloth (B)
 2066,11,あおチェッククロス
+2066,3,블루 체크 테이블보
+2066,6,Blaukaro-Tischtuch
+2066,7,Mantel Cuadros Azul
+2066,8,Tovaglia a quadri viola
+2066,12,蓝色格子桌巾
 2067,1,あかチェッククロス
-2067,4,红色格子桌巾
+2067,4,紅色格子桌巾
 2067,5,Nappe Tartan Rouge
 2067,9,Plaid Tablecloth (R)
 2067,11,あかチェッククロス
+2067,3,레드 체크 테이블보
+2067,6,Rotkaro-Tischtuch
+2067,7,Mantel Cuadros Rojo
+2067,8,Tovaglia a quadri rossa
+2067,12,红色格子桌巾
 2068,1,くさむらモノクロス
-2068,4,黑白草丛桌巾
+2068,4,黑白草叢桌巾
 2068,5,Nappe Hautes Herbes
 2068,9,B&W Grass Tablecloth
 2068,11,くさむらモノクロス
+2068,3,풀숲 흑백 테이블보
+2068,6,Retro-Gras-Tischtuch
+2068,7,Mantel Hierba Alta
+2068,8,Tovaglia erba alta
+2068,12,黑白草丛桌巾
 2069,1,しょうぶクロス
-2069,4,对决桌巾
+2069,4,對決桌巾
 2069,5,Nappe Combat Pokémon
 2069,9,Battle Tablecloth
 2069,11,しょうぶクロス
+2069,3,배틀 테이블보
+2069,6,Action-Tischtuch
+2069,7,Mantel Combate
+2069,8,Tovaglia sfida
+2069,12,对决桌巾
 2070,1,かいじゅうクロス
-2070,4,怪兽桌巾
+2070,4,怪獸桌巾
 2070,5,Nappe Kaiju
 2070,9,Monstrous Tablecloth
 2070,11,かいじゅうクロス
+2070,3,괴수 테이블보
+2070,6,Ungeheuer-Tischtuch
+2070,7,Mantel Monstruoso
+2070,8,Tovaglia mostruosa
+2070,12,怪兽桌巾
 2071,1,ストライプクロス
-2071,4,条纹桌巾
+2071,4,條紋桌巾
 2071,5,Nappe à Rayures
 2071,9,Striped Tablecloth
 2071,11,ストライプクロス
+2071,3,줄무늬 테이블보
+2071,6,Streifen-Tischtuch
+2071,7,Mantel Rayas
+2071,8,Tovaglia a righe
+2071,12,条纹桌巾
 2072,1,ダイヤクロス
-2072,4,菱纹桌巾
+2072,4,菱紋桌巾
 2072,5,Nappe à Losanges
 2072,9,Diamond Tablecloth
 2072,11,ダイヤクロス
+2072,3,다이아 테이블보
+2072,6,Rauten-Tischtuch
+2072,7,Mantel Rombos
+2072,8,Tovaglia a rombi
+2072,12,菱纹桌巾
 2073,1,みずたまクロス
-2073,4,圆点桌巾
+2073,4,圓點桌巾
 2073,5,Nappe à Pois
 2073,9,Polka-Dot Tablecloth
 2073,11,みずたまクロス
+2073,3,물방울 테이블보
+2073,6,Punkte-Tischtuch
+2073,7,Mantel Lunares
+2073,8,Tovaglia a pois
+2073,12,圆点桌巾
 2074,1,パープルクロス
 2074,4,紫色桌巾
 2074,5,Nappe Mauve
 2074,9,Lilac Tablecloth
 2074,11,パープルクロス
+2074,3,퍼플 테이블보
+2074,6,Violettes Tischtuch
+2074,7,Mantel Malva
+2074,8,Tovaglia lilla
+2074,12,紫色桌巾
 2075,1,ミントクロス
-2075,4,浅绿桌巾
+2075,4,淺綠桌巾
 2075,5,Nappe Menthe
 2075,9,Mint Tablecloth
 2075,11,ミントクロス
+2075,3,민트 테이블보
+2075,6,Türkises Tischtuch
+2075,7,Mantel Menta
+2075,8,Tovaglia menta
+2075,12,浅绿桌巾
 2076,1,ベージュクロス
 2076,4,米色桌巾
 2076,5,Nappe Beige
 2076,9,Peach Tablecloth
 2076,11,ベージュクロス
+2076,3,베이지 테이블보
+2076,6,Beiges Tischtuch
+2076,7,Mantel Beis
+2076,8,Tovaglia pesca
+2076,12,米色桌巾
 2077,1,イエロークロス
-2077,4,黄色桌巾
+2077,4,黃色桌巾
 2077,5,Nappe Jaune
 2077,9,Yellow Tablecloth
 2077,11,イエロークロス
+2077,3,옐로 테이블보
+2077,6,Gelbes Tischtuch
+2077,7,Mantel Amarillo
+2077,8,Tovaglia gialla
+2077,12,黄色桌巾
 2078,1,ブルークロス
-2078,4,蓝色桌巾
+2078,4,藍色桌巾
 2078,5,Nappe Bleue
 2078,9,Blue Tablecloth
 2078,11,ブルークロス
+2078,3,블루 테이블보
+2078,6,Blaues Tischtuch
+2078,7,Mantel Azul
+2078,8,Tovaglia blu
+2078,12,蓝色桌巾
 2079,1,ピンククロス
-2079,4,粉红桌巾
+2079,4,粉紅桌巾
 2079,5,Nappe Rose
 2079,9,Pink Tablecloth
 2079,11,ピンククロス
+2079,3,핑크 테이블보
+2079,6,Pinkes Tischtuch
+2079,7,Mantel Rosa
+2079,8,Tovaglia rosa
+2079,12,粉红桌巾
 2080,1,ゴールドチタンボトル
-2080,4,金钛水壶
+2080,4,金鈦水壺
 2080,5,Gourde Titane (Or)
 2080,9,Gold Bottle
 2080,11,ゴールドチタンボトル
+2080,3,골드 티탄 보틀
+2080,6,Gold-Titanflasche
+2080,7,Termo Dorado
+2080,8,Borraccia oro
+2080,12,金钛水壶
 2081,1,ブロンズチタンボトル
-2081,4,铜钛水壶
+2081,4,銅鈦水壺
 2081,5,Gourde Titane (Bronze)
 2081,9,Bronze Bottle
 2081,11,ブロンズチタンボトル
+2081,3,브론즈 티탄 보틀
+2081,6,Bronze-Titanflasche
+2081,7,Termo Bronceado
+2081,8,Borraccia bronzo
+2081,12,铜钛水壶
 2082,1,ゴールドチタンカップ
-2082,4,金钛水杯
+2082,4,金鈦水杯
 2082,5,Tasse Titane (Or)
 2082,9,Gold Cup
 2082,11,ゴールドチタンカップ
+2082,3,골드 티탄 컵
+2082,6,Gold-Titantasse
+2082,7,Taza Dorada
+2082,8,Tazza oro
+2082,12,金钛水杯
 2083,1,ブロンズチタンカップ
-2083,4,铜钛水杯
+2083,4,銅鈦水杯
 2083,5,Tasse Titane (Bronze)
 2083,9,Bronze Cup
 2083,11,ブロンズチタンカップ
+2083,3,브론즈 티탄 컵
+2083,6,Bronze-Titantasse
+2083,7,Taza Bronceada
+2083,8,Tazza bronzo
+2083,12,铜钛水杯
 2084,1,みどりボールピック
-2084,4,绿珠珠三明治签
+2084,4,綠珠珠三明治籤
 2084,5,Pique à Ball Verte
 2084,9,Green Poké Ball Pick
 2084,11,みどりボールピック
+2084,3,초록 볼 픽
+2084,6,Grünball-Pikser
+2084,7,Palillo Ball Verde
+2084,8,Stecchino Ball verde
+2084,12,绿珠珠三明治签
 2085,1,あかボールピック
-2085,4,红珠珠三明治签
+2085,4,紅珠珠三明治籤
 2085,5,Pique à Ball Rouge
 2085,9,Red Poké Ball Pick
 2085,11,あかボールピック
+2085,3,빨강 볼 픽
+2085,6,Rotball-Pikser
+2085,7,Palillo Ball Roja
+2085,8,Stecchino Ball rosso
+2085,12,红珠珠三明治签
 2086,1,おいわいはなびピック
-2086,4,烟花祝庆三明治签
+2086,4,煙火祝慶三明治籤
 2086,5,Pique Feu d'Artifice
 2086,9,Party Sparkler Pick
 2086,11,おいわいはなびピック
+2086,3,축하 폭죽 픽
+2086,6,Wunderkerzen-Pikser
+2086,7,Palillo Bengala
+2086,8,Stecchino scintille
+2086,12,烟花祝庆三明治签
 2087,1,ゆうしゃのけんピック
-2087,4,勇者之剑三明治签
+2087,4,勇者之劍三明治籤
 2087,5,Pique Épée du Héros
 2087,9,Heroic Sword Pick
 2087,11,ゆうしゃのけんピック
+2087,3,용사의 검 픽
+2087,6,Heldenschwert-Pikser
+2087,7,Palillo Heroico
+2087,8,Stecchino spadone
+2087,12,勇者之剑三明治签
 2088,1,マジカルスターピック
-2088,4,魔法星星三明治签
+2088,4,魔法星星三明治籤
 2088,5,Pique Étoile Magique
 2088,9,Magical Star Pick
 2088,11,マジカルスターピック
+2088,3,매지컬 스타 픽
+2088,6,Zauberstern-Pikser
+2088,7,Palillo Estrella
+2088,8,Stecchino magistella
+2088,12,魔法星星三明治签
 2089,1,マジカルハートピック
-2089,4,魔法甜心三明治签
+2089,4,魔法甜心三明治籤
 2089,5,Pique Cœur Magique
 2089,9,Magical Heart Pick
 2089,11,マジカルハートピック
+2089,3,매지컬 하트 픽
+2089,6,Zauberherz-Pikser
+2089,7,Palillo Corazón
+2089,8,Stecchino magicuore
+2089,12,魔法甜心三明治签
 2090,1,パラソルピック
-2090,4,阳伞三明治签
+2090,4,陽傘三明治籤
 2090,5,Pique Parasol
 2090,9,Parasol Pick
 2090,11,パラソルピック
+2090,3,파라솔 픽
+2090,6,Schirmchen-Pikser
+2090,7,Palillo Sombrilla
+2090,8,Ombrellino
+2090,12,阳伞三明治签
 2091,1,あおぞらおはなピック
-2091,4,晴空花三明治签
+2091,4,晴空花三明治籤
 2091,5,Pique Fleur d'Azur
 2091,9,Blue-Sky Flower Pick
 2091,11,あおぞらおはなピック
+2091,3,푸른하늘 꽃 픽
+2091,6,Mittagsblumen-Pikser
+2091,7,Palillo Flor Azul
+2091,8,Stecchino fiore blu
+2091,12,晴空花三明治签
 2092,1,ゆうやけおはなピック
-2092,4,夕阳花三明治签
+2092,4,夕陽花三明治籤
 2092,5,Pique Fleur du Ponant
 2092,9,Sunset Flower Pick
 2092,11,ゆうやけおはなピック
+2092,3,저녁노을 꽃 픽
+2092,6,Abendblumen-Pikser
+2092,7,Palillo Flor Naranja
+2092,8,Stecchino fiore arancio
+2092,12,夕阳花三明治签
 2093,1,あさやけおはなピック
-2093,4,朝霞花三明治签
+2093,4,朝霞花三明治籤
 2093,5,Pique Fleur du Levant
 2093,9,Sunrise Flower Pick
 2093,11,あさやけおはなピック
+2093,3,아침노을 꽃 픽
+2093,6,Morgenblumen-Pikser
+2093,7,Palillo Flor Rosa
+2093,8,Stecchino fiore rosso
+2093,12,朝霞花三明治签
 2094,1,ブループレート
-2094,4,蓝色盘子
+2094,4,藍色盤子
 2094,5,Assiette Bleue
 2094,9,Blue Dish
 2094,11,ブループレート
+2094,3,블루 플레이트
+2094,6,Blauer Teller
+2094,7,Plato Azul
+2094,8,Piatto celeste
+2094,12,蓝色盘子
 2095,1,グリーンプレート
-2095,4,绿色盘子
+2095,4,綠色盤子
 2095,5,Assiette Verte
 2095,9,Green Dish
 2095,11,グリーンプレート
+2095,3,그린 플레이트
+2095,6,Grüner Teller
+2095,7,Plato Verde
+2095,8,Piatto verde
+2095,12,绿色盘子
 2096,1,オレンジプレート
-2096,4,橘色盘子
+2096,4,橘色盤子
 2096,5,Assiette Orange
 2096,9,Orange Dish
 2096,11,オレンジプレート
+2096,3,오렌지 플레이트
+2096,6,Oranger Teller
+2096,7,Plato Naranja
+2096,8,Piatto arancione
+2096,12,橘色盘子
 2097,1,レッドプレート
-2097,4,红色盘子
+2097,4,紅色盤子
 2097,5,Assiette Rouge
 2097,9,Red Dish
 2097,11,レッドプレート
+2097,3,레드 플레이트
+2097,6,Roter Teller
+2097,7,Plato Rojo
+2097,8,Piatto rosso
+2097,12,红色盘子
 2098,1,ホワイトプレート
-2098,4,白色盘子
+2098,4,白色盤子
 2098,5,Assiette Blanche
 2098,9,White Dish
 2098,11,ホワイトプレート
+2098,3,화이트 플레이트
+2098,6,Weißer Teller
+2098,7,Plato Blanco
+2098,8,Piatto bianco
+2098,12,白色盘子
 2099,1,イエロープレート
-2099,4,黄色盘子
+2099,4,黃色盤子
 2099,5,Assiette Jaune
 2099,9,Yellow Dish
 2099,11,イエロープレート
+2099,3,옐로 플레이트
+2099,6,Gelber Teller
+2099,7,Plato Amarillo
+2099,8,Piatto giallo
+2099,12,黄色盘子
 2100,1,ロトりぼう
 2100,5,Perche à Motismart
 2100,9,Roto Stick
@@ -19672,73 +21852,173 @@ item_id,local_language_id,name
 2101,5,Carte Élégance Verte
 2101,9,Teal Style Card
 2101,11,おしゃれカードみどり
+2101,3,멋쟁이카드 그린
+2101,4,碧之時尚名人卡
+2101,6,Grüne Style-Karte
+2101,7,Tarjeta Chic Verde
+2101,8,Tessera chic verde
+2101,12,碧之时尚名人卡
 2102,1,みどりのめん
 2102,5,Masque Turquoise
 2102,9,Teal Mask
 2102,11,みどりのめん
+2102,3,벽록의가면
+2102,4,碧草面具
+2102,6,Türkisgrüne Maske
+2102,7,Máscara Turquesa
+2102,8,Maschera Turchese
+2102,12,碧草面具
 2103,1,きらめくおまもり
 2103,5,Charme Éclatant
 2103,9,Glimmering Charm
 2103,11,きらめくおまもり
+2103,3,반짝이는부적
+2103,4,晶耀護符
+2103,6,Glitzerpin
+2103,7,Amuleto Cristalino
+2103,8,Brillamuleto
+2103,12,晶耀护符
 2104,1,けっしょうのかけら
 2104,5,Morceau de Cristal
 2104,9,Crystal Cluster
 2104,11,けっしょうのかけら
+2104,3,결정조각
+2104,4,結晶碎片
+2104,6,Kristallfragment
+2104,7,Fragmento de Cristal
+2104,8,Pezzo di cristallo
+2104,12,结晶碎片
 2105,1,ようせいのハネ
 2105,5,Plume Enchantée
 2105,9,Fairy Feather
 2105,11,ようせいのハネ
 2105,14,Pluma Feérica
 2105,7,Pluma Feérica
+2105,3,요정의깃털
+2105,4,妖精之羽
+2105,6,Feendaune
+2105,8,Piuma fatata
+2105,12,妖精之羽
 2106,1,いどのめん
 2106,5,Masque du Puits
 2106,9,Wellspring Mask
 2106,11,いどのめん
+2106,3,우물의가면
+2106,4,水井面具
+2106,6,Brunnenmaske
+2106,7,Máscara Fuente
+2106,8,Maschera Pozzo
+2106,12,水井面具
 2107,1,かまどのめん
 2107,5,Masque du Fourneau
 2107,9,Hearthflame Mask
 2107,11,かまどのめん
+2107,3,화덕의가면
+2107,4,火灶面具
+2107,6,Ofenmaske
+2107,7,Máscara Horno
+2107,8,Maschera Focolare
+2107,12,火灶面具
 2108,1,いしずえのめん
 2108,5,Masque de la Pierre
 2108,9,Cornerstone Mask
 2108,11,いしずえのめん
+2108,3,주춧돌의가면
+2108,4,礎石面具
+2108,6,Fundamentmaske
+2108,7,Máscara Cimiento
+2108,8,Maschera Fondamenta
+2108,12,础石面具
 2109,1,みついりりんご
 2109,5,Pomme Nectar
 2109,6,Saftiger Apfel
 2109,9,Syrupy Apple
 2109,11,みついりりんご
+2109,3,꿀맛사과
+2109,4,蜜汁蘋果
+2109,7,Manzana Melosa
+2109,8,Sciroppomo
+2109,12,蜜汁苹果
 2110,1,ボンサクのちゃわん
 2110,5,Bol Médiocre
 2110,9,Unremarkable Teacup
 2110,11,ボンサクのちゃわん
+2110,3,범작찻잔
+2110,4,凡作茶碗
+2110,6,Simple Teeschale
+2110,7,Cuenco Mediocre
+2110,8,Tazza dozzinale
+2110,12,凡作茶碗
 2111,1,ケッサクのちゃわん
 2111,5,Bol Exceptionnel
 2111,9,Masterpiece Teacup
 2111,11,ボンサクのちゃわん
+2111,3,걸작찻잔
+2111,4,傑作茶碗
+2111,6,Edle Teeschale
+2111,7,Cuenco Exquisito
+2111,8,Tazza eccezionale
+2111,12,杰作茶碗
 2112,1,たいりょくのもち
 2112,5,Mochi Santé
 2112,9,Health Mochi
 2112,11,たいりょくのもち
+2112,3,체력떡
+2112,4,體力糬
+2112,6,Heil-Mochi
+2112,7,Mochi Vigor
+2112,8,Mochi della salute
+2112,12,体力粘糕
 2113,1,きんりょくのもち
 2113,5,Mochi Force
 2113,9,Muscle Mochi
 2113,11,きんりょくのもち
+2113,3,근력떡
+2113,4,肌力糬
+2113,6,Kraft-Mochi
+2113,7,Mochi Músculo
+2113,8,Mochi della potenza
+2113,12,肌力粘糕
 2114,1,ていこうのもち
 2114,5,Mochi Armure
 2114,9,Resist Mochi
 2114,11,ていこうのもち
+2114,3,저항력떡
+2114,4,抵抗糬
+2114,6,Abwehr-Mochi
+2114,7,Mochi Aguante
+2114,8,Mochi della tutela
+2114,12,抵抗粘糕
 2115,1,ちりょくのもち
 2115,5,Mochi Esprit
 2115,9,Genius Mochi
 2115,11,ちりょくのもち
+2115,3,지력떡
+2115,4,智力糬
+2115,6,Genie-Mochi
+2115,7,Mochi Intelecto
+2115,8,Mochi dell’ingegno
+2115,12,智力粘糕
 2116,1,せいしんのもち
 2116,5,Mochi Mental
 2116,9,Clever Mochi
 2116,11,せいしんのもち
+2116,3,정신력떡
+2116,4,精神糬
+2116,6,Esprit-Mochi
+2116,7,Mochi Mente
+2116,8,Mochi dell’intuito
+2116,12,精神粘糕
 2117,1,しゅんぱつのもち
 2117,5,Mochi Sprint
 2117,9,Swift Mochi
 2117,11,しゅんぱつのもち
+2117,3,순발력떡
+2117,4,瞬發糬
+2117,6,Flink-Mochi
+2117,7,Mochi Ímpetu
+2117,8,Mochi della reazione
+2117,12,瞬发粘糕
 2118,1,まっさらもち
 2118,5,Mochi Renouveau
 2118,9,Fresh Start Mochi
@@ -19747,368 +22027,1066 @@ item_id,local_language_id,name
 2119,5,Croc d'Abo
 2119,9,Ekans Fang
 2119,11,アーボのきば
+2119,3,아보의이빨
+2119,4,阿柏蛇的牙
+2119,6,Rettan-Zahn
+2119,7,Colmillo de Ekans
+2119,8,Zanna di Ekans
+2119,12,阿柏蛇的牙
 2120,1,サンドのツメ
 2120,5,Griffe de Sabelette
 2120,9,Sandshrew Claw
 2120,11,サンドのツメ
+2120,3,모래두지의발톱
+2120,4,穿山鼠的爪子
+2120,6,Sandan-Kralle
+2120,7,Garra de Sandshrew
+2120,8,Artiglio di Sandshrew
+2120,12,穿山鼠的爪子
 2121,1,ピィのけ
 2121,5,Poils de Mélo
 2121,9,Cleffa Fur
 2121,11,ピィのけ
+2121,3,삐의털
+2121,4,皮寶寶的毛
+2121,6,Pii-Haar
+2121,7,Pelo de Cleffa
+2121,8,Pelo di Cleffa
+2121,12,皮宝宝的毛
 2122,1,ロコンのけ
 2122,5,Poils de Goupix
 2122,9,Vulpix Fur
 2122,11,ロコンのけ
+2122,3,식스테일의털
+2122,4,六尾的毛
+2122,6,Vulpix-Haar
+2122,7,Pelo de Vulpix
+2122,8,Pelo di Vulpix
+2122,12,六尾的毛
 2123,1,ニョロモのめんえき
 2123,5,Mucus de Ptitard
 2123,9,Poliwag Slime
 2123,11,ニョロモのめんえき
+2123,3,발챙이의점액
+2123,4,蚊香蝌蚪的黏液
+2123,6,Quapsel-Schleim
+2123,7,Secreción de Poliwag
+2123,8,Muco di Poliwag
+2123,12,蚊香蝌蚪的黏液
 2124,1,マダツボミのツル
 2124,5,Liane de Chétiflor
 2124,9,Bellsprout Vine
 2124,11,マダツボミのツル
+2124,3,모다피의덩굴
+2124,4,喇叭芽的藤蔓
+2124,6,Knofensa-Ranke
+2124,7,Liana de Bellsprout
+2124,8,Viticcio di Bellsprout
+2124,12,喇叭芽的藤蔓
 2125,1,イシツブテのかけら
 2125,5,Fragment de Racaillou
 2125,9,Geodude Fragment
 2125,11,イシツブテのかけら
+2125,3,꼬마돌의조각
+2125,4,小拳石的碎片
+2125,6,Kleinstein-Splitter
+2125,7,Fragmento de Geodude
+2125,8,Frammento di Geodude
+2125,12,小拳石的碎片
 2126,1,ドガースのガス
 2126,5,Gaz de Smogo
 2126,9,Koffing Gas
 2126,11,ドガースのガス
+2126,3,또가스의가스
+2126,4,瓦斯彈的氣體
+2126,6,Smogon-Gas
+2126,7,Gas de Koffing
+2126,8,Gas di Koffing
+2126,12,瓦斯弹的气体
 2127,1,ゴンベのキバ
 2127,5,Croc de Goinfrex
 2127,9,Munchlax Fang
 2127,11,ゴンベのキバ
+2127,3,먹고자의이빨
+2127,4,小卡比獸的牙
+2127,6,Mampfaxo-Zahn
+2127,7,Colmillo de Munchlax
+2127,8,Zanna di Munchlax
+2127,12,小卡比兽的牙
 2128,1,オタチのけ
 2128,5,Poils de Fouinette
 2128,9,Sentret Fur
 2128,11,オタチのけ
+2128,3,꼬리선의털
+2128,4,尾立的毛
+2128,6,Wiesor-Haar
+2128,7,Pelo de Sentret
+2128,8,Pelo di Sentret
+2128,12,尾立的毛
 2129,1,ホーホーのはね
 2129,5,Plume de Hoothoot
 2129,9,Hoothoot Feather
 2129,11,ホーホーのはね
+2129,3,부우부의깃털
+2129,4,咕咕的羽毛
+2129,6,Hoothoot-Feder
+2129,7,Pluma de Hoothoot
+2129,8,Penna di Hoothoot
+2129,12,咕咕的羽毛
 2130,1,イトマルのいと
 2130,5,Fil de Mimigal
 2130,9,Spinarak Thread
 2130,11,イトマルのいと
+2130,3,페이검의실
+2130,4,圓絲蛛的絲
+2130,6,Webarak-Faden
+2130,7,Hilo de Spinarak
+2130,8,Filo di Spinarak
+2130,12,圆丝蛛的丝
 2131,1,エイパムのけ
 2131,5,Poils de Capumain
 2131,9,Aipom Hair
 2131,11,エイパムのけ
+2131,3,에이팜의털
+2131,4,長尾怪手的毛
+2131,6,Griffel-Haar
+2131,7,Pelo de Aipom
+2131,8,Pelo di Aipom
+2131,12,长尾怪手的毛
 2132,1,ヤンヤンマのトゲ
 2132,5,Dard de Yanma
 2132,9,Yanma Spike
 2132,11,ヤンヤンマのトゲ
+2132,3,왕자리의가시
+2132,4,蜻蜻蜓的刺
+2132,6,Yanma-Stachel
+2132,7,Aguijón de Yanma
+2132,8,Aculeo di Yanma
+2132,12,蜻蜻蜓的刺
 2133,1,グライガーのキバ
 2133,5,Croc de Scorplane
 2133,9,Gligar Fang
 2133,11,グライガーのキバ
+2133,3,글라이거의이빨
+2133,4,天蠍的牙
+2133,6,Skorgla-Zahn
+2133,7,Colmillo de Gligar
+2133,8,Zanna di Gligar
+2133,12,天蝎的牙
 2134,1,マグマッグのようがん
 2134,5,Lave de Limagma
 2134,9,Slugma Lava
 2134,11,マグマッグのようがん
+2134,3,마그마그의용암
+2134,4,熔岩蟲的熔岩
+2134,6,Schneckmag-Lava
+2134,7,Lava de Slugma
+2134,8,Lava di Slugma
+2134,12,熔岩虫的熔岩
 2135,1,ウリムーのけ
 2135,5,Poils de Marcacrin
 2135,9,Swinub Hair
 2135,11,ウリムーのけ
+2135,3,꾸꾸리의털
+2135,4,小山豬的毛
+2135,6,Quiekel-Haar
+2135,7,Pelo de Swinub
+2135,8,Pelo di Swinub
+2135,12,小山猪的毛
 2136,1,ポチエナのキバ
 2136,5,Croc de Medhyèna
 2136,9,Poochyena Fang
 2136,11,ポチエナのキバ
+2136,3,포챠나의이빨
+2136,4,土狼犬的牙
+2136,6,Fiffyen-Zahn
+2136,7,Colmillo de Poochyena
+2136,8,Zanna di Poochyena
+2136,12,土狼犬的牙
 2137,1,ハスボーのはっぱ
 2137,5,Feuille de Nénupiot
 2137,9,Lotad Leaf
 2137,11,ハスボーのはっぱ
+2137,3,연꽃몬의잎
+2137,4,蓮葉童子的葉片
+2137,6,Loturzel-Blatt
+2137,7,Hoja de Lotad
+2137,8,Foglia di Lotad
+2137,12,莲叶童子的叶片
 2138,1,タネボーのえだ
 2138,5,Tige de Grainipiot
 2138,9,Seedot Stem
 2138,11,タネボーのえだ
+2138,3,도토링의가지
+2138,4,橡實果的枝條
+2138,6,Samurzel-Zweig
+2138,7,Tallo de Seedot
+2138,8,Picciolo di Seedot
+2138,12,橡实果的枝条
 2139,1,ノズパスのかけら
 2139,5,Fragment de Tarinor
 2139,9,Nosepass Fragment
 2139,11,ノズパスのかけら
+2139,3,코코파스의조각
+2139,4,朝北鼻的碎片
+2139,6,Nasgnet-Splitter
+2139,7,Fragmento de Nosepass
+2139,8,Frammento di Nosepass
+2139,12,朝北鼻的碎片
 2140,1,バルビートのしる
 2140,5,Fluide de Muciole
 2140,9,Volbeat Fluid
 2140,11,バルビートのしる
+2140,3,볼비트의체액
+2140,4,電螢蟲的汁液
+2140,6,Volbeat-Sekret
+2140,7,Fluido de Volbeat
+2140,8,Fluido di Volbeat
+2140,12,电萤虫的汁液
 2141,1,イルミーゼのしる
 2141,5,Fluide de Lumivole
 2141,9,Illumise Fluid
 2141,11,イルミーゼのしる
+2141,3,네오비트의체액
+2141,4,甜甜螢的汁液
+2141,6,Illumise-Sekret
+2141,7,Fluido de Illumise
+2141,8,Fluido di Illumise
+2141,12,甜甜萤的汁液
 2142,1,ヘイガニのから
 2142,5,Carapace d’Écrapince
 2142,9,Corphish Shell
 2142,11,ヘイガニのから
+2142,3,가재군의껍데기
+2142,4,龍蝦小兵的殼
+2142,6,Krebscorps-Schale
+2142,7,Cáscara de Corphish
+2142,8,Carapace di Corphish
+2142,12,龙虾小兵的壳
 2143,1,ヒンバスのうろこ
 2143,5,Écaille de Barpau
 2143,9,Feebas Scales
 2143,11,ヒンバスのうろこ
+2143,3,빈티나의비늘
+2143,4,醜醜魚的鱗片
+2143,6,Barschwa-Schuppe
+2143,7,Escama de Feebas
+2143,8,Squama di Feebas
+2143,12,丑丑鱼的鳞片
 2144,1,ヨマワルのかけら
 2144,5,Fragment de Skelénox
 2144,9,Duskull Fragment
 2144,11,ヨマワルのかけら
+2144,3,해골몽의조각
+2144,4,夜巡靈的碎片
+2144,6,Zwirrlicht-Splitter
+2144,7,Fragmento de Duskull
+2144,8,Frammento di Duskull
+2144,12,夜巡灵的碎片
 2145,1,リーシャンのかけら
 2145,5,Fragment de Korillon
 2145,9,Chingling Fragment
 2145,11,リーシャンのかけら
+2145,3,랑딸랑의조각
+2145,4,鈴鐺響的碎片
+2145,6,Klingplim-Splitter
+2145,7,Fragmento de Chingling
+2145,8,Frammento di Chingling
+2145,12,铃铛响的碎片
 2146,1,ドッコラーのあせ
 2146,5,Sueur de Charpenti
 2146,9,Timburr Sweat
 2146,11,ドッコラーのあせ
+2146,3,으랏차의땀
+2146,4,搬運小匠的汗
+2146,6,Praktibalk-Schweiß
+2146,7,Sudor de Timburr
+2146,8,Sudore di Timburr
+2146,12,搬运小匠的汗
 2147,1,クルミルのはっぱ
 2147,5,Feuille de Larveyette
 2147,9,Sewaddle Leaf
 2147,11,クルミルのはっぱ
+2147,3,두르보의잎
+2147,4,蟲寶包的葉片
+2147,6,Strawickl-Blatt
+2147,7,Hoja de Sewaddle
+2147,8,Foglia di Sewaddle
+2147,12,虫宝包的叶片
 2148,1,コアルヒーのはね
 2148,5,Plume de Couaneton
 2148,9,Ducklett Feather
 2148,11,コアルヒーのはね
+2148,3,꼬지보리의깃털
+2148,4,鴨寶寶的羽毛
+2148,6,Piccolente-Feder
+2148,7,Pluma de Ducklett
+2148,8,Penna di Ducklett
+2148,12,鸭宝宝的羽毛
 2149,1,ヒトモシのすす
 2149,5,Suie de Funécire
 2149,9,Litwick Soot
 2149,11,ヒトモシのすす
+2149,3,불켜미의검댕
+2149,4,燭光靈的煤灰
+2149,6,Lichtel-Ruß
+2149,7,Hollín de Litwick
+2149,8,Fuliggine di Litwick
+2149,12,烛光灵的煤灰
 2150,1,コジョフーのツメ
 2150,5,Griffe de Kungfouine
 2150,9,Mienfoo Claw
 2150,11,コジョフーのツメ
+2150,3,비조푸의손톱
+2150,4,功夫鼬的爪子
+2150,6,Lin-Fu-Kralle
+2150,7,Garra de Mienfoo
+2150,8,Artiglio di Mienfoo
+2150,12,功夫鼬的爪子
 2151,1,バルチャイのはね
 2151,5,Plume de Vostourno
 2151,9,Vullaby Feather
 2151,11,バルチャイのはね
+2151,3,벌차이의깃털
+2151,4,禿鷹丫頭的羽毛
+2151,6,Skallyk-Feder
+2151,7,Pluma de Vullaby
+2151,8,Penna di Vullaby
+2151,12,秃鹰丫头的羽毛
 2152,1,メレシーのほうせき
 2152,5,Joyau de Strassie
 2152,9,Carbink Jewel
 2152,11,メレシーのほうせき
+2152,3,멜리시의보석
+2152,4,小碎鑽的寶石
+2152,6,Rocara-Edelstein
+2152,7,Gema de Carbink
+2152,8,Gemma di Carbink
+2152,12,小碎钻的宝石
 2153,1,ボクレーのえだ
 2153,5,Branche de Brocélôme
 2153,9,Phantump Twig
 2153,11,ボクレーのえだ
+2153,3,나목령의가지
+2153,4,小木靈的枝條
+2153,6,Paragoni-Zweig
+2153,7,Rama de Phantump
+2153,8,Ramo di Phantump
+2153,12,小木灵的枝条
 2154,1,アゴジムシのいと
 2154,5,Fil de Larvibule
 2154,9,Grubbin Thread
 2154,11,アゴジムシのいと
+2154,3,턱지충이의실
+2154,4,強顎雞母蟲的絲
+2154,6,Mabula-Faden
+2154,7,Hilo de Grubbin
+2154,8,Filo di Grubbin
+2154,12,强颚鸡母虫的丝
 2155,1,アブリーのこな
 2155,5,Poudre de Bombydou
 2155,9,Cutiefly Powder
 2155,11,アブリーのこな
+2155,3,에블리의가루
+2155,4,萌虻的粉
+2155,6,Wommel-Puder
+2155,7,Polvo de Cutiefly
+2155,8,Polvere di Cutiefly
+2155,12,萌虻的粉
 2156,1,ジャラコのウロコ
 2156,5,Écaille de Bébécaille
 2156,9,Jangmo-o Scales
 2156,11,ジャラコのウロコ
+2156,3,짜랑꼬의비늘
+2156,4,心鱗寶的鱗片
+2156,6,Miniras-Schuppe
+2156,7,Escama de Jangmo-o
+2156,8,Squama di Jangmo-o
+2156,12,心鳞宝的鳞片
 2157,1,ウッウのうもう
 2157,5,Duvet de Nigosier
 2157,9,Cramorant Down
 2157,11,ウッウのうもう
+2157,3,윽우지의솜털
+2157,4,古月鳥的羽絨
+2157,6,Urgl-Daune
+2157,7,Plumón de Cramorant
+2157,8,Piuma di Cramorant
+2157,12,古月鸟的羽绒
 2158,1,モルペコのたね
 2158,5,Graine de Morpeko
 2158,9,Morpeko Snack
 2158,11,モルペコのたね
+2158,3,모르페코의씨앗
+2158,4,莫魯貝可的種子
+2158,6,Morpeko-Samen
+2158,7,Semilla de Morpeko
+2158,8,Seme di Morpeko
+2158,12,莫鲁贝可的种子
 2159,1,チャデスのこな
 2159,5,Poudre de Poltchageist
 2159,9,Poltchageist Powder
 2159,11,チャデスのこな
+2159,3,차데스의가루
+2159,4,斯魔茶的粉
+2159,6,Mortcha-Puder
+2159,7,Polvo de Poltchageist
+2159,8,Polvere di Poltchageist
+2159,12,斯魔茶的粉
 2160,5,Fil de Liaison
 2160,9,Linking Cord
 2160,11, つながりのヒモ
+2160,3,연결의끈
+2160,4,聯繫繩
+2160,6,Verbindungsschnur
+2160,7,Cordón Unión
+2160,8,Filo dell’unione
+2160,12,联系绳
 2161,5,CT172
 2161,9,TM172
 2161,11,わざマシン１７２
+2161,3,기술머신172
+2161,4,招式學習器１７２
+2161,6,TM172
+2161,7,MT172
+2161,8,MT172
+2161,12,招式学习器１７２
 2162,5,CT173
 2162,9,TM173
 2162,11,わざマシン１７３
+2162,3,기술머신173
+2162,4,招式學習器１７３
+2162,6,TM173
+2162,7,MT173
+2162,8,MT173
+2162,12,招式学习器１７３
 2163,5,CT174
 2163,9,TM174
 2163,11,わざマシン１７４
+2163,3,기술머신174
+2163,4,招式學習器１７４
+2163,6,TM174
+2163,7,MT174
+2163,8,MT174
+2163,12,招式学习器１７４
 2164,5,CT175
 2164,9,TM175
 2164,11,わざマシン１７５
+2164,3,기술머신175
+2164,4,招式學習器１７５
+2164,6,TM175
+2164,7,MT175
+2164,8,MT175
+2164,12,招式学习器１７５
 2165,5,CT176
 2165,9,TM176
 2165,11,わざマシン１７６
+2165,3,기술머신176
+2165,4,招式學習器１７６
+2165,6,TM176
+2165,7,MT176
+2165,8,MT176
+2165,12,招式学习器１７６
 2166,5,CT177
 2166,9,TM177
 2166,11,わざマシン１７７
+2166,3,기술머신177
+2166,4,招式學習器１７７
+2166,6,TM177
+2166,7,MT177
+2166,8,MT177
+2166,12,招式学习器１７７
 2167,5,CT178
 2167,9,TM178
 2167,11,わざマシン１７８
+2167,3,기술머신178
+2167,4,招式學習器１７８
+2167,6,TM178
+2167,7,MT178
+2167,8,MT178
+2167,12,招式学习器１７８
 2168,5,CT179
 2168,9,TM179
 2168,11,わざマシン１７９
+2168,3,기술머신179
+2168,4,招式學習器１７９
+2168,6,TM179
+2168,7,MT179
+2168,8,MT179
+2168,12,招式学习器１７９
 2169,5,CT180
 2169,9,TM180
 2169,11,わざマシン１８０
+2169,3,기술머신180
+2169,4,招式學習器１８０
+2169,6,TM180
+2169,7,MT180
+2169,8,MT180
+2169,12,招式学习器１８０
 2170,5,CT181
 2170,9,TM181
 2170,11,わざマシン１８１
+2170,3,기술머신181
+2170,4,招式學習器１８１
+2170,6,TM181
+2170,7,MT181
+2170,8,MT181
+2170,12,招式学习器１８１
 2171,5,CT182
 2171,9,TM182
 2171,11,わざマシン１８２
+2171,3,기술머신182
+2171,4,招式學習器１８２
+2171,6,TM182
+2171,7,MT182
+2171,8,MT182
+2171,12,招式学习器１８２
 2172,5,CT183
 2172,9,TM183
 2172,11,わざマシン１８３
+2172,3,기술머신183
+2172,4,招式學習器１８３
+2172,6,TM183
+2172,7,MT183
+2172,8,MT183
+2172,12,招式学习器１８３
 2173,5,CT184
 2173,9,TM184
 2173,11,わざマシン１８４
+2173,3,기술머신184
+2173,4,招式學習器１８４
+2173,6,TM184
+2173,7,MT184
+2173,8,MT184
+2173,12,招式学习器１８４
 2174,5,CT185
 2174,9,TM185
 2174,11,わざマシン１８５
+2174,3,기술머신185
+2174,4,招式學習器１８５
+2174,6,TM185
+2174,7,MT185
+2174,8,MT185
+2174,12,招式学习器１８５
 2175,5,CT186
 2175,9,TM186
 2175,11,わざマシン１８６
+2175,3,기술머신186
+2175,4,招式學習器１８６
+2175,6,TM186
+2175,7,MT186
+2175,8,MT186
+2175,12,招式学习器１８６
 2176,5,CT187
 2176,9,TM187
 2176,11,わざマシン１８７
+2176,3,기술머신187
+2176,4,招式學習器１８７
+2176,6,TM187
+2176,7,MT187
+2176,8,MT187
+2176,12,招式学习器１８７
 2177,5,CT188
 2177,9,TM188
 2177,11,わざマシン１８８
+2177,3,기술머신188
+2177,4,招式學習器１８８
+2177,6,TM188
+2177,7,MT188
+2177,8,MT188
+2177,12,招式学习器１８８
 2178,5,CT189
 2178,9,TM189
 2178,11,わざマシン１８９
+2178,3,기술머신189
+2178,4,招式學習器１８９
+2178,6,TM189
+2178,7,MT189
+2178,8,MT189
+2178,12,招式学习器１８９
 2179,5,CT190
 2179,9,TM190
 2179,11,わざマシン１９０
+2179,3,기술머신190
+2179,4,招式學習器１９０
+2179,6,TM190
+2179,7,MT190
+2179,8,MT190
+2179,12,招式学习器１９０
 2180,5,CT191
 2180,9,TM191
 2180,11,わざマシン１９１
+2180,3,기술머신191
+2180,4,招式學習器１９１
+2180,6,TM191
+2180,7,MT191
+2180,8,MT191
+2180,12,招式学习器１９１
 2181,5,CT192
 2181,9,TM192
 2181,11,わざマシン１９２
+2181,3,기술머신192
+2181,4,招式學習器１９２
+2181,6,TM192
+2181,7,MT192
+2181,8,MT192
+2181,12,招式学习器１９２
 2182,5,CT193
 2182,9,TM193
 2182,11,わざマシン１９３
+2182,3,기술머신193
+2182,4,招式學習器１９３
+2182,6,TM193
+2182,7,MT193
+2182,8,MT193
+2182,12,招式学习器１９３
 2183,5,CT194
 2183,9,TM194
 2183,11,わざマシン１９４
+2183,3,기술머신194
+2183,4,招式學習器１９４
+2183,6,TM194
+2183,7,MT194
+2183,8,MT194
+2183,12,招式学习器１９４
 2184,5,CT195
 2184,9,TM195
 2184,11,わざマシン１９５
+2184,3,기술머신195
+2184,4,招式學習器１９５
+2184,6,TM195
+2184,7,MT195
+2184,8,MT195
+2184,12,招式学习器１９５
 2185,5,CT196
 2185,9,TM196
 2185,11,わざマシン１９６
+2185,3,기술머신196
+2185,4,招式學習器１９６
+2185,6,TM196
+2185,7,MT196
+2185,8,MT196
+2185,12,招式学习器１９６
 2186,5,CT197
 2186,9,TM197
 2186,11,わざマシン１９７
+2186,3,기술머신197
+2186,4,招式學習器１９７
+2186,6,TM197
+2186,7,MT197
+2186,8,MT197
+2186,12,招式学习器１９７
 2187,5,CT198
 2187,9,TM198
 2187,11,わざマシン１９８
+2187,3,기술머신198
+2187,4,招式學習器１９８
+2187,6,TM198
+2187,7,MT198
+2187,8,MT198
+2187,12,招式学习器１９８
 2188,5,CT199
 2188,9,TM199
 2188,11,わざマシン１９９
+2188,3,기술머신199
+2188,4,招式學習器１９９
+2188,6,TM199
+2188,7,MT199
+2188,8,MT199
+2188,12,招式学习器１９９
 2189,5,CT200
 2189,9,TM200
 2189,11,わざマシン２００
+2189,3,기술머신200
+2189,4,招式學習器２００
+2189,6,TM200
+2189,7,MT200
+2189,8,MT200
+2189,12,招式学习器２００
 2190,5,CT201
 2190,9,TM201
 2190,11,わざマシン２０１
+2190,3,기술머신201
+2190,4,招式學習器２０１
+2190,6,TM201
+2190,7,MT201
+2190,8,MT201
+2190,12,招式学习器２０１
 2191,5,CT202
 2191,9,TM202
 2191,11,わざマシン２０２
+2191,3,기술머신202
+2191,4,招式學習器２０２
+2191,6,TM202
+2191,7,MT202
+2191,8,MT202
+2191,12,招式学习器２０２
 2192,5,CT203
 2192,9,TM203
 2192,11,わざマシン２０３
+2192,3,기술머신203
+2192,4,招式學習器２０３
+2192,6,TM203
+2192,7,MT203
+2192,8,MT203
+2192,12,招式学习器２０３
 2193,5,CT204
 2193,9,TM204
 2193,11,わざマシン２０４
+2193,3,기술머신204
+2193,4,招式學習器２０４
+2193,6,TM204
+2193,7,MT204
+2193,8,MT204
+2193,12,招式学习器２０４
 2194,5,CT205
 2194,9,TM205
 2194,11,わざマシン２０５
+2194,3,기술머신205
+2194,4,招式學習器２０５
+2194,6,TM205
+2194,7,MT205
+2194,8,MT205
+2194,12,招式学习器２０５
 2195,5,CT206
 2195,9,TM206
 2195,11,わざマシン２０６
+2195,3,기술머신206
+2195,4,招式學習器２０６
+2195,6,TM206
+2195,7,MT206
+2195,8,MT206
+2195,12,招式学习器２０６
 2196,5,CT207
 2196,9,TM207
 2196,11,わざマシン２０７
+2196,3,기술머신207
+2196,4,招式學習器２０７
+2196,6,TM207
+2196,7,MT207
+2196,8,MT207
+2196,12,招式学习器２０７
 2197,5,CT208
 2197,9,TM208
 2197,11,わざマシン２０８
+2197,3,기술머신208
+2197,4,招式學習器２０８
+2197,6,TM208
+2197,7,MT208
+2197,8,MT208
+2197,12,招式学习器２０８
 2198,5,CT209
 2198,9,TM209
 2198,11,わざマシン２０９
+2198,3,기술머신209
+2198,4,招式學習器２０９
+2198,6,TM209
+2198,7,MT209
+2198,8,MT209
+2198,12,招式学习器２０９
 2199,5,CT210
 2199,9,TM210
 2199,11,わざマシン２１０
+2199,3,기술머신210
+2199,4,招式學習器２１０
+2199,6,TM210
+2199,7,MT210
+2199,8,MT210
+2199,12,招式学习器２１０
 2200,5,CT211
 2200,9,TM211
 2200,11,わざマシン２１１
+2200,3,기술머신211
+2200,4,招式學習器２１１
+2200,6,TM211
+2200,7,MT211
+2200,8,MT211
+2200,12,招式学习器２１１
 2201,5,CT212
 2201,9,TM212
 2201,11,わざマシン２１２
+2201,3,기술머신212
+2201,4,招式學習器２１２
+2201,6,TM212
+2201,7,MT212
+2201,8,MT212
+2201,12,招式学习器２１２
 2202,5,CT213
 2202,9,TM213
 2202,11,わざマシン２１３
+2202,3,기술머신213
+2202,4,招式學習器２１３
+2202,6,TM213
+2202,7,MT213
+2202,8,MT213
+2202,12,招式学习器２１３
 2203,5,CT214
 2203,9,TM214
 2203,11,わざマシン２１４
+2203,3,기술머신214
+2203,4,招式學習器２１４
+2203,6,TM214
+2203,7,MT214
+2203,8,MT214
+2203,12,招式学习器２１４
 2204,5,CT215
 2204,9,TM215
 2204,11,わざマシン２１５
+2204,3,기술머신215
+2204,4,招式學習器２１５
+2204,6,TM215
+2204,7,MT215
+2204,8,MT215
+2204,12,招式学习器２１５
 2205,5,CT216
 2205,9,TM216
 2205,11,わざマシン２１６
+2205,3,기술머신216
+2205,4,招式學習器２１６
+2205,6,TM216
+2205,7,MT216
+2205,8,MT216
+2205,12,招式学习器２１６
 2206,5,CT217
 2206,9,TM217
 2206,11,わざマシン２１７
+2206,3,기술머신217
+2206,4,招式學習器２１７
+2206,6,TM217
+2206,7,MT217
+2206,8,MT217
+2206,12,招式学习器２１７
 2207,5,CT218
 2207,9,TM218
 2207,11,わざマシン２１８
+2207,3,기술머신218
+2207,4,招式學習器２１８
+2207,6,TM218
+2207,7,MT218
+2207,8,MT218
+2207,12,招式学习器２１８
 2208,5,CT219
 2208,9,TM219
 2208,11,わざマシン２１９
+2208,3,기술머신219
+2208,4,招式學習器２１９
+2208,6,TM219
+2208,7,MT219
+2208,8,MT219
+2208,12,招式学习器２１９
 2209,5,CT220
 2209,9,TM220
 2209,11,わざマシン２２０
+2209,3,기술머신220
+2209,4,招式學習器２２０
+2209,6,TM220
+2209,7,MT220
+2209,8,MT220
+2209,12,招式学习器２２０
 2210,5,CT221
 2210,9,TM221
 2210,11,わざマシン２２１
+2210,3,기술머신221
+2210,4,招式學習器２２１
+2210,6,TM221
+2210,7,MT221
+2210,8,MT221
+2210,12,招式学习器２２１
 2211,5,CT222
 2211,9,TM222
 2211,11,わざマシン２２２
+2211,3,기술머신222
+2211,4,招式學習器２２２
+2211,6,TM222
+2211,7,MT222
+2211,8,MT222
+2211,12,招式学习器２２２
 2212,5,CT223
 2212,9,TM223
 2212,11,わざマシン２２３
+2212,3,기술머신223
+2212,4,招式學習器２２３
+2212,6,TM223
+2212,7,MT223
+2212,8,MT223
+2212,12,招式学习器２２３
 2213,5,CT224
 2213,9,TM224
 2213,11,わざマシン２２４
+2213,3,기술머신224
+2213,4,招式學習器２２４
+2213,6,TM224
+2213,7,MT224
+2213,8,MT224
+2213,12,招式学习器２２４
 2214,5,CT225
 2214,9,TM225
 2214,11,わざマシン２２５
+2214,3,기술머신225
+2214,4,招式學習器２２５
+2214,6,TM225
+2214,7,MT225
+2214,8,MT225
+2214,12,招式学习器２２５
 2215,5,CT226
 2215,9,TM226
 2215,11,わざマシン２２６
+2215,3,기술머신226
+2215,4,招式學習器２２６
+2215,6,TM226
+2215,7,MT226
+2215,8,MT226
+2215,12,招式学习器２２６
 2216,5,CT227
 2216,9,TM227
 2216,11,わざマシン２２７
+2216,3,기술머신227
+2216,4,招式學習器２２７
+2216,6,TM227
+2216,7,MT227
+2216,8,MT227
+2216,12,招式学习器２２７
 2217,5,CT228
 2217,9,TM228
 2217,11,わざマシン２２８
+2217,3,기술머신228
+2217,4,招式學習器２２８
+2217,6,TM228
+2217,7,MT228
+2217,8,MT228
+2217,12,招式学习器２２８
 2218,5,CT229
 2218,9,TM229
 2218,11,わざマシン２２９
+2218,3,기술머신229
+2218,4,招式學習器２２９
+2218,6,TM229
+2218,7,MT229
+2218,8,MT229
+2218,12,招式学习器２２９
 2219,5,Étrange Ball
 2219,9,Strange Ball
+2219,3,스트레인지볼
+2219,4,奇異球
+2219,6,Rätselball
+2219,7,Extraña Ball
+2219,8,Strange Ball
+2219,11,ストレンジボール
+2219,12,奇异球
 2220,5,Poké Ball
 2220,9,Poké Ball
+2220,3,몬스터볼
+2220,4,精靈球
+2220,6,Pokéball
+2220,7,Poké Ball
+2220,8,Poké Ball
+2220,11,モンスターボール
+2220,12,精灵球
 2221,5,Super Ball
 2221,9,Great Ball
+2221,3,슈퍼볼
+2221,4,超級球
+2221,6,Superball
+2221,7,Super Ball
+2221,8,Mega Ball
+2221,11,スーパーボール
+2221,12,超级球
 2222,5,Hyper Ball
 2222,9,Ultra Ball
+2222,3,하이퍼볼
+2222,4,高級球
+2222,6,Hyperball
+2222,7,Ultra Ball
+2222,8,Ultra Ball
+2222,11,ハイパーボール
+2222,12,高级球
 2223,5,Masse Ball
 2223,9,Heavy Ball
+2223,3,헤비볼
+2223,4,沉重球
+2223,6,Schwerball
+2223,7,Peso Ball
+2223,8,Peso Ball
+2223,11,ヘビーボール
+2223,12,沉重球
 2224,5,Mégamasse Ball
 2224,9,Leaden Ball
+2224,3,메가톤볼
+2224,4,超重球
+2224,6,Zentnerball
+2224,7,Kilo Ball
+2224,8,Megaton Ball
+2224,11,メガトンボール
+2224,12,超重球
 2225,5,Gigamasse Ball
 2225,9,Gigaton Ball
+2225,3,기가톤볼
+2225,4,巨重球
+2225,6,Tonnenball
+2225,7,Quintal Ball
+2225,8,Gigaton Ball
+2225,11,ギガトンボール
+2225,12,巨重球
 2226,5,Plume Ball
 2226,9,Feather Ball
+2226,3,페더볼
+2226,4,飛羽球
+2226,6,Federball
+2226,7,Pluma Ball
+2226,8,Piuma Ball
+2226,11,フェザーボール
+2226,12,飞羽球
 2227,5,Envol Ball
 2227,9,Wing Ball
+2227,3,윙볼
+2227,4,飛翼球
+2227,6,Flügelball
+2227,7,Ala Ball
+2227,8,Wing Ball
+2227,11,ウイングボール
+2227,12,飞翼球
 2228,5,Propulse Ball
 2228,9,Jet Ball
+2228,3,제트볼
+2228,4,飛梭球
+2228,6,Düsenball
+2228,7,Aero Ball
+2228,8,Jet Ball
+2228,11,ジェットボール
+2228,12,飞梭球
 2229,5,Origine Ball
 2229,9,Origin Ball
+2229,3,오리진볼
+2229,4,起源球
+2229,6,Urball
+2229,7,Origen Ball
+2229,8,Origin Ball
+2229,11,オリジンボール
+2229,12,起源球
 2230,6,Schwarzaugit
 2230,9,Black Augurite
+2230,3,검은휘석
+2230,4,黑奇石
+2230,5,Obsidienne
+2230,7,Mineral Negro
+2230,8,Augite nera
+2230,11,くろのきせき
+2230,12,黑奇石
 2231,6,Torfblock
 2231,9,Peat Block
+2231,3,피트블록
+2231,4,泥炭塊
+2231,5,Bloc de Tourbe
+2231,7,Bloque de Turba
+2231,8,Blocco di torba
+2231,11,ピートブロック
+2231,12,泥炭块
 2232,6,Legierungsmetall
 2232,9,Metal Alloy
+2232,3,복합금속
+2232,4,複合金屬
+2232,5,Métal Composite
+2232,7,Metal Compuesto
+2232,8,Metallo composito
+2232,11,ふくごうきんぞく
+2232,12,复合金属

--- a/data/v2/csv/item_names.csv
+++ b/data/v2/csv/item_names.csv
@@ -9511,7 +9511,7 @@ item_id,local_language_id,name
 933,14,Ticket Barco
 934,1,ライブドレス
 934,3,라이브드레스
-934,4,演出禮服
+934,4,演出禮裙
 934,5,Robe Live
 934,6,Live-Kleid
 934,7,Vestido de Gala

--- a/data/v2/csv/move_names.csv
+++ b/data/v2/csv/move_names.csv
@@ -9089,530 +9089,530 @@ move_id,local_language_id,name
 827,3,페이탈클로
 827,4,剋命爪
 827,5,Griffes Funestes
+827,6,Unheilsklauen
 827,8,Artigli Fatali
 827,9,Dire Claw
 827,11,フェイタルクロー
+827,12,克命爪
 827,14,Garra Nociva
 827,7,Garra Nociva
-827,6,Unheilsklauen
-827,12,克命爪
 828,1,バリアーラッシュ
 828,3,배리어러시
 828,4,屏障猛攻
 828,5,Sprint Bouclier
+828,6,Barrierenstoß
 828,8,Barrierassalto
 828,9,Psyshield Bash
 828,11,バリアーラッシュ
+828,12,屏障猛攻
 828,14,Asalto Barrera
 828,7,Asalto Barrera
-828,6,Barrierenstoß
-828,12,屏障猛攻
 829,1,パワーシフト
 829,3,파워시프트
 829,4,力量轉換
 829,5,Échange Force
+829,6,Kraftwechsel
 829,8,Scambioforza
 829,9,Power Shift
 829,11,パワーシフト
+829,12,力量转换
 829,14,Cambiapoder
 829,7,Cambiapoder
-829,6,Kraftwechsel
-829,12,力量转换
 830,1,がんせきアックス
 830,3,암석액스
 830,4,岩斧
 830,5,Hache de Pierre
+830,6,Felsaxt
 830,8,Rocciascure
 830,9,Stone Axe
 830,11,がんせきアックス
+830,12,岩斧
 830,14,Hachazo Pétreo
 830,7,Hachazo Pétreo
-830,6,Felsaxt
-830,12,岩斧
 831,1,はるのあらし
 831,3,봄의폭풍
 831,4,陽春風暴
 831,5,Typhon Passionné
+831,6,Frühlingsorkan
 831,8,Tempesta Zefirea
 831,9,Springtide Storm
 831,11,はるのあらし
+831,12,阳春风暴
 831,14,Ciclón Primavera
 831,7,Ciclón Primavera
-831,6,Frühlingsorkan
-831,12,阳春风暴
 832,1,しんぴのちから
 832,3,신비의힘
 832,4,神秘之力
 832,5,Force Mystique
+832,6,Mythenkraft
 832,8,Forza Mistica
 832,9,Mystical Power
 832,11,しんぴのちから
+832,12,神秘之力
 832,14,Poder Místico
 832,7,Poder Místico
-832,6,Mythenkraft
-832,12,神秘之力
 833,1,だいふんげき
 833,3,대격분
 833,4,大憤慨
 833,5,Grand Courroux
+833,6,Flammenwut
 833,8,Ira Furente
 833,9,Raging Fury
 833,11,だいふんげき
+833,12,大愤慨
 833,14,Erupción de Ira
 833,7,Erupción de Ira
-833,6,Flammenwut
-833,12,大愤慨
 834,1,ウェーブタックル
 834,3,웨이브태클
 834,4,波動衝
 834,5,Aquatacle
+834,6,Wellentackle
 834,8,Ondaschianto
 834,9,Wave Crash
 834,11,ウェーブタックル
+834,12,波动冲
 834,14,Acuatacleada
 834,7,Envite Acuático
-834,6,Wellentackle
-834,12,波动冲
 835,1,クロロブラスト
 835,3,클로로블라스트
 835,4,葉綠爆震
 835,5,Herblast
+835,6,Chlorostrahl
 835,8,Clorofillaser
 835,9,Chloroblast
 835,11,クロロブラスト
+835,12,叶绿爆震
 835,14,Clorofiláser
 835,7,Clorofiláser
-835,6,Chlorostrahl
-835,12,叶绿爆震
 836,1,ひょうざんおろし
 836,3,빙산바람
 836,4,冰山風
 836,5,Bise Glaciaire
+836,6,Frostfallwind
 836,8,Soffio d’Iceberg
 836,9,Mountain Gale
 836,11,ひょうざんおろし
+836,12,冰山风
 836,14,Viento Carámbano
 836,7,Viento Carámbano
-836,6,Frostfallwind
-836,12,冰山风
 837,1,しょうりのまい
 837,3,승리의춤
 837,4,勝利之舞
 837,5,Danse Victoire
+837,6,Siegestanz
 837,8,Danzavittoria
 837,9,Victory Dance
 837,11,しょうりのまい
+837,12,胜利之舞
 837,14,Danza Triunfal
 837,7,Danza Triunfal
-837,6,Siegestanz
-837,12,胜利之舞
 838,1,ぶちかまし
 838,3,들이받기
 838,4,突飛猛撲
 838,5,Assaut Frontal
+838,6,Schmetterramme
 838,8,Scontro Frontale
 838,9,Headlong Rush
 838,11,ぶちかまし
+838,12,突飞猛扑
 838,14,Asalto Frontal
 838,7,Arremetida
-838,6,Schmetterramme
-838,12,突飞猛扑
 839,1,どくばりセンボン
 839,3,독침천발
 839,4,毒千針
 839,5,Multitoxik
+839,6,Giftstachelregen
 839,8,Mille Fielespine
 839,9,Barb Barrage
 839,11,どくばりセンボン
+839,12,毒千针
 839,14,Mil Púas Tóxicas
 839,7,Mil Púas Tóxicas
-839,6,Giftstachelregen
-839,12,毒千针
 840,1,オーラウイング
 840,3,오라윙
 840,4,氣場之翼
 840,5,Ailes Psycho
+840,6,Auraschwingen
 840,8,Ali d’Aura
 840,9,Esper Wing
 840,11,オーラウイング
+840,12,气场之翼
 840,14,Ala Aural
 840,7,Ala Aural
-840,6,Auraschwingen
-840,12,气场之翼
 841,1,うらみつらみ
 841,3,천추지한
 841,4,冤冤相報
 841,5,Cœur de Rancœur
+841,6,Niedertracht
 841,8,Livore
 841,9,Bitter Malice
 841,11,うらみつらみ
+841,12,冤冤相报
 841,14,Rencor Reprimido
 841,7,Rencor Reprimido
-841,6,Niedertracht
-841,12,冤冤相报
 842,1,たてこもる
 842,3,농성
 842,4,閉關
 842,5,Mur Fumigène
+842,6,Refugium
 842,8,Barricata
 842,9,Shelter
 842,11,たてこもる
+842,12,闭关
 842,14,Retracción
 842,7,Retracción
-842,6,Refugium
-842,12,闭关
 843,1,３ぼんのや
 843,3,3연화살
 843,4,三連箭
 843,5,Triple Flèche
+843,6,Drillingspfeile
 843,8,Triplodardo
 843,9,Triple Arrows
 843,11,３ぼんのや
+843,12,三连箭
 843,14,Triple Flecha
 843,7,Triple Flecha
-843,6,Drillingspfeile
-843,12,三连箭
 844,1,ひゃっきやこう
 844,3,백귀야행
 844,4,群魔亂舞
 844,5,Cortège Funèbre
+844,6,Phantomparade
 844,8,Corteo Spettrale
 844,9,Infernal Parade
 844,11,ひゃっきやこう
+844,12,群魔乱舞
 844,14,Marcha Espectral
 844,7,Marcha Espectral
-844,6,Phantomparade
-844,12,群魔乱舞
 845,1,ひけん・ちえなみ
 845,3,비검천중파
 845,4,秘劍・千重濤
 845,5,Vagues à Lames
+845,6,Klingenschwall
 845,8,Lama Milleflutti
 845,9,Ceaseless Edge
 845,11,ひけん・ちえなみ
+845,12,秘剑・千重涛
 845,14,Corte Metralla
 845,7,Tajo Metralla
-845,6,Klingenschwall
-845,12,秘剑・千重涛
 846,1,こがらしあらし
 846,3,찬바람폭풍
 846,4,枯葉風暴
 846,5,Typhon Hivernal
+846,6,Polarorkan
 846,8,Tempesta Boreale
 846,9,Bleakwind Storm
 846,11,こがらしあらし
+846,12,枯叶风暴
 846,14,Vendaval Gélido
 846,7,Vendaval Gélido
-846,6,Polarorkan
-846,12,枯叶风暴
 847,1,かみなりあらし
 847,3,번개폭풍
 847,4,鳴雷風暴
 847,5,Typhon Fulgurant
+847,6,Donnerorkan
 847,8,Tempesta Tonante
 847,9,Wildbolt Storm
 847,11,かみなりあらし
+847,12,鸣雷风暴
 847,14,Electormenta
 847,7,Electormenta
-847,6,Donnerorkan
-847,12,鸣雷风暴
 848,1,ねっさのあらし
 848,3,열사의폭풍
 848,4,熱沙風暴
 848,5,Typhon Pyrosable
+848,6,Wüstenorkan
 848,8,Tempesta Ardente
 848,9,Sandsear Storm
 848,11,ねっさのあらし
+848,12,热沙风暴
 848,14,Tifón de Arena
 848,7,Simún de Arena
-848,6,Wüstenorkan
-848,12,热沙风暴
 849,1,みかづきのいのり
 849,3,초승달의기도
 849,4,新月祈禱
 849,5,Prière Lunaire
+849,6,Lunargebet
 849,8,Invocaluna
 849,9,Lunar Blessing
 849,11,みかづきのいのり
+849,12,新月祈祷
 849,14,Plegaria Lunar
 849,7,Plegaria Lunar
-849,6,Lunargebet
-849,12,新月祈祷
 850,1,ブレイブチャージ
 850,3,브레이브차지
 850,4,勇氣填充
 850,5,Extravaillance
+850,6,Mutschub
 850,8,Baldimpulso
 850,9,Take Heart
 850,11,ブレイブチャージ
+850,12,勇气填充
 850,14,Bálsamo Osado
 850,7,Bálsamo Osado
-850,6,Mutschub
-850,12,勇气填充
 851,1,テラバースト
 851,3,테라버스트
 851,4,太晶爆發
 851,5,Téra Explosion
+851,6,Tera-Ausbruch
 851,8,Terascoppio
 851,9,Tera Blast
 851,11,テラバースト
+851,12,太晶爆发
 851,14,Teraexplosión
 851,7,Teraexplosión
-851,6,Tera-Ausbruch
-851,12,太晶爆发
 852,1,スレッドトラップ
 852,3,스레드트랩
 852,4,線阱
 852,5,Piège de Fil
+852,6,Fadenfalle
 852,8,Telatrappola
 852,9,Silk Trap
 852,11,スレッドトラップ
+852,12,线阱
 852,14,Telatrampa
 852,7,Telatrampa
-852,6,Fadenfalle
-852,12,线阱
 853,1,かかとおとし
 853,3,발꿈치찍기
 853,4,下壓踢
 853,5,Talon-Marteau
+853,6,Fersenkick
 853,8,Calcio ad Ascia
 853,9,Axe Kick
 853,11,かかとおとし
+853,12,下压踢
 853,14,Patada Hacha
 853,7,Patada Hacha
-853,6,Fersenkick
-853,12,下压踢
 854,1,おはかまいり
 854,3,성묘
 854,4,掃墓
 854,5,Hommage Posthume
+854,6,Letzte Ehre
 854,8,Omaggio ai KO
 854,9,Last Respects
 854,11,おはかまいり
+854,12,扫墓
 854,14,Homenaje Póstumo
 854,7,Homenaje Póstumo
-854,6,Letzte Ehre
-854,12,扫墓
 855,1,ルミナコリジョン
 855,3,루미나콜리전
 855,4,琉光衝激
 855,5,Lumino-Impact
+855,6,Lichteinschlag
 855,8,Fotocollisione
 855,9,Lumina Crash
 855,11,ルミナコリジョン
+855,12,琉光冲激
 855,14,Fotocolisión
 855,7,Fotocolisión
-855,6,Lichteinschlag
-855,12,琉光冲激
 856,1,いっちょうあがり
 856,3,한판내기
 856,4,上菜
 856,5,Plat du Jour
+856,6,Auftischen
 856,8,Alta Cucina
 856,9,Order Up
 856,11,いっちょうあがり
+856,12,上菜
 856,14,Emplatar
 856,7,Oído Cocina
-856,6,Auftischen
-856,12,上菜
 857,1,ジェットパンチ
 857,3,제트펀치
 857,4,噴射拳
 857,5,Poing Sonique
+857,6,Düsenhieb
 857,8,Pugnojet
 857,9,Jet Punch
 857,11,ジェットパンチ
+857,12,喷射拳
 857,14,Puño Jet
 857,7,Puño Jet
-857,6,Düsenhieb
-857,12,喷射拳
 858,1,ハバネロエキス
 858,3,하바네로엑기스
 858,4,辣椒精華
 858,5,Habanerage
+858,6,Chili-Essenz
 858,8,Essenza Piccante
 858,9,Spicy Extract
 858,11,ハバネロエキス
+858,12,辣椒精华
 858,14,Extracto Picante
 858,7,Extracto Picante
-858,6,Chili-Essenz
-858,12,辣椒精华
 859,1,ホイールスピン
 859,3,휠스핀
 859,4,疾速轉輪
 859,5,Dérapage
+859,6,Reifendrehung
 859,8,Slittaruote
 859,9,Spin Out
 859,11,ホイールスピン
+859,12,疾速转轮
 859,14,Quemarrueda
 859,7,Quemarrueda
-859,6,Reifendrehung
-859,12,疾速转轮
 860,1,ネズミざん
 860,3,찍찍베기
 860,4,鼠數兒
 860,5,Prolifération
+860,6,Mäuseplage
 860,8,Infestazione
 860,9,Population Bomb
 860,11,ネズミざん
+860,12,鼠数儿
 860,14,Proliferación
 860,7,Proliferación
-860,6,Mäuseplage
-860,12,鼠数儿
 861,1,アイススピナー
 861,3,아이스스피너
 861,4,冰旋
 861,5,Cryo-Pirouette
+861,6,Eiskreisel
 861,8,Vortighiaccio
 861,9,Ice Spinner
 861,11,アイススピナー
+861,12,冰旋
 861,14,Pirueta Helada
 861,7,Pirueta Helada
-861,6,Eiskreisel
-861,12,冰旋
 862,1,きょけんとつげき
 862,3,대검돌격
 862,4,巨劍突擊
 862,5,Charge Glaive
+862,6,Großklingenstoß
 862,8,Spadoncarica
 862,9,Glaive Rush
 862,11,きょけんとつげき
+862,12,巨剑突击
 862,14,Asalto Espadón
 862,7,Asalto Espadón
-862,6,Großklingenstoß
-862,12,巨剑突击
 863,1,さいきのいのり
 863,3,회생의기도
 863,4,復生祈禱
 863,5,Second Souffle
+863,6,Vitalsegen
 863,8,Preghiera Vitale
 863,9,Revival Blessing
 863,11,さいきのいのり
+863,12,复生祈祷
 863,14,Plegaria Vital
 863,7,Plegaria Vital
-863,6,Vitalsegen
-863,12,复生祈祷
 864,1,しおづけ
 864,3,소금절이
 864,4,鹽醃
 864,5,Salaison
+864,6,Pökelsalz
 864,8,Sotto Sale
 864,9,Salt Cure
 864,11,しおづけ
+864,12,盐腌
 864,14,Salación
 864,7,Salazón
-864,6,Pökelsalz
-864,12,盐腌
 865,1,トリプルダイブ
 865,3,트리플다이브
 865,4,三連鑽
 865,5,Triple Plongeon
+865,6,Tauchtriade
 865,8,Triplo Tuffo
 865,9,Triple Dive
 865,11,トリプルダイブ
+865,12,三连钻
 865,14,Triple Inmersión
 865,7,Triple Inmersión
-865,6,Tauchtriade
-865,12,三连钻
 866,1,キラースピン
 866,3,킬러스핀
 866,4,晶光轉轉
 866,5,Toupie Éclat
+866,6,Letalwirbler
 866,8,Glitturbine
 866,9,Mortal Spin
 866,11,キラースピン
+866,12,晶光转转
 866,14,Giro Mortífero
 866,7,Giro Mortífero
-866,6,Letalwirbler
-866,12,晶光转转
 867,1,うつしえ
 867,3,배껴그리기
 867,4,描繪
 867,5,Décalquage
+867,6,Abpausen
 867,8,Ricalco
 867,9,Doodle
 867,11,うつしえ
+867,12,描绘
 867,14,Plagio
 867,7,Decalcomanía
-867,6,Abpausen
-867,12,描绘
 868,1,みをけずる
 868,3,제살깎기
 868,4,甩肉
 868,5,Décharnement
+868,6,Abspaltung
 868,8,Alleggerimento
 868,9,Fillet Away
 868,11,みをけずる
+868,12,甩肉
 868,14,Fileteo
 868,7,Deslome
-868,6,Abspaltung
-868,12,甩肉
 869,1,ドゲザン
 869,3,도각참
 869,4,仆斬
 869,5,Génusection
+869,6,Kniefallspalter
 869,8,Genufendente
 869,9,Kowtow Cleave
 869,11,ドゲザン
+869,12,仆刀
 869,14,Genufendiente
 869,7,Genufendiente
-869,6,Kniefallspalter
-869,12,仆刀
 870,1,トリックフラワー
 870,3,트릭플라워
 870,4,千變萬花
 870,5,Magie Florale
+870,6,Blumentrick
 870,8,Prestigiafiore
 870,9,Flower Trick
 870,11,トリックフラワー
+870,12,千变万花
 870,14,Truco Floral
 870,7,Truco Floral
-870,6,Blumentrick
-870,12,千变万花
 871,1,フレアソング
 871,3,플레어송
 871,4,閃焰高歌
 871,5,Chant Flamboyant
+871,6,Loderlied
 871,8,Canzone Ardente
 871,9,Torch Song
 871,11,フレアソング
+871,12,闪焰高歌
 871,14,Canto Ígneo
 871,7,Canto Ardiente
-871,6,Loderlied
-871,12,闪焰高歌
 872,1,アクアステップ
 872,3,아쿠아스텝
 872,4,流水旋舞
 872,5,Danse Aquatique
+872,6,Wogentanz
 872,8,Idroballetto
 872,9,Aqua Step
 872,11,アクアステップ
+872,12,流水旋舞
 872,14,Danza Acuática
 872,7,Danza Acuática
-872,6,Wogentanz
-872,12,流水旋舞
 873,1,レイジングブル
 873,3,레이징불
 873,4,怒牛
 873,5,Taurogne
+873,6,Rasender Stier
 873,8,Scatenatoro
 873,9,Raging Bull
 873,11,レイジングブル
+873,12,怒牛
 873,14,Furia Taurina
 873,7,Furia Taurina
-873,6,Rasender Stier
-873,12,怒牛
 874,1,ゴールドラッシュ
 874,3,골드러시
 874,4,淘金潮
 874,5,Ruée d'Or
+874,6,Goldrausch
 874,8,Corsa all’Oro
 874,9,Make It Rain
 874,11,ゴールドラッシュ
+874,12,淘金潮
 874,14,Fiebre Dorada
 874,7,Fiebre Dorada
-874,6,Goldrausch
-874,12,淘金潮
 875,1,サイコブレイド
 875,3,사이코블레이드
 875,4,精神劍
@@ -9639,310 +9639,310 @@ move_id,local_language_id,name
 877,3,카타스트로피
 877,4,大災難
 877,5,Cataclysme
+877,6,Verderben
 877,8,Catastrofe
 877,9,Ruination
 877,11,カタストロフィ
+877,12,大灾难
 877,14,Calamidad
 877,7,Calamidad
-877,6,Verderben
-877,12,大灾难
 878,1,アクセルブレイク
 878,3,엑셀브레이크
 878,4,全開猛撞
 878,5,Nitro Crash
+878,6,Kollisionskurs
 878,8,Turboschianto
 878,9,Collision Course
 878,11,アクセルブレイク
+878,12,全开猛撞
 878,14,Nitrochoque
 878,7,Nitrochoque
-878,6,Kollisionskurs
-878,12,全开猛撞
 879,1,イナズマドライブ
 879,3,라이트닝드라이브
 879,4,閃電猛衝
 879,5,Turbo Volt
+879,6,Blitztour
 879,8,Fulmiscatto
 879,9,Electro Drift
 879,11,イナズマドライブ
+879,12,闪电猛冲
 879,14,Electroderrape
 879,7,Electroderrape
-879,6,Blitztour
-879,12,闪电猛冲
 880,1,しっぽきり
 880,3,꼬리자르기
 880,4,斷尾
 880,5,Queulonage
+880,6,Schwanzabwurf
 880,8,Tagliacoda
 880,9,Shed Tail
 880,11,しっぽきり
+880,12,断尾
 880,14,Autotomía
 880,7,Autotomía
-880,6,Schwanzabwurf
-880,12,断尾
 881,1,さむいギャグ
 881,3,썰렁개그
 881,4,冷笑話
 881,5,Neigeux de Mots
+881,6,Eisige Stimmung
 881,8,Freddura
 881,9,Chilly Reception
 881,11,さむいギャグ
+881,12,冷笑话
 881,14,Respuesta Fría
 881,7,Fría Acogida
-881,6,Eisige Stimmung
-881,12,冷笑话
 882,1,おかたづけ
 882,3,정리정돈
 882,4,大掃除
 882,5,Grand Nettoyage
+882,6,Aufräumen
 882,8,Pulizie
 882,9,Tidy Up
 882,11,おかたづけ
+882,12,大扫除
 882,14,Limpieza General
 882,7,Limpieza General
-882,6,Aufräumen
-882,12,大扫除
 883,1,ゆきげしき
 883,3,설경
 883,4,雪景
 883,5,Chute de Neige
+883,6,Schneelandschaft
 883,8,Vista Innevata
 883,9,Snowscape
 883,11,ゆきげしき
+883,12,雪景
 883,14,Paisaje Nevado
 883,7,Paisaje Nevado
-883,6,Schneelandschaft
-883,12,雪景
 884,1,とびつく
 884,3,달려들기
 884,4,蟲撲
 884,5,Bond
+884,6,Anspringen
 884,8,Balzo
 884,9,Pounce
 884,11,とびつく
+884,12,虫扑
 884,14,Brinco
 884,7,Brinco
-884,6,Anspringen
-884,12,虫扑
 885,1,くさわけ
 885,3,개척하기
 885,4,起草
 885,5,Désherbaffe
+885,6,Wegbereiter
 885,8,Apripista
 885,9,Trailblaze
 885,11,くさわけ
+885,12,起草
 885,14,Abrecaminos
 885,7,Abrecaminos
-885,6,Wegbereiter
-885,12,起草
 886,1,ひやみず
 886,3,찬물끼얹기
 886,4,潑冷水
 886,5,Douche Froide
+886,6,Kalte Dusche
 886,8,Doccia Fredda
 886,9,Chilling Water
 886,11,ひやみず
+886,12,泼冷水
 886,14,Agua Fría
 886,7,Agua Fría
-886,6,Kalte Dusche
-886,12,泼冷水
 887,1,ハイパードリル
 887,3,하이퍼드릴
 887,4,強力鑽
 887,5,Hyperceuse
+887,6,Hyperbohrer
 887,8,Ipertrapano
 887,9,Hyper Drill
 887,11,ハイパードリル
+887,12,强力钻
 887,14,Hipertaladro
 887,7,Hipertaladro
-887,6,Hyperbohrer
-887,12,强力钻
 888,1,ツインビーム
 888,3,트윈빔
 888,4,雙光束
 888,5,Double Laser
+888,6,Doppelstrahl
 888,8,Doppioraggio
 888,9,Twin Beam
 888,11,ツインビーム
+888,12,双光束
 888,14,Láser Doble
 888,7,Láser Doble
-888,6,Doppelstrahl
-888,12,双光束
 889,1,ふんどのこぶし
 889,3,분노의주먹
 889,4,憤怒之拳
 889,5,Poing de Colère
+889,6,Zornesfaust
 889,8,Pugno Furibondo
 889,9,Rage Fist
 889,11,ふんどのこぶし
+889,12,愤怒之拳
 889,14,Puño Furia
 889,7,Puño Furia
-889,6,Zornesfaust
-889,12,愤怒之拳
 890,1,アーマーキャノン
 890,3,아머캐논
 890,4,鎧農炮
 890,5,Canon Blindé
+890,6,Rüstungskanone
 890,8,Corazza Cannone
 890,9,Armor Cannon
 890,11,アーマーキャノン
+890,12,铠农炮
 890,14,Cañón Armadura
 890,7,Cañón Armadura
-890,6,Rüstungskanone
-890,12,铠农炮
 891,1,むねんのつるぎ
 891,3,원념의칼
 891,4,悔念劍
 891,5,Lame en Peine
+891,6,Reueschwert
 891,8,Lama del Rimorso
 891,9,Bitter Blade
 891,11,むねんのつるぎ
+891,12,悔念剑
 891,14,Espada Lamento
 891,7,Espada Lamento
-891,6,Reueschwert
-891,12,悔念剑
 892,1,でんこうそうげき
 892,3,전광쌍격
 892,4,電光雙擊
 892,5,Double Décharge
+892,6,Zweifachladung
 892,8,Doppiolampo
 892,9,Double Shock
 892,11,でんこうそうげき
+892,12,电光双击
 892,14,Electropalmas
 892,7,Electropalmas
-892,6,Zweifachladung
-892,12,电光双击
 893,1,デカハンマー
 893,3,거대해머
 893,4,巨力錘
 893,5,Marteau Mastoc
+893,6,Riesenhammer
 893,8,Granmartello
 893,9,Gigaton Hammer
 893,11,デカハンマー
+893,12,巨力锤
 893,14,Martillo Colosal
 893,7,Martillo Colosal
-893,6,Riesenhammer
-893,12,巨力锤
 894,1,ほうふく
 894,3,앙갚음
 894,4,復仇
 894,5,Vindicte
+894,6,Vendetta
 894,8,Ritorsione
 894,9,Comeuppance
 894,11,ほうふく
+894,12,复仇
 894,14,Resarcimiento
 894,7,Resarcimiento
-894,6,Vendetta
-894,12,复仇
 895,1,アクアカッター
 895,3,아쿠아커터
 895,4,水波刀
 895,5,Tranch'Aqua
+895,6,Aquaschnitt
 895,8,Idrotaglio
 895,9,Aqua Cutter
 895,11,アクアカッター
+895,12,水波刀
 895,14,Corte Acuático
 895,7,Tajo Acuático
-895,6,Aquaschnitt
-895,12,水波刀
 896,1,バーンアクセル
 896,3,번액셀
 896,4,灼熱暴衝
 896,5,Crash Brûlant
+896,6,Hitzeturbo
 896,8,Turboustione
 896,9,Blazing Torque
 896,11,バーンアクセル
+896,12,灼热暴冲
 896,14,Pirochoque
 896,7,Pirochoque
-896,6,Hitzeturbo
-896,12,灼热暴冲
 897,1,ダークアクセル
 897,3,다크액셀
 897,4,黑暗暴衝
 897,5,Crash Obscur
+897,6,Finsterturbo
 897,8,Turbotenebra
 897,9,Wicked Torque
 897,11,ダークアクセル
+897,12,黑暗暴冲
 897,14,Ominochoque
 897,7,Ominochoque
-897,6,Finsterturbo
-897,12,黑暗暴冲
 898,1,ポイズンアクセル
 898,3,포이즌액셀
 898,4,劇毒暴衝
 898,5,Crash Toxique
+898,6,Toxiturbo
 898,8,Turbotossina
 898,9,Noxious Torque
 898,11,ポイズンアクセル
+898,12,剧毒暴冲
 898,14,Ponzochoque
 898,7,Ponzochoque
-898,6,Toxiturbo
-898,12,剧毒暴冲
 899,1,ファイトアクセル
 899,3,파이트액셀
 899,4,格鬥暴衝
 899,5,Crash Musclé
+899,6,Raufturbo
 899,8,Turborissa
 899,9,Combat Torque
 899,11,ファイトアクセル
+899,12,格斗暴冲
 899,14,Pugnachoque
 899,7,Pugnachoque
-899,6,Raufturbo
-899,12,格斗暴冲
 900,1,マジカルアクセル
 900,3,매지컬액셀
 900,4,魔法暴衝
 900,5,Crash Magique
+900,6,Zauberturbo
 900,8,Turboincanto
 900,9,Magical Torque
 900,11,マジカルアクセル
+900,12,魔法暴冲
 900,14,Feerichoque
 900,7,Feerichoque
-900,6,Zauberturbo
-900,12,魔法暴冲
 901,1,ブラッドムーン
 901,3,블러드문
-901,5,Lune Rouge
-901,9,Blood Moon
-901,11,ブラッドムーン
-901,14,Luna Roja
-901,7,Luna Roja
 901,4,血月
+901,5,Lune Rouge
 901,6,Blutmond
 901,8,Luna Rossa
+901,9,Blood Moon
+901,11,ブラッドムーン
 901,12,血月
+901,14,Luna Roja
+901,7,Luna Roja
 902,1,シャカシャカほう
 902,3,휘적휘적포
-902,5,Mortier Matcha
-902,9,Matcha Gotcha
-902,11,シャカシャカほう
-902,14,Cañón Batidor
-902,7,Cañón Batidor
 902,4,刷刷茶炮
+902,5,Mortier Matcha
 902,6,Quirlschuss
 902,8,Spruzzatè
+902,9,Matcha Gotcha
+902,11,シャカシャカほう
 902,12,刷刷茶炮
+902,14,Cañón Batidor
+902,7,Cañón Batidor
 903,1,みずあめボム
 903,3,시럽봄
-903,5,Bombe au Sirop
-903,9,Syrup Bomb
-903,11,みずあめボム
-903,14,Bomba Caramelo
-903,7,Bomba Caramelo
 903,4,糖漿炸彈
+903,5,Bombe au Sirop
 903,6,Sirupbombe
 903,8,Bomba Sciroppata
+903,9,Syrup Bomb
+903,11,みずあめボム
 903,12,糖浆炸弹
+903,14,Bomba Caramelo
+903,7,Bomba Caramelo
 904,1,ツタこんぼう
 904,3,덩굴방망이
-904,5,Massue Liane
-904,9,Ivy Cudgel
-904,11,ツタこんぼう
-904,14,Garrote Liana
-904,7,Garrote Liana
 904,4,棘藤棒
+904,5,Massue Liane
 904,6,Rankenkeule
 904,8,Clava di Liane
+904,9,Ivy Cudgel
+904,11,ツタこんぼう
 904,12,棘藤棒
+904,14,Garrote Liana
+904,7,Garrote Liana
 905,1,エレクトロビーム
 905,3,일렉트로빔
 905,4,電光束

--- a/data/v2/csv/move_names.csv
+++ b/data/v2/csv/move_names.csv
@@ -9087,13 +9087,15 @@ move_id,local_language_id,name
 826,14,Conjuro Funesto
 827,1,フェイタルクロー
 827,3,페이탈클로
-827,4,克命爪
+827,4,剋命爪
 827,5,Griffes Funestes
 827,8,Artigli Fatali
 827,9,Dire Claw
 827,11,フェイタルクロー
 827,14,Garra Nociva
 827,7,Garra Nociva
+827,6,Unheilsklauen
+827,12,克命爪
 828,1,バリアーラッシュ
 828,3,배리어러시
 828,4,屏障猛攻
@@ -9103,15 +9105,19 @@ move_id,local_language_id,name
 828,11,バリアーラッシュ
 828,14,Asalto Barrera
 828,7,Asalto Barrera
+828,6,Barrierenstoß
+828,12,屏障猛攻
 829,1,パワーシフト
 829,3,파워시프트
-829,4,力量转换
+829,4,力量轉換
 829,5,Échange Force
 829,8,Scambioforza
 829,9,Power Shift
 829,11,パワーシフト
 829,14,Cambiapoder
 829,7,Cambiapoder
+829,6,Kraftwechsel
+829,12,力量转换
 830,1,がんせきアックス
 830,3,암석액스
 830,4,岩斧
@@ -9121,15 +9127,19 @@ move_id,local_language_id,name
 830,11,がんせきアックス
 830,14,Hachazo Pétreo
 830,7,Hachazo Pétreo
+830,6,Felsaxt
+830,12,岩斧
 831,1,はるのあらし
 831,3,봄의폭풍
-831,4,阳春风暴
+831,4,陽春風暴
 831,5,Typhon Passionné
 831,8,Tempesta Zefirea
 831,9,Springtide Storm
 831,11,はるのあらし
 831,14,Ciclón Primavera
 831,7,Ciclón Primavera
+831,6,Frühlingsorkan
+831,12,阳春风暴
 832,1,しんぴのちから
 832,3,신비의힘
 832,4,神秘之力
@@ -9139,213 +9149,261 @@ move_id,local_language_id,name
 832,11,しんぴのちから
 832,14,Poder Místico
 832,7,Poder Místico
+832,6,Mythenkraft
+832,12,神秘之力
 833,1,だいふんげき
 833,3,대격분
-833,4,大愤慨
+833,4,大憤慨
 833,5,Grand Courroux
 833,8,Ira Furente
 833,9,Raging Fury
 833,11,だいふんげき
 833,14,Erupción de Ira
 833,7,Erupción de Ira
+833,6,Flammenwut
+833,12,大愤慨
 834,1,ウェーブタックル
 834,3,웨이브태클
-834,4,波动冲
+834,4,波動衝
 834,5,Aquatacle
 834,8,Ondaschianto
 834,9,Wave Crash
 834,11,ウェーブタックル
 834,14,Acuatacleada
 834,7,Envite Acuático
+834,6,Wellentackle
+834,12,波动冲
 835,1,クロロブラスト
 835,3,클로로블라스트
-835,4,叶绿爆震
+835,4,葉綠爆震
 835,5,Herblast
 835,8,Clorofillaser
 835,9,Chloroblast
 835,11,クロロブラスト
 835,14,Clorofiláser
 835,7,Clorofiláser
+835,6,Chlorostrahl
+835,12,叶绿爆震
 836,1,ひょうざんおろし
 836,3,빙산바람
-836,4,冰山风
+836,4,冰山風
 836,5,Bise Glaciaire
 836,8,Soffio d’Iceberg
 836,9,Mountain Gale
 836,11,ひょうざんおろし
 836,14,Viento Carámbano
 836,7,Viento Carámbano
+836,6,Frostfallwind
+836,12,冰山风
 837,1,しょうりのまい
 837,3,승리의춤
-837,4,胜利之舞
+837,4,勝利之舞
 837,5,Danse Victoire
 837,8,Danzavittoria
 837,9,Victory Dance
 837,11,しょうりのまい
 837,14,Danza Triunfal
 837,7,Danza Triunfal
+837,6,Siegestanz
+837,12,胜利之舞
 838,1,ぶちかまし
 838,3,들이받기
-838,4,突飞猛扑
+838,4,突飛猛撲
 838,5,Assaut Frontal
 838,8,Scontro Frontale
 838,9,Headlong Rush
 838,11,ぶちかまし
 838,14,Asalto Frontal
 838,7,Arremetida
+838,6,Schmetterramme
+838,12,突飞猛扑
 839,1,どくばりセンボン
 839,3,독침천발
-839,4,毒千针
+839,4,毒千針
 839,5,Multitoxik
 839,8,Mille Fielespine
 839,9,Barb Barrage
 839,11,どくばりセンボン
 839,14,Mil Púas Tóxicas
 839,7,Mil Púas Tóxicas
+839,6,Giftstachelregen
+839,12,毒千针
 840,1,オーラウイング
 840,3,오라윙
-840,4,气场之翼
+840,4,氣場之翼
 840,5,Ailes Psycho
 840,8,Ali d’Aura
 840,9,Esper Wing
 840,11,オーラウイング
 840,14,Ala Aural
 840,7,Ala Aural
+840,6,Auraschwingen
+840,12,气场之翼
 841,1,うらみつらみ
 841,3,천추지한
-841,4,冤冤相报
+841,4,冤冤相報
 841,5,Cœur de Rancœur
 841,8,Livore
 841,9,Bitter Malice
 841,11,うらみつらみ
 841,14,Rencor Reprimido
 841,7,Rencor Reprimido
+841,6,Niedertracht
+841,12,冤冤相报
 842,1,たてこもる
 842,3,농성
-842,4,闭关
+842,4,閉關
 842,5,Mur Fumigène
 842,8,Barricata
 842,9,Shelter
 842,11,たてこもる
 842,14,Retracción
 842,7,Retracción
+842,6,Refugium
+842,12,闭关
 843,1,３ぼんのや
 843,3,3연화살
-843,4,三连箭
+843,4,三連箭
 843,5,Triple Flèche
 843,8,Triplodardo
 843,9,Triple Arrows
 843,11,３ぼんのや
 843,14,Triple Flecha
 843,7,Triple Flecha
+843,6,Drillingspfeile
+843,12,三连箭
 844,1,ひゃっきやこう
 844,3,백귀야행
-844,4,群魔乱舞
+844,4,群魔亂舞
 844,5,Cortège Funèbre
 844,8,Corteo Spettrale
 844,9,Infernal Parade
 844,11,ひゃっきやこう
 844,14,Marcha Espectral
 844,7,Marcha Espectral
+844,6,Phantomparade
+844,12,群魔乱舞
 845,1,ひけん・ちえなみ
 845,3,비검천중파
-845,4,秘剑・千重涛
+845,4,秘劍・千重濤
 845,5,Vagues à Lames
 845,8,Lama Milleflutti
 845,9,Ceaseless Edge
 845,11,ひけん・ちえなみ
 845,14,Corte Metralla
 845,7,Tajo Metralla
+845,6,Klingenschwall
+845,12,秘剑・千重涛
 846,1,こがらしあらし
 846,3,찬바람폭풍
-846,4,枯叶风暴
+846,4,枯葉風暴
 846,5,Typhon Hivernal
 846,8,Tempesta Boreale
 846,9,Bleakwind Storm
 846,11,こがらしあらし
 846,14,Vendaval Gélido
 846,7,Vendaval Gélido
+846,6,Polarorkan
+846,12,枯叶风暴
 847,1,かみなりあらし
 847,3,번개폭풍
-847,4,鸣雷风暴
+847,4,鳴雷風暴
 847,5,Typhon Fulgurant
 847,8,Tempesta Tonante
 847,9,Wildbolt Storm
 847,11,かみなりあらし
 847,14,Electormenta
 847,7,Electormenta
+847,6,Donnerorkan
+847,12,鸣雷风暴
 848,1,ねっさのあらし
 848,3,열사의폭풍
-848,4,热沙风暴
+848,4,熱沙風暴
 848,5,Typhon Pyrosable
 848,8,Tempesta Ardente
 848,9,Sandsear Storm
 848,11,ねっさのあらし
 848,14,Tifón de Arena
 848,7,Simún de Arena
+848,6,Wüstenorkan
+848,12,热沙风暴
 849,1,みかづきのいのり
 849,3,초승달의기도
-849,4,新月祈祷
+849,4,新月祈禱
 849,5,Prière Lunaire
 849,8,Invocaluna
 849,9,Lunar Blessing
 849,11,みかづきのいのり
 849,14,Plegaria Lunar
 849,7,Plegaria Lunar
+849,6,Lunargebet
+849,12,新月祈祷
 850,1,ブレイブチャージ
 850,3,브레이브차지
-850,4,勇气填充
+850,4,勇氣填充
 850,5,Extravaillance
 850,8,Baldimpulso
 850,9,Take Heart
 850,11,ブレイブチャージ
 850,14,Bálsamo Osado
 850,7,Bálsamo Osado
+850,6,Mutschub
+850,12,勇气填充
 851,1,テラバースト
 851,3,테라버스트
-851,4,太晶爆发
+851,4,太晶爆發
 851,5,Téra Explosion
 851,8,Terascoppio
 851,9,Tera Blast
 851,11,テラバースト
 851,14,Teraexplosión
 851,7,Teraexplosión
+851,6,Tera-Ausbruch
+851,12,太晶爆发
 852,1,スレッドトラップ
 852,3,스레드트랩
-852,4,线阱
+852,4,線阱
 852,5,Piège de Fil
 852,8,Telatrappola
 852,9,Silk Trap
 852,11,スレッドトラップ
 852,14,Telatrampa
 852,7,Telatrampa
+852,6,Fadenfalle
+852,12,线阱
 853,1,かかとおとし
 853,3,발꿈치찍기
-853,4,下压踢
+853,4,下壓踢
 853,5,Talon-Marteau
 853,8,Calcio ad Ascia
 853,9,Axe Kick
 853,11,かかとおとし
 853,14,Patada Hacha
 853,7,Patada Hacha
+853,6,Fersenkick
+853,12,下压踢
 854,1,おはかまいり
 854,3,성묘
-854,4,扫墓
+854,4,掃墓
 854,5,Hommage Posthume
 854,8,Omaggio ai KO
 854,9,Last Respects
 854,11,おはかまいり
 854,14,Homenaje Póstumo
 854,7,Homenaje Póstumo
+854,6,Letzte Ehre
+854,12,扫墓
 855,1,ルミナコリジョン
 855,3,루미나콜리전
-855,4,琉光冲激
+855,4,琉光衝激
 855,5,Lumino-Impact
 855,8,Fotocollisione
 855,9,Lumina Crash
 855,11,ルミナコリジョン
 855,14,Fotocolisión
 855,7,Fotocolisión
+855,6,Lichteinschlag
+855,12,琉光冲激
 856,1,いっちょうあがり
 856,3,한판내기
 856,4,上菜
@@ -9355,42 +9413,52 @@ move_id,local_language_id,name
 856,11,いっちょうあがり
 856,14,Emplatar
 856,7,Oído Cocina
+856,6,Auftischen
+856,12,上菜
 857,1,ジェットパンチ
 857,3,제트펀치
-857,4,喷射拳
+857,4,噴射拳
 857,5,Poing Sonique
 857,8,Pugnojet
 857,9,Jet Punch
 857,11,ジェットパンチ
 857,14,Puño Jet
 857,7,Puño Jet
+857,6,Düsenhieb
+857,12,喷射拳
 858,1,ハバネロエキス
 858,3,하바네로엑기스
-858,4,辣椒精华
+858,4,辣椒精華
 858,5,Habanerage
 858,8,Essenza Piccante
 858,9,Spicy Extract
 858,11,ハバネロエキス
 858,14,Extracto Picante
 858,7,Extracto Picante
+858,6,Chili-Essenz
+858,12,辣椒精华
 859,1,ホイールスピン
 859,3,휠스핀
-859,4,疾速转轮
+859,4,疾速轉輪
 859,5,Dérapage
 859,8,Slittaruote
 859,9,Spin Out
 859,11,ホイールスピン
 859,14,Quemarrueda
 859,7,Quemarrueda
+859,6,Reifendrehung
+859,12,疾速转轮
 860,1,ネズミざん
 860,3,찍찍베기
-860,4,鼠数儿
+860,4,鼠數兒
 860,5,Prolifération
 860,8,Infestazione
 860,9,Population Bomb
 860,11,ネズミざん
 860,14,Proliferación
 860,7,Proliferación
+860,6,Mäuseplage
+860,12,鼠数儿
 861,1,アイススピナー
 861,3,아이스스피너
 861,4,冰旋
@@ -9400,60 +9468,74 @@ move_id,local_language_id,name
 861,11,アイススピナー
 861,14,Pirueta Helada
 861,7,Pirueta Helada
+861,6,Eiskreisel
+861,12,冰旋
 862,1,きょけんとつげき
 862,3,대검돌격
-862,4,巨剑突击
+862,4,巨劍突擊
 862,5,Charge Glaive
 862,8,Spadoncarica
 862,9,Glaive Rush
 862,11,きょけんとつげき
 862,14,Asalto Espadón
 862,7,Asalto Espadón
+862,6,Großklingenstoß
+862,12,巨剑突击
 863,1,さいきのいのり
 863,3,회생의기도
-863,4,复生祈祷
+863,4,復生祈禱
 863,5,Second Souffle
 863,8,Preghiera Vitale
 863,9,Revival Blessing
 863,11,さいきのいのり
 863,14,Plegaria Vital
 863,7,Plegaria Vital
+863,6,Vitalsegen
+863,12,复生祈祷
 864,1,しおづけ
 864,3,소금절이
-864,4,盐腌
+864,4,鹽醃
 864,5,Salaison
 864,8,Sotto Sale
 864,9,Salt Cure
 864,11,しおづけ
 864,14,Salación
 864,7,Salazón
+864,6,Pökelsalz
+864,12,盐腌
 865,1,トリプルダイブ
 865,3,트리플다이브
-865,4,三连钻
+865,4,三連鑽
 865,5,Triple Plongeon
 865,8,Triplo Tuffo
 865,9,Triple Dive
 865,11,トリプルダイブ
 865,14,Triple Inmersión
 865,7,Triple Inmersión
+865,6,Tauchtriade
+865,12,三连钻
 866,1,キラースピン
 866,3,킬러스핀
-866,4,晶光转转
+866,4,晶光轉轉
 866,5,Toupie Éclat
 866,8,Glitturbine
 866,9,Mortal Spin
 866,11,キラースピン
 866,14,Giro Mortífero
 866,7,Giro Mortífero
+866,6,Letalwirbler
+866,12,晶光转转
 867,1,うつしえ
 867,3,배껴그리기
-867,4,描绘
+867,4,描繪
 867,5,Décalquage
 867,8,Ricalco
 867,9,Doodle
 867,11,うつしえ
 867,14,Plagio
 867,7,Decalcomanía
+867,6,Abpausen
+867,12,描绘
 868,1,みをけずる
 868,3,제살깎기
 868,4,甩肉
@@ -9463,33 +9545,41 @@ move_id,local_language_id,name
 868,11,みをけずる
 868,14,Fileteo
 868,7,Deslome
+868,6,Abspaltung
+868,12,甩肉
 869,1,ドゲザン
 869,3,도각참
-869,4,仆刀
+869,4,仆斬
 869,5,Génusection
 869,8,Genufendente
 869,9,Kowtow Cleave
 869,11,ドゲザン
 869,14,Genufendiente
 869,7,Genufendiente
+869,6,Kniefallspalter
+869,12,仆刀
 870,1,トリックフラワー
 870,3,트릭플라워
-870,4,千变万花
+870,4,千變萬花
 870,5,Magie Florale
 870,8,Prestigiafiore
 870,9,Flower Trick
 870,11,トリックフラワー
 870,14,Truco Floral
 870,7,Truco Floral
+870,6,Blumentrick
+870,12,千变万花
 871,1,フレアソング
 871,3,플레어송
-871,4,闪焰高歌
+871,4,閃焰高歌
 871,5,Chant Flamboyant
 871,8,Canzone Ardente
 871,9,Torch Song
 871,11,フレアソング
 871,14,Canto Ígneo
 871,7,Canto Ardiente
+871,6,Loderlied
+871,12,闪焰高歌
 872,1,アクアステップ
 872,3,아쿠아스텝
 872,4,流水旋舞
@@ -9499,6 +9589,8 @@ move_id,local_language_id,name
 872,11,アクアステップ
 872,14,Danza Acuática
 872,7,Danza Acuática
+872,6,Wogentanz
+872,12,流水旋舞
 873,1,レイジングブル
 873,3,레이징불
 873,4,怒牛
@@ -9508,6 +9600,8 @@ move_id,local_language_id,name
 873,11,レイジングブル
 873,14,Furia Taurina
 873,7,Furia Taurina
+873,6,Rasender Stier
+873,12,怒牛
 874,1,ゴールドラッシュ
 874,3,골드러시
 874,4,淘金潮
@@ -9517,6 +9611,8 @@ move_id,local_language_id,name
 874,11,ゴールドラッシュ
 874,14,Fiebre Dorada
 874,7,Fiebre Dorada
+874,6,Goldrausch
+874,12,淘金潮
 875,1,サイコブレイド
 875,3,사이코블레이드
 875,4,精神劍
@@ -9541,58 +9637,70 @@ move_id,local_language_id,name
 876,14,Hidrovapor
 877,1,カタストロフィ
 877,3,카타스트로피
-877,4,大灾难
+877,4,大災難
 877,5,Cataclysme
 877,8,Catastrofe
 877,9,Ruination
 877,11,カタストロフィ
 877,14,Calamidad
 877,7,Calamidad
+877,6,Verderben
+877,12,大灾难
 878,1,アクセルブレイク
 878,3,엑셀브레이크
-878,4,全开猛撞
+878,4,全開猛撞
 878,5,Nitro Crash
 878,8,Turboschianto
 878,9,Collision Course
 878,11,アクセルブレイク
 878,14,Nitrochoque
 878,7,Nitrochoque
+878,6,Kollisionskurs
+878,12,全开猛撞
 879,1,イナズマドライブ
 879,3,라이트닝드라이브
-879,4,闪电猛冲
+879,4,閃電猛衝
 879,5,Turbo Volt
 879,8,Fulmiscatto
 879,9,Electro Drift
 879,11,イナズマドライブ
 879,14,Electroderrape
 879,7,Electroderrape
+879,6,Blitztour
+879,12,闪电猛冲
 880,1,しっぽきり
 880,3,꼬리자르기
-880,4,断尾
+880,4,斷尾
 880,5,Queulonage
 880,8,Tagliacoda
 880,9,Shed Tail
 880,11,しっぽきり
 880,14,Autotomía
 880,7,Autotomía
+880,6,Schwanzabwurf
+880,12,断尾
 881,1,さむいギャグ
 881,3,썰렁개그
-881,4,冷笑话
+881,4,冷笑話
 881,5,Neigeux de Mots
 881,8,Freddura
 881,9,Chilly Reception
 881,11,さむいギャグ
 881,14,Respuesta Fría
 881,7,Fría Acogida
+881,6,Eisige Stimmung
+881,12,冷笑话
 882,1,おかたづけ
 882,3,정리정돈
-882,4,大扫除
+882,4,大掃除
 882,5,Grand Nettoyage
 882,8,Pulizie
 882,9,Tidy Up
 882,11,おかたづけ
 882,14,Limpieza General
 882,7,Limpieza General
+882,6,Aufräumen
+882,12,大扫除
 883,1,ゆきげしき
 883,3,설경
 883,4,雪景
@@ -9602,15 +9710,19 @@ move_id,local_language_id,name
 883,11,ゆきげしき
 883,14,Paisaje Nevado
 883,7,Paisaje Nevado
+883,6,Schneelandschaft
+883,12,雪景
 884,1,とびつく
 884,3,달려들기
-884,4,虫扑
+884,4,蟲撲
 884,5,Bond
 884,8,Balzo
 884,9,Pounce
 884,11,とびつく
 884,14,Brinco
 884,7,Brinco
+884,6,Anspringen
+884,12,虫扑
 885,1,くさわけ
 885,3,개척하기
 885,4,起草
@@ -9620,87 +9732,107 @@ move_id,local_language_id,name
 885,11,くさわけ
 885,14,Abrecaminos
 885,7,Abrecaminos
+885,6,Wegbereiter
+885,12,起草
 886,1,ひやみず
 886,3,찬물끼얹기
-886,4,泼冷水
+886,4,潑冷水
 886,5,Douche Froide
 886,8,Doccia Fredda
 886,9,Chilling Water
 886,11,ひやみず
 886,14,Agua Fría
 886,7,Agua Fría
+886,6,Kalte Dusche
+886,12,泼冷水
 887,1,ハイパードリル
 887,3,하이퍼드릴
-887,4,强力钻
+887,4,強力鑽
 887,5,Hyperceuse
 887,8,Ipertrapano
 887,9,Hyper Drill
 887,11,ハイパードリル
 887,14,Hipertaladro
 887,7,Hipertaladro
+887,6,Hyperbohrer
+887,12,强力钻
 888,1,ツインビーム
 888,3,트윈빔
-888,4,双光束
+888,4,雙光束
 888,5,Double Laser
 888,8,Doppioraggio
 888,9,Twin Beam
 888,11,ツインビーム
 888,14,Láser Doble
 888,7,Láser Doble
+888,6,Doppelstrahl
+888,12,双光束
 889,1,ふんどのこぶし
 889,3,분노의주먹
-889,4,愤怒之拳
+889,4,憤怒之拳
 889,5,Poing de Colère
 889,8,Pugno Furibondo
 889,9,Rage Fist
 889,11,ふんどのこぶし
 889,14,Puño Furia
 889,7,Puño Furia
+889,6,Zornesfaust
+889,12,愤怒之拳
 890,1,アーマーキャノン
 890,3,아머캐논
-890,4,铠农炮
+890,4,鎧農炮
 890,5,Canon Blindé
 890,8,Corazza Cannone
 890,9,Armor Cannon
 890,11,アーマーキャノン
 890,14,Cañón Armadura
 890,7,Cañón Armadura
+890,6,Rüstungskanone
+890,12,铠农炮
 891,1,むねんのつるぎ
 891,3,원념의칼
-891,4,悔念剑
+891,4,悔念劍
 891,5,Lame en Peine
 891,8,Lama del Rimorso
 891,9,Bitter Blade
 891,11,むねんのつるぎ
 891,14,Espada Lamento
 891,7,Espada Lamento
+891,6,Reueschwert
+891,12,悔念剑
 892,1,でんこうそうげき
 892,3,전광쌍격
-892,4,电光双击
+892,4,電光雙擊
 892,5,Double Décharge
 892,8,Doppiolampo
 892,9,Double Shock
 892,11,でんこうそうげき
 892,14,Electropalmas
 892,7,Electropalmas
+892,6,Zweifachladung
+892,12,电光双击
 893,1,デカハンマー
 893,3,거대해머
-893,4,巨力锤
+893,4,巨力錘
 893,5,Marteau Mastoc
 893,8,Granmartello
 893,9,Gigaton Hammer
 893,11,デカハンマー
 893,14,Martillo Colosal
 893,7,Martillo Colosal
+893,6,Riesenhammer
+893,12,巨力锤
 894,1,ほうふく
 894,3,앙갚음
-894,4,复仇
+894,4,復仇
 894,5,Vindicte
 894,8,Ritorsione
 894,9,Comeuppance
 894,11,ほうふく
 894,14,Resarcimiento
 894,7,Resarcimiento
+894,6,Vendetta
+894,12,复仇
 895,1,アクアカッター
 895,3,아쿠아커터
 895,4,水波刀
@@ -9710,51 +9842,63 @@ move_id,local_language_id,name
 895,11,アクアカッター
 895,14,Corte Acuático
 895,7,Tajo Acuático
+895,6,Aquaschnitt
+895,12,水波刀
 896,1,バーンアクセル
 896,3,번액셀
-896,4,灼热暴冲
+896,4,灼熱暴衝
 896,5,Crash Brûlant
 896,8,Turboustione
 896,9,Blazing Torque
 896,11,バーンアクセル
 896,14,Pirochoque
 896,7,Pirochoque
+896,6,Hitzeturbo
+896,12,灼热暴冲
 897,1,ダークアクセル
 897,3,다크액셀
-897,4,黑暗暴冲
+897,4,黑暗暴衝
 897,5,Crash Obscur
 897,8,Turbotenebra
 897,9,Wicked Torque
 897,11,ダークアクセル
 897,14,Ominochoque
 897,7,Ominochoque
+897,6,Finsterturbo
+897,12,黑暗暴冲
 898,1,ポイズンアクセル
 898,3,포이즌액셀
-898,4,剧毒暴冲
+898,4,劇毒暴衝
 898,5,Crash Toxique
 898,8,Turbotossina
 898,9,Noxious Torque
 898,11,ポイズンアクセル
 898,14,Ponzochoque
 898,7,Ponzochoque
+898,6,Toxiturbo
+898,12,剧毒暴冲
 899,1,ファイトアクセル
 899,3,파이트액셀
-899,4,格斗暴冲
+899,4,格鬥暴衝
 899,5,Crash Musclé
 899,8,Turborissa
 899,9,Combat Torque
 899,11,ファイトアクセル
 899,14,Pugnachoque
 899,7,Pugnachoque
+899,6,Raufturbo
+899,12,格斗暴冲
 900,1,マジカルアクセル
 900,3,매지컬액셀
-900,4,魔法暴冲
+900,4,魔法暴衝
 900,5,Crash Magique
 900,8,Turboincanto
 900,9,Magical Torque
 900,11,マジカルアクセル
 900,14,Feerichoque
 900,7,Feerichoque
+900,6,Zauberturbo
+900,12,魔法暴冲
 901,1,ブラッドムーン
 901,3,블러드문
 901,5,Lune Rouge
@@ -9762,6 +9906,10 @@ move_id,local_language_id,name
 901,11,ブラッドムーン
 901,14,Luna Roja
 901,7,Luna Roja
+901,4,血月
+901,6,Blutmond
+901,8,Luna Rossa
+901,12,血月
 902,1,シャカシャカほう
 902,3,휘적휘적포
 902,5,Mortier Matcha
@@ -9769,6 +9917,10 @@ move_id,local_language_id,name
 902,11,シャカシャカほう
 902,14,Cañón Batidor
 902,7,Cañón Batidor
+902,4,刷刷茶炮
+902,6,Quirlschuss
+902,8,Spruzzatè
+902,12,刷刷茶炮
 903,1,みずあめボム
 903,3,시럽봄
 903,5,Bombe au Sirop
@@ -9776,6 +9928,10 @@ move_id,local_language_id,name
 903,11,みずあめボム
 903,14,Bomba Caramelo
 903,7,Bomba Caramelo
+903,4,糖漿炸彈
+903,6,Sirupbombe
+903,8,Bomba Sciroppata
+903,12,糖浆炸弹
 904,1,ツタこんぼう
 904,3,덩굴방망이
 904,5,Massue Liane
@@ -9783,6 +9939,10 @@ move_id,local_language_id,name
 904,11,ツタこんぼう
 904,14,Garrote Liana
 904,7,Garrote Liana
+904,4,棘藤棒
+904,6,Rankenkeule
+904,8,Clava di Liane
+904,12,棘藤棒
 905,1,エレクトロビーム
 905,3,일렉트로빔
 905,4,電光束

--- a/data/v2/csv/pokemon_species_names.csv
+++ b/data/v2/csv/pokemon_species_names.csv
@@ -12254,26 +12254,26 @@ pokemon_species_id,local_language_id,name,genus
 1022,1,テツノイワオ,パラドックスポケモン
 1022,2,Tetsunoiwao,
 1022,3,무쇠암석,패러독스포켓몬
-1022,4,铁磐岩,
+1022,4,鐵磐岩,
 1022,5,Roc-de-Fer,Paradoxe
 1022,6,Eisenfels,
 1022,7,Ferromole,
 1022,8,Massoferreo,
 1022,9,Iron Boulder,Paradox Pokémon
 1022,11,テツノイワオ,パラドックスポケモン
-1022,12,鐵磐岩,
+1022,12,铁磐岩,
 1022,14,Ferromole,
 1023,1,テツノカシラ,パラドックスポケモン
 1023,2,Tetsunokashira,
 1023,3,무쇠감투,패러독스포켓몬
-1023,4,铁头壳,
+1023,4,鐵頭殼,
 1023,5,Chef-de-Fer,Paradoxe
 1023,6,Eisenhaupt,
 1023,7,Ferrotesta,
 1023,8,Capoferreo,
 1023,9,Iron Crown,Paradox Pokémon
 1023,11,テツノカシラ,パラドックスポケモン
-1023,12,鐵頭殼,
+1023,12,铁头壳,
 1023,14,Ferrotesta,
 1024,1,テラパゴス,テラスタルポケモン
 1024,2,Terapagos,


### PR DESCRIPTION
# Change description

Hi! Pokémon Showdown is in the process of adding support for other languages. We were originally going to use PokéAPI to source species/move/ability/item names, but PokéAPI seems to be missing a few, so we're sourcing them from https://github.com/abcboy101/poke-corpus instead.

I figured I'd contribute the translations we sourced from poke-corpus back to PokéAPI, so everyone can be up-to-date.

In addition to the missing ones, you also seem to be using a mixture of Simplified and Traditional Chinese in your Traditional Chinese translation, which I also corrected for you.

## AI coding assistance disclosure

Nope, no code at all.

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
