### PR TITLE
feat: expose form transformations in evolution chains

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -3810,10 +3810,39 @@ components:
           allOf:
           - $ref: '#/components/schemas/EvolutionChainLink'
           readOnly: true
+        transformations:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvolutionChainTransformation'
+          readOnly: true
       required:
       - baby_trigger_item
       - chain
       - id
+      - transformations
+    EvolutionChainFormTransformation:
+      type: object
+      properties:
+        form:
+          $ref: '#/components/schemas/PokemonFormSummary'
+        trigger:
+          type: string
+          readOnly: true
+        item:
+          $ref: '#/components/schemas/ItemSummary'
+        ability:
+          $ref: '#/components/schemas/AbilitySummary'
+        move:
+          $ref: '#/components/schemas/MoveSummary'
+        base_form:
+          $ref: '#/components/schemas/PokemonFormSummary'
+      required:
+      - ability
+      - base_form
+      - form
+      - item
+      - move
+      - trigger
     EvolutionChainLink:
       type: object
       properties:
@@ -3844,6 +3873,18 @@ components:
           readOnly: true
       required:
       - url
+    EvolutionChainTransformation:
+      type: object
+      properties:
+        species:
+          $ref: '#/components/schemas/PokemonSpeciesSummary'
+        forms:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvolutionChainFormTransformation'
+      required:
+      - forms
+      - species
     EvolutionTriggerDetail:
       type: object
       properties:

--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -76,8 +76,10 @@ __all__: tuple[str, ...] = (
     "EncounterPokemonDetailSerializer",
     "EncounterSlotSerializer",
     "EvolutionChainDetailSerializer",
+    "EvolutionChainFormTransformationSerializer",
     "EvolutionChainLinkSerializer",
     "EvolutionChainSummarySerializer",
+    "EvolutionChainTransformationSerializer",
     "EvolutionTriggerDetailSerializer",
     "EvolutionTriggerNameSerializer",
     "EvolutionTriggerSummarySerializer",
@@ -3372,6 +3374,24 @@ class PokemonEvolutionSerializer(serializers.ModelSerializer[PokemonEvolution]):
         )
 
 
+class EvolutionChainFormTransformationSerializer(serializers.ModelSerializer[PokemonFormCondition]):
+    form = PokemonFormSummarySerializer(source="pokemon_form")
+    trigger = serializers.CharField(source="form_trigger.name", read_only=True)
+    item = ItemSummarySerializer()
+    ability = AbilitySummarySerializer()
+    move = MoveSummarySerializer()
+    base_form = PokemonFormSummarySerializer()
+
+    class Meta:
+        model = PokemonFormCondition
+        fields = ("form", "trigger", "item", "ability", "move", "base_form")
+
+
+class EvolutionChainTransformationSerializer(serializers.Serializer[Any]):
+    species = PokemonSpeciesSummarySerializer()
+    forms = EvolutionChainFormTransformationSerializer(many=True)
+
+
 class EvolutionChainLinkSerializer(serializers.Serializer[Any]):
     is_baby = serializers.BooleanField()
     species = PokemonSpeciesSummarySerializer()
@@ -3382,6 +3402,7 @@ class EvolutionChainLinkSerializer(serializers.Serializer[Any]):
 class EvolutionChainDetailSerializer(serializers.ModelSerializer[EvolutionChain]):
     baby_trigger_item = ItemSummarySerializer()
     chain = serializers.SerializerMethodField("build_chain")
