### PR TITLE
feat: Add Generation VII form-specific Pokédex flavor text

### DIFF
--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -12,6 +12,18 @@ are always fighting each other over territory."
 550,30,9,"When a school of Basculin appears in a lake,
 everything else disappears, except for Corphish
 and Crawdaunt. That’s how violent Basculin are."
+741,27,9,"It beats its wings together to create fire.
+As it moves in the steps of its beautiful dance,
+it bathes opponents in intense flames."
+741,28,9,"This Oricorio has sipped red nectar. Its
+passionate dance moves cause its enemies
+to combust in both body and mind."
+741,29,9,"It wins the hearts of its enemies with its
+passionate dancing and then uses the opening
+it creates to burn them up with blazing flames."
+741,30,9,"This Oricorio has drunk red nectar. If its Trainer
+gives the wrong order, this passionate Pokémon
+becomes fiercely angry."
 10031,10,9,"This DEOXYS has transformed into its
 aggressive guise. It can fool enemies by
 altering its appearance."
@@ -694,3 +706,40 @@ kind."
 departed mother into flames, and tonight it will
 once again dance in mourning of others of its
 kind."
+10225,27,9,"This Oricorio has sipped bright yellow nectar.
+Its bright, cheerful dance melts the hearts of
+its enemies."
+10225,28,9,"It creates an electric charge by rubbing its
+feathers together. It dances over to its enemies
+and delivers shocking electrical punches."
+10225,29,9,"It lifts its opponents’ spirits with its
+cheerful dance moves. When they let their guard
+down, it electrocutes them with a jolt."
+10225,30,9,"This Oricorio has drunk bright yellow nectar.
+When it sees someone looking glum, it will try
+to cheer them up with a dance."
+10226,27,9,"This Oricorio relaxes by swaying gently. This
+increases its psychic energy, which it then
+fires at its enemies."
+10226,28,9,"This Oricorio has sipped pink nectar. Its
+enemies’ hearts melt at the sight of its gently
+swaying hips."
+10226,29,9,"It relaxes its opponents with its elegant
+dancing. When they let their guard down, it
+showers them with psychic energy."
+10226,30,9,"This Oricorio has sipped pink nectar. It gets so
+caught up in its dancing that it sometimes
+doesn’t hear its Trainer’s orders."
+10227,27,9,"This Oricorio has sipped purple nectar. Its
+elegant, attractive dance will send the minds
+and hearts of its enemies to another world."
+10227,28,9,"It summons the dead with its dreamy dancing.
+From their malice, it draws power with which to
+curse its enemies."
+10227,29,9,"It charms its opponents with its refined
+dancing. When they let their guard down, it
+places a curse on them that will bring on their
+demise."
+10227,30,9,"This Oricorio has sipped purple nectar. Some
+dancers use its graceful, elegant dancing as
+inspiration."

--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -17,3 +17,337 @@ cellular structure."
 extraterrestrial virus exposed to a laser
 beam. Its body is configured for superior
 agility and speed."
