### PR TITLE
Fix column indices when building MoveChange from move_changelog.csv

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -789,7 +789,7 @@ def _build_moves():
     existing_effect_ids = set(MoveEffect.objects.values_list("pk", flat=True))
 
     def csv_record_to_objects(info):
-        effect_id = int(info[6]) if info[6] != "" else None
+        effect_id = int(info[8]) if info[8] != "" else None
         if effect_id not in existing_effect_ids:
             effect_id = None
 
@@ -801,7 +801,7 @@ def _build_moves():
             pp=int(info[4]) if info[4] != "" else None,
             accuracy=int(info[5]) if info[5] != "" else None,
             move_effect_id=effect_id,
-            move_effect_chance=int(info[7]) if info[7] != "" else None,
+            move_effect_chance=int(info[9]) if info[9] != "" else None,
         )
 
     build_generic((MoveChange,), "move_changelog.csv", csv_record_to_objects)


### PR DESCRIPTION
Fixes #1663.

## Problem

`move_changelog.csv` columns are:
```
move_id,changed_in_version_group_id,type_id,power,pp,accuracy,priority,target_id,effect_id,effect_chance
```

The build script's `csv_record_to_objects` for `MoveChange` read `info[6]`/`info[7]` (`priority`/`target_id` — neither of which `MoveChange` even has a field for) as `effect_id`/`effect_chance`, instead of the actual `info[8]`/`info[9]` columns.

This both dropped real effect changes and fabricated bogus ones from unrelated numeric values, e.g.:
- **Double-Edge** (move 38): CSV row is `38,3,,100,,,,,49,` — real `effect_id` is 49 (recoil), but the old code read `info[6]` (empty `priority`) → the recoil effect at gold-silver was silently dropped.
- **Follow Me** (move 266): CSV row is `266,15,,,,,3,,,` — `effect_id` is actually empty, but the old code read `info[6]` (`priority` = `3`) → it fabricated `move_effect_id=3`, which happens to be "Has a chance to poison the target," giving Follow Me a completely fictitious effect change.

## Fix

Read `info[8]`/`info[9]` instead of `info[6]`/`info[7]`.

## Test plan

There's no existing test coverage for `data/v2/build.py`'s CSV-import logic, so I verified against the real production CSV data:
- Rebuilt the local sqlite DB from the CSVs with the fix applied.
- `MoveChange.objects.get(move_id=38, version_group_id=3).move_effect_id` → `49` (recoil), previously `None`.
- `MoveChange.objects.get(move_id=266, version_group_id=15).move_effect_id` → `None`, previously `3` (poison).
- Confirmed via the live endpoints: `GET /api/v2/move/double-edge/` now shows the recoil effect in `past_values` for gold-silver; `GET /api/v2/move/follow-me/` no longer shows the fabricated poison effect.
- `manage.py test pokemon_v2` passes (60 tests).
- `pre-commit run --files data/v2/build.py` passes (ruff check, ruff format, ty).