### PR TITLE
feat: Add missing sprites gen-iii animated, gen-v icons

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -1396,6 +1396,12 @@ def _build_pokemons():
                             info,
                             "png",
                         ),
+                        "animated": {
+                            "front_default": try_image_names(poke_sprites + gen_ii + "crystal/animated/", info, "gif"),
+                            "front_shiny": try_image_names(
+                                poke_sprites + gen_ii + "crystal/animated/shiny/", info, "gif"
+                            ),
+                        },
                     },
                     "gold": {
                         "front_default": try_image_names(poke_sprites + gen_ii + "gold/", info, "png"),
@@ -1628,7 +1634,13 @@ def _build_pokemons():
                                 "gif",
                             ),
                         },
-                    }
+                    },
+                    "icons": {
+                        "front_default": try_image_names(poke_sprites + gen_v + "icons/", info, "png"),
+                        "animated": {
+                            "front_default": try_image_names(poke_sprites + gen_v + "icons/animated/", info, "png"),
+                        },
+                    },
                 },
                 "generation-vi": {
                     "omegaruby-alphasapphire": {


### PR DESCRIPTION
# Change description

Add sprite fields for gen-iii crystal animated which is present in sprites repo but missing from build, similarly gen-v icons is present in sprites repo but missing from build added that too

<img width="1511" height="416" alt="image" src="https://github.com/user-attachments/assets/9f1abe12-ad92-4e8d-a805-772c9461a3f4" />
<img width="1628" height="708" alt="image" src="https://github.com/user-attachments/assets/0cce1865-f792-4fb8-bb54-e4c3e258c76c" />

related issue: https://github.com/PokeAPI/sprites/issues/251

## AI coding assistance disclosure

None

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