+    transformations = serializers.SerializerMethodField("build_transformations")
 
     POKEMON_EVOLUTION_FK_FIELDS: ClassVar[list[str]] = [
         field.name
@@ -3391,7 +3412,7 @@ class EvolutionChainDetailSerializer(serializers.ModelSerializer[EvolutionChain]
 
     class Meta:
         model = EvolutionChain
-        fields = ("id", "baby_trigger_item", "chain")
+        fields = ("id", "baby_trigger_item", "chain", "transformations")
 
     @extend_schema_field(EvolutionChainLinkSerializer)
     def build_chain(self, obj: EvolutionChain) -> dict[str, Any]:
@@ -3463,6 +3484,41 @@ class EvolutionChainDetailSerializer(serializers.ModelSerializer[EvolutionChain]
             "evolution_details": evolution_data or [],
             "evolves_to": [self.build_chain_link_entry(c, summary_data) for c in chain_link["children"]],
         }
+
+    # collects the reversible form changes of every species in the chain (mega evolution,
+    # primal reversion, gigantamax, in-battle transformations), grouped by species
+    @extend_schema_field(EvolutionChainTransformationSerializer(many=True))
+    def build_transformations(self, obj: EvolutionChain) -> list[dict[str, Any]]:
+        conditions = (
+            PokemonFormCondition.objects.filter(pokemon_form__pokemon__pokemon_species__evolution_chain=obj)
+            .select_related(
+                "form_trigger",
+                "item",
+                "ability",
+                "move",
+                "base_form",
+                "pokemon_form__pokemon__pokemon_species",
+            )
+            .order_by(
+                "pokemon_form__pokemon__pokemon_species__order",
+                "pokemon_form__pokemon__pokemon_species__pk",
+                "pokemon_form__order",
+                "pk",
+            )
+        )
+
+        return [
+            {
+                "species": PokemonSpeciesSummarySerializer(species, context=self.context).data,
+                "forms": EvolutionChainFormTransformationSerializer(
+                    list(species_conditions), many=True, context=self.context
+                ).data,
+            }
+            for species, species_conditions in itertools.groupby(
+                conditions,
+                key=lambda condition: condition.pokemon_form.pokemon.pokemon_species,
+            )
+        ]
 
 
 ############################

--- a/pokemon_v2/tests.py
+++ b/pokemon_v2/tests.py
@@ -4837,6 +4837,7 @@ class APITests(APIData, APITestCase):
 
         # base params
         self.assertEqual(response.data["id"], evolution_chain.pk)
+        self.assertEqual(response.data["transformations"], [])
         # baby trigger params
         self.assertEqual(response.data["baby_trigger_item"]["name"], baby_trigger_item.name)
         self.assertEqual(
@@ -4920,6 +4921,73 @@ class APITests(APIData, APITestCase):
             stage_two_second_data["evolution_details"][0]["party_type"]["url"],
             "{}{}/type/{}/".format(TEST_HOST, API_V2, stage_two_second_party_type.pk),
         )
+
+    # verifies that the reversible form changes of the chain's species are exposed
+    def test_evolution_chain_api_transformations(self):
+        evolution_chain = self.setup_evolution_chain_data()
+
+        basic = self.setup_pokemon_species_data(name="bsc for evo chn trnsfrm", evolution_chain=evolution_chain)
+        evolved = self.setup_pokemon_species_data(
+            name="evlvd for evo chn trnsfrm",
+            evolves_from_species=basic,
+            evolution_chain=evolution_chain,
+            order=2,
+        )
+        self.setup_pokemon_evolution_data(evolved_species=evolved, min_level=16)
+
+        evolved_pokemon = self.setup_pokemon_data(pokemon_species=evolved, name="pkmn for evo chn trnsfrm")
+        default_form = self.setup_pokemon_form_data(
+            pokemon=evolved_pokemon, name="dflt frm for evo chn trnsfrm", order=1, form_order=1
+        )
+        mega_form = self.setup_pokemon_form_data(
+            pokemon=evolved_pokemon,
+            name="mg frm for evo chn trnsfrm",
+            order=2,
+            form_order=2,
+            is_mega=True,
+        )
+        mega_stone = self.setup_item_data(name="itm for evo chn trnsfrm")
+        form_trigger = self.setup_pokemon_form_trigger_data(name="frm trgr for evo chn trnsfrm")
+        self.setup_pokemon_form_condition_data(
+            pokemon_form=mega_form,
+            form_trigger=form_trigger,
+            item=mega_stone,
+            base_form=default_form,
+        )
+
+        response = self.client.get("{}/evolution-chain/{}/".format(API_V2, evolution_chain.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # the chain itself is untouched by the transformations
+        self.assertEqual(response.data["chain"]["species"]["name"], basic.name)
+        self.assertEqual(response.data["chain"]["evolves_to"][0]["species"]["name"], evolved.name)
+        self.assertEqual(response.data["chain"]["evolves_to"][0]["evolves_to"], [])
+
+        transformations = response.data["transformations"]
+        self.assertEqual(len(transformations), 1)
+        self.assertEqual(transformations[0]["species"]["name"], evolved.name)
+        self.assertEqual(
+            transformations[0]["species"]["url"],
+            "{}{}/pokemon-species/{}/".format(TEST_HOST, API_V2, evolved.pk),
+        )
+
+        forms = transformations[0]["forms"]
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(forms[0]["form"]["name"], mega_form.name)
+        self.assertEqual(
+            forms[0]["form"]["url"],
+            "{}{}/pokemon-form/{}/".format(TEST_HOST, API_V2, mega_form.pk),
+        )
+        self.assertEqual(forms[0]["trigger"], form_trigger.name)
+        self.assertEqual(forms[0]["item"]["name"], mega_stone.name)
+        self.assertEqual(
+            forms[0]["item"]["url"],
+            "{}{}/item/{}/".format(TEST_HOST, API_V2, mega_stone.pk),
+        )
+        self.assertEqual(forms[0]["base_form"]["name"], default_form.name)
+        self.assertIsNone(forms[0]["ability"])
+        self.assertIsNone(forms[0]["move"])
 
     # verifies that the wurmple evolution chain is serialized correctly
     def test_evolution_chain_api_wurmple_bugfix(self):


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Consider adding the `no-deploy` label if this PR shouldn't be deployed and does not alter the data served by the API.
-->

## Change description

`/api/v2/evolution-chain/{id}/` only describes species-level evolution. The reversible form changes of those same species (mega evolution, primal reversion, gigantamax, in-battle transformations) live in `pokemon_form_conditions.csv` and are only reachable one variety at a time: `pokemon-species/6` → `varieties` → `pokemon/6` → `forms` → `pokemon-form/10134` → `trigger_conditions`, i.e. 4 hops to learn that Charizard has two megas and a gmax form.

This PR adds a `transformations` field next to `chain`, grouping those conditions by species:

```json
"transformations": [
  { "species": {"name": "charizard"},
    "forms": [
      {"form": {"name": "charizard-mega-x"}, "trigger": "held-item",
       "item": {"name": "charizardite-x"}, "ability": null, "move": null, "base_form": null},
      {"form": {"name": "charizard-gmax"}, "trigger": "gigantamax-factor", ...}
    ]
  }
]
```

Design notes:

- **`chain` is untouched.** Form changes are not evolutions, so they are not chain links (otherwise Arceus would "evolve" into 17 plates and Aegislash into aegislash-blade). Purely additive: no model or migration changes.
- Keys stay explicit (`item` / `ability` / `move`), unlike `pokemon-form`'s `trigger_conditions`, which merges the target's `{name, url}` into the trigger dict and loses which of the three it came from.
- `transformations` is always present, `[]` when the chain has no form conditions (399 of the 541 chains).
- Costs exactly **1 extra query** per request regardless of chain size.

## AI coding assistance disclosure

It wrote the serializer and the tests from my design decisions.

## Contributor check list

<!-- Your PR will not be reviewed until you have completed all these steps: -->

- [x] I have written a description of the contribution and explained its motivation.
- [x] I have written tests for my code changes (if applicable).
- [x] I have read and understood the [AI Assisted Contribution guidelines](https://github.com/PokeAPI/pokeapi/blob/master/CONTRIBUTING.md#ai-assisted-coding).
- [x] I will own this change in production, and I am prepared to fix any bugs caused by my code change.