+10193,27,9,"With its incisors, it gnaws through doors and
+infiltrates people’s homes. Then, with a twitch
+of its whiskers, it steals whatever food it
+finds."
+10193,28,9,"When the sun goes down, it becomes active. It
+runs around town on a chase for good food for
+the boss of its nest—Raticate."
+10193,29,9,"It shows no interest in anything that isn’t
+fresh. If you take it shopping with you, it will
+help you pick out ingredients."
+10193,30,9,"Night after night, they sneak into people’s
+homes seeking food. A massive outbreak of them
+has become an issue of public concern."
+10193,31,9,"Its whiskers provide it with a keen sense of
+smell, enabling it to pick up the scent of
+hidden food and locate it instantly."
+10193,32,9,"Its whiskers provide it with a keen sense of
+smell, enabling it to pick up the scent of
+hidden food and locate it instantly."
+10194,27,9,"It forms a group of Rattata, which it assumes
+command of. Each group has its own territory,
+and disputes over food happen often."
+10194,28,9,"This gourmet Pokémon is particular about the
+taste and freshness of its food. Restaurants
+where Raticate live have a good reputation."
+10194,29,9,"It has an incredibly greedy personality. Its
+nest is filled with so much food gathered by
+Rattata at its direction, it can’t possibly eat
+it all."
+10194,30,9,"It commands a nest of Rattata. Different nests
+don’t get along, whipping up severe fights over
+feeding grounds."
+10194,31,9,"It makes its Rattata underlings gather food for
+it, dining solely on the most nutritious and
+delicious fare."
+10194,32,9,"It makes its Rattata underlings gather food for
+it, dining solely on the most nutritious and
+delicious fare."
+10202,27,9,"It only evolves to this form in the Alola
+region. According to researchers, its diet is
+one of the causes of this change."
+10202,28,9,"It uses psychokinesis to control electricity. It
+hops aboard its own tail, using psychic power to
+lift the tail and move about while riding it."
+10202,29,9,"It focuses psychic energy into its tail and
+rides it like it’s surfing. Another name for
+this Pokémon is “hodad.”"
+10202,30,9,"When you rub its cheeks, a sweet fragrance comes
+wafting out. However, you’ll also get a light
+shock!"
+10202,31,9,"It loves pancakes prepared with a secret Alolan
+recipe. Some wonder whether that recipe holds
+the key to this Pokémon’s evolution."
+10202,32,9,"It loves pancakes prepared with a secret Alolan
+recipe. Some wonder whether that recipe holds
+the key to this Pokémon’s evolution."
+10203,27,9,"It lives on snowy mountains. Its steel shell is
+very hard—so much so, it can’t roll its body up
+into a ball."
+10203,28,9,"An ancient tradition of Alolan festivals, still
+carried on to this day, is a competition to
+slide Sandshrew across ice as far as one can."
+10203,29,9,"After fleeing a volcanic eruption, it ended up
+moving to an area of snowy mountains. Its ice
+shell is as hard as steel."
+10203,30,9,"The skin on its back is as hard as steel.
+Predators go after its soft belly, so it clings
+to the ground desperately."
+10203,31,9,"Its ice-covered body lets it slide across the
+ground with bullet-like speed, sending its
+enemies flying when it hits them."
+10203,32,9,"Its ice-covered body lets it slide across the
+ground with bullet-like speed, sending its
+enemies flying when it hits them."
+10204,27,9,"Fleeing a volcanic eruption, it settled on a
+snowy mountain. As it races through the
+snowfields, it sends up a spray of snow."
+10204,28,9,"This Pokémon’s steel spikes are sheathed in ice.
+Stabs from these spikes cause deep wounds and
+severe frostbite as well."
+10204,29,9,"It runs across snow-covered plains at high
+speeds. It developed thick, sharp claws to plow
+through the snow."
+10204,30,9,"A long, long time ago, it lived in the desert.
+With its sharp claws fully extended, it can
+climb right up an iceberg without slipping."
+10204,31,9,"This is Sandslash’s form after adaptation to a
+frigid environment. The cold air emitted by its
+body sharpens its icy spikes."
+10204,32,9,"This is Sandslash’s form after adaptation to a
+frigid environment. The cold air emitted by its
+body sharpens its icy spikes."
+10205,27,9,"It exhales air colder than -58 degrees
+Fahrenheit. Elderly people in Alola call this
+Pokémon by an older name—Keokeo."
+10205,28,9,"In hot weather, this Pokémon makes ice shards
+with its six tails and sprays them around to
+cool itself off."
+10205,29,9,"If you carelessly approach it because it’s cute,
+the boss of the pack, Ninetales, will appear and
+freeze you."
+10205,30,9,"They live together in a skulk, helping one
+another. Before eating their prey, they freeze
+it solid with their -58 degree Fahrenheit
+breath."
+10205,31,9,"It looks like snow come to life, and the breath
+it exhales is -58 degrees Fahrenheit. Another
+name for it is Keokeo."
+10205,32,9,"It looks like snow come to life, and the breath
+it exhales is -58 degrees Fahrenheit. Another
+name for it is Keokeo."
+10206,27,9,"It creates drops of ice in its coat and showers
+them over its enemies. Anyone who angers it will
+be frozen stiff in an instant."
+10206,28,9,"Possessing a calm demeanor, this Pokémon was
+revered as a deity incarnate before it was
+identified as a regional variant of Ninetales."
+10206,29,9,"The reason it guides people all the way down to
+the mountain’s base is that it wants them to
+hurry up and leave."
+10206,30,9,"Some said that deities visited mountains where
+Ninetales live, so in times long past, no one
+was allowed to go into those mountains."
+10206,31,9,"It lives on mountains perpetually covered in
+snow and is revered as a deity incarnate. It
+appears draped in a blizzard."
+10206,32,9,"It lives on mountains perpetually covered in
+snow and is revered as a deity incarnate. It
+appears draped in a blizzard."
+10207,27,9,"Its head sports an altered form of whiskers made
+of metal. When in communication with its
+comrades, its whiskers wobble to and fro."
+10207,28,9,"Its golden hairs function as sensors. It pokes
+them out of its burrow to monitor its
+surroundings."
+10207,29,9,"Although it’s powerful enough to dig right
+through volcanic rock, it doesn’t allow itself
+to be seen very often."
+10207,30,9,"The need to dig through volcanic rock in the
+ground has made them more powerful than the
+Diglett of other regions."
+10207,31,9,"After living in soil with high iron content for
+some time, three steel whiskers sprouted from
+the top of its head."
+10207,32,9,"After living in soil with high iron content for
+some time, three steel whiskers sprouted from
+the top of its head."
+10208,27,9,"Its shining gold hair provides it with
+protection. It’s reputed that keeping any of its
+fallen hairs will bring bad luck."
+10208,28,9,"These Pokémon are cherished in the Alola region,
+where they are thought to be feminine deities of
+the land incarnate."
+10208,29,9,"Its metallic whiskers are heavy, so it’s not
+very fast, but it has the power to dig through
+bedrock."
+10208,30,9,"Its shining gold whiskers are advanced sensors
+that can detect vibrations from sounds several
+miles away."
+10208,31,9,"They’re referred to as triplets, but they’re not
+identical—the metallic elements in their bodies
+differ slightly. The proof shows in their
+whiskers!"
+10208,32,9,"They’re referred to as triplets, but they’re not
+identical—the metallic elements in their bodies
+differ slightly. The proof shows in their
+whiskers!"
+10209,27,9,"This Pokémon was not originally found in Alola.
+Human actions caused a surge in their numbers,
+and they went feral. They’re prideful and
+crafty."
+10209,28,9,"When its delicate pride is wounded, or when the
+gold coin on its forehead is dirtied, it flies
+into a hysterical rage."
+10209,29,9,"It’s impulsive, selfish, and fickle. It’s very
+popular with some Trainers who like giving it
+the attention it needs."
+10209,30,9,"A royal house that flourished in the distant
+past brought it here from another region. Meowth
+is both selfish and prideful."
+10209,31,9,"Highly intelligent and prideful, it’s famously
+difficult to handle—but that’s also a reason for
+its popularity."
+10209,32,9,"Highly intelligent and prideful, it’s famously
+difficult to handle—but that’s also a reason for
+its popularity."
+10210,27,9,"Its round face and smooth coat—softer than the
+most high-class velvet—have made this a very
+popular Pokémon in Alola."
+10210,28,9,"It looks down on everyone other than itself. Its
+preferred tactics are sucker punches and
+blindside attacks."
+10210,29,9,"In contrast to its lovely face, it’s so brutal
+that it tortures its weakened prey rather than
+finishing them off."
+10210,30,9,"Its round face is a symbol of wealth. Persian
+that have bigger, plumper faces are considered
+more beautiful."
+10210,31,9,"It has the classiest coat. The rippling of its
+fur in the heat of battle has a beauty all its
+own."
+10210,32,9,"It has the classiest coat. The rippling of its
+fur in the heat of battle has a beauty all its
+own."
+10211,27,9,"Its body is a magnetic stone. Iron sand attaches
+firmly to the portions of its body that are
+particularly magnetic."
+10211,28,9,"If you accidentally step on a Geodude sleeping
+on the ground, you’ll hear a crunching sound and
+feel a shock ripple through your entire body."
+10211,29,9,"If you mistake it for a rock and step on it, it
+will headbutt you in anger. In addition to the
+pain, it will also zap you with a shock."
+10211,30,9,"Geodude compete against each other with
+headbutts. The iron sand on their heads will
+stick to whichever one has stronger magnetism."
+10211,31,9,"Its stone head is imbued with electricity and
+magnetism. If you carelessly step on one, you’ll
+be in for a painful shock."
+10211,32,9,"Its stone head is imbued with electricity and
+magnetism. If you carelessly step on one, you’ll
+be in for a painful shock."
+10212,27,9,"Its preferred food is dravite. After it has
+eaten this mineral, crystals form inside the
+Pokémon, rising to the surface of part of its
+body."
+10212,28,9,"They eat rocks and often get into a scrap over
+them. The shock of Graveler smashing together
+causes a flash of light and a booming noise."
+10212,29,9,"When two Graveler fight each other, it fills the
+surroundings with flashes of light and sound.
+People call it the “fireworks of the earth.”"
+10212,30,9,"Graveler’s entire body is tinged with
+electricity due to the stones it likes to eat.
+It’s very quick-tempered."
+10212,31,9,"When it comes rolling down a mountain path,
+anything in its way gets zapped by electricity
+and sent flying."
+10212,32,9,"When it comes rolling down a mountain path,
+anything in its way gets zapped by electricity
+and sent flying."
+10213,27,9,"It fires rocks charged with electricity. Even if
+the rock isn’t fired that accurately, just
+grazing an opponent will cause numbness and
+fainting."
+10213,28,9,"Because it can’t fire boulders at a rapid pace,
+it’s been known to seize nearby Geodude and fire
+them from its back."
+10213,29,9,"It’s grumpy and stubborn. If you upset it, it
+discharges electricity from the surface of its
+body and growls with a voice like thunder."
+10213,30,9,"It shoots large rocks that are charged with
+electricity. Tremendous electric shocks are
+flung out across the whole area of impact."
+10213,31,9,"It uses magnetism to accelerate and fire off
+rocks tinged with electricity. Even if it
+doesn’t score a direct hit, the jolt of
+electricity will do the job."
+10213,32,9,"It uses magnetism to accelerate and fire off
+rocks tinged with electricity. Even if it
+doesn’t score a direct hit, the jolt of
+electricity will do the job."
+10214,27,9,"A Grimer, which had been brought in to solve a
+problem with garbage, developed over time into
+this form."
+10214,28,9,"The crystals on Grimer’s body are lumps of
+toxins. If one falls off, lethal poisons leak
+out."
+10214,29,9,"There are a hundred or so of them living in
+Alola’s waste-disposal site. They’re all hard
+workers who eat a lot of trash."
+10214,30,9,"Brought to Alola to solve the garbage problem,
+Grimer seems to relish any and all kinds of
+trash."
+10214,31,9,"It has a passion for trash above all else,
+speedily digesting it and creating brilliant
+crystals of sparkling poison."
+10214,32,9,"It has a passion for trash above all else,
+speedily digesting it and creating brilliant
+crystals of sparkling poison."
+10215,27,9,"The garbage it eats causes continuous chemical
+changes in its body, which produce its
+exceedingly vivid coloration."
+10215,28,9,"While it’s unexpectedly quiet and friendly, if
+it’s not fed any trash for a while, it will
+smash its Trainer’s furnishings and eat up the
+fragments."
+10215,29,9,"There are over a hundred kinds of poison inside
+its body. Chemical reactions between different
+poisons are the source of its vitality."
+10215,30,9,"What look like fangs and claws are actually
+crystallized poison that will afflict you at a
+mere touch, so don’t get too close."
+10215,31,9,"Muk’s coloration becomes increasingly vivid the
+more it feasts on its favorite dish—trash."
+10215,32,9,"Muk’s coloration becomes increasingly vivid the
+more it feasts on its favorite dish—trash."
+10216,27,9,"Alola is the best environment for this Pokémon.
+Local people take pride in its appearance,
+saying this is how Exeggutor ought to look."
+10216,28,9,"As it grew taller and taller, it outgrew its
+reliance on psychic powers, while within it
+awakened the power of the sleeping dragon."
+10216,29,9,"Exeggutor is the pride of the Alolan people. Its
+image is carved into historical buildings and
+murals."
+10216,30,9,"It swings its long neck like a whip and smacks
+its opponents. This makes Exeggutor itself
+dizzy, too."
+10216,31,9,"The strong sunlight of the Alola region has
+awakened the power hidden within Exeggcute. This
+is the result."
+10216,32,9,"The strong sunlight of the Alola region has
+awakened the power hidden within Exeggcute. This
+is the result."
+10217,27,9,"The bones it possesses were once its mother’s.
+Its mother’s regrets have become like a vengeful
+spirit protecting this Pokémon."
+10217,28,9,"Its custom is to mourn its lost companions.
+Mounds of dirt by the side of the road mark the
+graves of the Marowak."
+10217,29,9,"The rich greenery of the Alola region is hard on
+Marowak. It controls fire to stay alive."
+10217,30,9,"When it beats opponents with its bone, the
+cursed flames spread to them. No amount of water
+will stop those flames from burning."
+10217,31,9,"It has transformed the spirit of its dear
+departed mother into flames, and tonight it will
+once again dance in mourning of others of its
+kind."
+10217,32,9,"It has transformed the spirit of its dear
+departed mother into flames, and tonight it will
+once again dance in mourning of others of its
+kind."

--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -17,6 +17,338 @@ cellular structure."
 extraterrestrial virus exposed to a laser
 beam. Its body is configured for superior
 agility and speed."
+10133,31,9,"In order to support its flower, which has grown
+larger due to Mega Evolution, its back and legs
+have become stronger."
+10133,32,9,"In order to support its flower, which has grown
+larger due to Mega Evolution, its back and legs
+have become stronger."
+10134,31,9,"The overwhelming power that fills its entire
+body causes it to turn black and creates intense
+blue flames."
+10134,32,9,"The overwhelming power that fills its entire
+body causes it to turn black and creates intense
+blue flames."
+10135,31,9,"Its bond with its Trainer is the source of its
+power. It boasts speed and maneuverability
+greater than that of a jet fighter."
+10135,32,9,"Its bond with its Trainer is the source of its
+power. It boasts speed and maneuverability
+greater than that of a jet fighter."
+10136,31,9,"The cannon on its back is as powerful as a tank
+gun. Its tough legs and back enable it to
+withstand the recoil from firing the cannon."
+10136,32,9,"The cannon on its back is as powerful as a tank
+gun. Its tough legs and back enable it to
+withstand the recoil from firing the cannon."
+10137,27,9,"As a result of Mega Evolution, its power has
+been entirely converted into psychic energy, and
+it has lost all strength in its muscles."
+10137,28,9,"Its hidden psychic power has been unleashed. A
+glance at someone gives it knowledge of the
+course of that person’s life, from birth to
+death."
+10137,29,9,"It sends out psychic power from the red organ on
+its forehead to foresee its opponents’ every
+move."
+10137,30,9,"Having traded away its muscles, Alakazam’s true
+power has been unleashed. With its psychic
+powers, it can foresee all things."
+10137,31,9,"It’s adept at precognition. When attacks
+completely miss Alakazam, that’s because it’s
+seeing the future."
+10137,32,9,"It’s adept at precognition. When attacks
+completely miss Alakazam, that’s because it’s
+seeing the future."
+10138,27,9,"Gengar’s relationships are warped. It has no
+interest in opponents unless it perceives them
+as prey."
+10138,28,9,"The energy of Mega Evolution awakened it. It
+sinks into another dimension, where it keeps a
+patient watch for its chance to attack."
+10138,29,9,"It tries to take the lives of anyone and
+everyone. It will even try to curse the Trainer
+who is its master!"
+10138,30,9,"Mega Evolution has made it possible for Gengar
+to access other dimensions. Its entire body is
+brimming with strange power."
+10138,31,9,"It can pass through other dimensions and appear
+anywhere. It caused a stir one time when it
+stuck just one leg out of a wall."
+10138,32,9,"It can pass through other dimensions and appear
+anywhere. It caused a stir one time when it
+stuck just one leg out of a wall."
+10139,27,9,"Mega Kangaskhan’s strength derives from the
+mother’s happiness about her child’s growth.
+Watching it grow up keeps her spirits high."
+10139,28,9,"Thanks to Mega Evolution, its child grows. But
+as the child is good only at fighting and
+nothing else, its mother feels uneasy about its
+future."
+10139,29,9,"The explosive energy the child is bathed in
+causes temporary growth. The mother is beside
+herself with worry about it."
+10139,30,9,"When the mother sees the back of her
+Mega-Evolved child, it makes her think of the
+day when her child will inevitably leave her."
+10139,31,9,"Its child has grown rapidly, thanks to the
+energy of Mega Evolution. Mother and child show
+off their harmonious teamwork in battle."
+10139,32,9,"Its child has grown rapidly, thanks to the
+energy of Mega Evolution. Mother and child show
+off their harmonious teamwork in battle."
+10140,27,9,"The influence of Mega Evolution leaves it in a
+state of constant excitement. It pierces enemies
+with its two large horns before shredding them."
+10140,28,9,"Bathed in the energy of Mega Evolution, its
+wings become unusually developed. It flies at
+speeds of approximately 30 mph."
+10140,29,9,"After Mega Evolution, it becomes able to fly.
+Perhaps because it’s so happy, it rarely touches
+the ground."
+10140,30,9,"It zips around at blistering speeds, looking for
+an opening to skewer its opponent on its giant
+pincers."
+10140,31,9,"With its vaunted horns, it can lift an opponent
+10 times heavier than itself and fly about with
+ease."
+10140,32,9,"With its vaunted horns, it can lift an opponent
+10 times heavier than itself and fly about with
+ease."
+10141,27,9,"Mega Evolution also affects its brain, leaving
+no other function except its destructive
+instinct to burn everything to cinders."
+10141,28,9,"It jets water from the orifices on its sides,
+streaking above the water surface at supersonic
+speed."
+10141,29,9,"Mega Evolution places a burden on its body. The
+stress causes it to become all the more
+ferocious."
+10141,30,9,"It zooms out of the water at Mach speeds. Even
+large ships caught in its path are split cleanly
+in two!"
+10141,31,9,"Although it obeys its instinctive drive to
+destroy everything within its reach, it will
+respond to orders from a Trainer it truly
+trusts."
+10141,32,9,"Although it obeys its instinctive drive to
+destroy everything within its reach, it will
+respond to orders from a Trainer it truly
+trusts."
+10142,27,9,"Part of its body has become stone. Some scholars
+claim that this is Aerodactyl’s true appearance."
+10142,28,9,"When it Mega Evolves, it becomes more vicious
+than ever before. Some say that’s because its
+excess of power is causing it pain."
+10142,29,9,"It will attack anything that moves. Mega
+Evolution is a burden on its body, so it’s
+incredibly irritated."
+10142,30,9,"Mega Evolution awakened some dormant genes,
+bringing back the sharp rocks that once covered
+Aerodactyl’s entire body."
+10142,31,9,"The power of Mega Evolution has completely
+restored its genes. The rocks on its body are
+harder than diamond."
+10142,32,9,"The power of Mega Evolution has completely
+restored its genes. The rocks on its body are
+harder than diamond."
+10143,31,9,"Psychic power has augmented its muscles. It has
+a grip strength of one ton and can sprint a
+hundred meters in two seconds flat!"
+10143,32,9,"Psychic power has augmented its muscles. It has
+a grip strength of one ton and can sprint a
+hundred meters in two seconds flat!"
+10144,31,9,"Despite its diminished size, its mental power
+has grown phenomenally. With a mere thought, it
+can smash a skyscraper to smithereens."
+10144,32,9,"Despite its diminished size, its mental power
+has grown phenomenally. With a mere thought, it
+can smash a skyscraper to smithereens."
+10145,29,9,"Excess energy from Mega Evolution stimulates its
+genes, and the wool it had lost grows in again."
+10145,30,9,"Massive amounts of energy intensely stimulated
+Ampharos’s cells, apparently awakening its
+long-sleeping dragon’s blood."
+10146,27,9,"The excess energy that bathes this Pokémon keeps
+it in constant danger of overflow. It can’t
+sustain a battle over long periods of time."
+10146,28,9,"Due to the effects of Mega Evolution, its
+pincers have taken on a more diabolical form,
+ripping anything they pinch to shreds."
+10146,29,9,"It stores the excess energy from Mega Evolution,
+so after a long time passes, its body starts to
+melt."
+10146,30,9,"It’s better at beating things than grasping
+them. When it battles for a long time, the
+weight of its pincers becomes too much to bear."
+10147,29,9,"It can grip things with its two horns and lift
+500 times its own body weight."
+10147,30,9,"A tremendous influx of energy builds it up, but
+when Mega Evolution ends, Heracross is bothered
+by terrible soreness in its muscles."
+10148,29,9,"Its red claws and the tips of its tail are
+melting from high internal temperatures that are
+painful to Houndoom itself."
+10148,30,9,"Houndoom’s entire body generates heat when it
+Mega Evolves. Its fearsome fiery breath turns
+its opponents to ash."
+10149,29,9,"Due to the colossal power poured into it, this
+Pokémon’s back split right open. Its destructive
+instincts are the only thing keeping it moving."
+10149,30,9,"The effects of Mega Evolution make it more
+ferocious than ever. It’s unclear whether it can
+even hear its Trainer’s orders."
+10152,29,9,"It has an extremely vicious disposition. It
+grips prey in its two sets of jaws and tears
+them apart with raw power."
+10152,30,9,"Its two sets of jaws thrash about violently as
+if they each had a will of their own. One gnash
+from them can turn a boulder to dust."
+10155,29,9,"Mega Evolution fills its body with a tremendous
+amount of electricity, but it’s too much for
+Manectric to fully control."
+10155,30,9,"Too much electricity has built up in its body,
+irritating Manectric. Its explosive speed is
+equal to that of a lightning bolt."
+10156,29,9,"Extraordinary energy amplifies its cursing power
+to such an extent that it can’t help but curse
+its own Trainer."
+10156,30,9,"Mega Evolution increases its vindictiveness, and
+the cursing power that was held back by its
+zipper comes spilling out."
+10157,27,9,"When this Pokémon whips the winglike fur on its
+back as though beating its wings, it sends an
+intimidating aura flying at its opponents."
+10157,28,9,"As the energy of Mega Evolution fills it, its
+fur bristles. What you see on its back are not
+true wings, and this Pokémon isn’t able to fly."
+10157,29,9,"Normally, it dislikes fighting, so it really
+hates changing to this form for battles."
+10157,30,9,"It converts the energy from Mega Evolution into
+an intimidating aura. Fainthearted people expire
+from shock at the sight of it."
+10158,27,9,"Excess energy melted its arms and wings,
+transforming them into giant scythes."
+10158,28,9,"Its vaunted wings become scythes, sending it mad
+with rage. It swings its scythes wildly and
+slices the ground to pieces."
+10158,29,9,"Its arms and wings melted into something like
+scythes. Mad with rage, it rampages on and on."
+10158,30,9,"Its disposition is more vicious than before its
+Mega Evolution. Garchomp carves its opponents up
+with the scythes on both arms."
+10159,27,9,"Black streaks all over its body show where its
+auras and the energy of Mega Evolution
+intermingled and raced through it."
+10159,28,9,"It readies itself to face its enemies by
+focusing its mental energies. Its fighting style
+can be summed up in a single word: heartless."
+10159,29,9,"Its aura has expanded due to Mega Evolution.
+Governed only by its combative instincts, it
+strikes enemies without mercy."
+10159,30,9,"Bathed in explosive energy, its combative
+instincts have awakened. For its enemies, it has
+no mercy whatsoever."
+10168,27,9,"The jewel from its chest, which has grown
+gigantic due to the effects of Mega Evolution,
+can turn back any attack."
+10168,28,9,"Supporting a giant heavy jewel, it can’t change
+direction very nimbly and is vulnerable to
+attack from behind."
+10168,29,9,"Bathed in the energy of Mega Evolution, the
+gemstone on its chest expands, rips through its
+skin, and falls out."
+10168,30,9,"It blocks any and all attacks with its
+giant-sized gemstone. However, the stone’s a
+heavy burden, and it limits Mega Sableye’s
+movements."
+10172,27,9,"The spines sprouting from its head are
+transformed fangs. If they’re injured or broken
+off, the spines will regenerate countless times."
+10172,28,9,"As a consequence of Mega Evolution, its
+combative instincts exploded. The yellow marks
+it bears are scars from a long history of
+battles."
+10172,29,9,"The yellow patterns it bears are old scars. The
+energy from Mega Evolution runs through them,
+causing it sharp pain and suffering."
+10172,30,9,"The moment it charges into its opponent, sharp
+spikes pop out of Sharpedo’s head, leaving its
+opponent with deep wounds."
+10173,27,9,"All the energy from Mega Evolution poured into
+the Shellder on its tail, leaving Slowpoke to be
+swallowed whole."
+10173,28,9,"When bathed in the energy of Mega Evolution,
+Shellder converts into impregnable armor. There
+is virtually no change in Slowpoke."
+10173,29,9,"Tremendous energy strengthened the power of the
+Shellder on its tail, but it doesn’t really
+affect Slowpoke."
+10173,30,9,"Having been swallowed whole by Shellder, Slowbro
+now has an iron defense. It’s pretty comfortable
+in there, too."
+10173,31,9,"Under the influence of Shellder’s digestive
+fluids, Slowpoke has awakened, gaining a great
+deal of power—and a little motivation to boot."
+10173,32,9,"Under the influence of Shellder’s digestive
+fluids, Slowpoke has awakened, gaining a great
+deal of power—and a little motivation to boot."
+10175,31,9,"With its muscular strength now greatly
+increased, it can fly continuously for two weeks
+without resting."
+10175,32,9,"With its muscular strength now greatly
+increased, it can fly continuously for two weeks
+without resting."
+10176,27,9,"The excess energy from Mega Evolution spilled
+over from its mouth, breaking its jaw. It spews
+endless blizzards."
+10176,28,9,"It envelops prey in its mouth, freezing them
+instantly. But its jaw is dislocated, so it’s
+unable to eat them."
+10176,29,9,"When it spews stupendously cold air from its
+broken mouth, the entire area around it gets
+whited out."
+10176,30,9,"The power of Mega Evolution was so strong that
+it smashed Glalie’s jaw. Its inability to eat
+very well leaves Glalie irritated."
+10178,27,9,"This form results from one Metagross, one
+Metang, and two Beldum linking up."
+10178,28,9,"Mega Evolution stimulated its brain. It emerged
+as a ruthless Pokémon that will clutch at any
+means of ensuring its victories."
+10178,29,9,"Its intellect surpasses its previous level,
+resulting in battles so cruel, they’ll make you
+want to cover your eyes."
+10178,30,9,"When it knows it can’t win, it digs the claws on
+its legs into its opponent and starts the
+countdown to a big explosion."
+10190,29,9,"It swings its ears like whips and strikes its
+enemies with them. It has an intensely combative
+disposition."
+10190,30,9,"Mega Evolution awakens its combative instincts.
+It has shed any fur that got in the way of its
+attacks."
+10191,27,9,"Anyone standing in its path gets sliced right in
+two, while this Pokémon continues its flight
+without interruption."
+10191,28,9,"Mega Evolution fuels its brutality, and it may
+even turn on the Trainer who raised it. It’s
+been dubbed “the blood-soaked crescent.”"
+10191,29,9,"The stress of its two proud wings becoming
+misshapen and stuck together because of strong
+energy makes it go on a rampage."
+10191,30,9,"It puts its forelegs inside its shell to
+streamline itself for flight. Salamence flies at
+high speeds over all kinds of topographical
+features."
+10192,31,9,"Its legs have become poison stingers. It stabs
+its prey repeatedly with the stingers on its
+limbs, dealing the final blow with the stinger
+on its rear."
+10192,32,9,"Its legs have become poison stingers. It stabs
+its prey repeatedly with the stingers on its
+limbs, dealing the final blow with the stinger
+on its rear."
 10193,27,9,"With its incisors, it gnaws through doors and
 infiltrates people’s homes. Then, with a twitch
 of its whiskers, it steals whatever food it

--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -7,6 +7,11 @@ chest appears to be its brain."
 from space. It is highly intelligent and
 wields psychokinetic powers.This POKéMON shoots lasers from the
 crystalline organ on its chest."
+550,29,9,"Savage, violent Pokémon, red and blue Basculin
+are always fighting each other over territory."
+550,30,9,"When a school of Basculin appears in a lake,
+everything else disappears, except for Corphish
+and Crawdaunt. That’s how violent Basculin are."
 10031,10,9,"This DEOXYS has transformed into its
 aggressive guise. It can fool enemies by
 altering its appearance."
@@ -17,6 +22,12 @@ cellular structure."
 extraterrestrial virus exposed to a laser
 beam. Its body is configured for superior
 agility and speed."
+10066,29,9,"Even Basculin, which devours everything it can
+with its huge jaws, is nothing more than food to
+organisms stronger than itself."
+10066,30,9,"Some people call it “the thug of the lake.”
+Whether the differences in color are meaningful
+is not yet known."
 10133,31,9,"In order to support its flower, which has grown
 larger due to Mega Evolution, its back and legs
 have become stronger."

--- a/data/v2/csv/pokemon_form_flavor_text.csv
+++ b/data/v2/csv/pokemon_form_flavor_text.csv
@@ -743,3 +743,21 @@ demise."
 10227,30,9,"This Oricorio has sipped purple nectar. Some
 dancers use its graceful, elegant dancing as
 inspiration."
+10314,29,9,"This is its form while it is devouring the light
+of Solgaleo. It pounces on foes and then slashes
+them with the claws on its four limbs and back."
+10314,30,9,"This is Necrozma’s form while it’s absorbing the
+power of Solgaleo, making it extremely ferocious
+and impossible to control."
+10315,29,9,"Lunala no longer has a will of its own. Now
+under the control of Necrozma, it continuously
+expels all of its energy."
+10315,30,9,"This is its form while it’s devouring the light
+of Lunala. It grasps foes in its giant claws and
+rips them apart with brute force."
+10316,29,9,"This is its form when it has absorbed
+overwhelming light energy. It fires laser beams
+from all over its body."
+10316,30,9,"The light pouring out from all over its body
+affects living things and nature, impacting them
+in various ways."


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

Adds English form-specific Pokédex flavor text to `pokemon_form_flavor_text.csv` for alternate forms as they appear in the Generation VII games (Sun/Moon, Ultra Sun/Ultra Moon) and Let's Go, Pikachu!/Eevee!.

**244 new entries across 51 forms**, structured per-pokemon so each can be reviewed independently (following up on the per-pokemon approach agreed in #1629):

- **Alolan forms** (18 forms, 108 entries) — regional variants of Kanto species.
- **Mega Evolutions** (32 forms, 110 entries)
- **Oricorio** (4 styles, 16 entries), **Necrozma** (Dusk/Dawn/Ultra, 6 entries), **Basculin** (both stripes, 4 entries).

Default-form flavor text already lives in `pokemon_species_flavor_text.csv`, so it is not repeated in this file. The only default-form entries included are cases where the default is a *named* variant within a form set and it would be odd to list the other members without it: **Oricorio (Baile Style)** and **Basculin (Red-Striped)** — like **Deoxys (Normal Forme)** from https://github.com/PokeAPI/pokeapi/pull/1629.

## AI coding assistance disclosure

Non-default forms have no canonical in-game line breaks in the veekun source nor in other sources, so they are reconstructed with a greedy word wrap. The wrap width was chosen to match the existing dataset's line-length distribution (median ~44, 95th percentile 50, max 54), which is consistent across SM, USUM and LGPE — LGPE uses the same text-box width as Sun/Moon, so a single width applies to all versions. Curly typography (`'` `"` `"`) matches the rest of the dataset.

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
